### PR TITLE
feat(phase-1): implement usable CLI with branching, functions, and multiple types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Format check
+        run: cargo fmt --check
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+      - name: Build
+        run: cargo build
+      - name: Test
+        run: cargo test --all

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,7 +310,9 @@ dependencies = [
  "serde",
  "serde_json",
  "target-lexicon",
+ "tempfile",
  "thiserror",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -314,6 +322,22 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fixedbitset"
@@ -332,6 +356,19 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
 
 [[package]]
 name = "gimli"
@@ -367,6 +404,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,6 +417,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -395,10 +440,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.182"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -462,6 +525,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,6 +551,12 @@ checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "regalloc2"
@@ -498,6 +577,25 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -540,6 +638,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -587,6 +694,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
+name = "tempfile"
+version = "3.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,6 +734,47 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -679,6 +840,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,6 +856,58 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "wasmtime-internal-core"
@@ -712,6 +931,103 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,9 @@ cranelift-frontend = "0.129"
 cranelift-module = "0.129"
 cranelift-object = "0.129"
 target-lexicon = "0.13"
+toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = "0.3"
+
+[dev-dependencies]
+tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > AI-first semantic graph compiler. Programs are stored as JSON-LD graphs — not text files. The toolchain validates, compiles, and links them to native binaries via Cranelift.
 
-**Status:** Phase 0 — active development. No release yet.
+**Status:** Phase 1 — usable CLI with branching, function calls, and multiple types.
 
 ---
 
@@ -32,7 +32,30 @@ cc --version
 
 ---
 
-## Build
+## Quickstart (5 minutes)
+
+```bash
+# Install
+git clone git@github.com:hgahub/duumbi.git
+cd duumbi
+cargo install --path .
+
+# Create a workspace
+duumbi init myproject
+cd myproject
+
+# Build and run the skeleton program (prints 8)
+duumbi build
+duumbi run
+
+# Validate without compiling
+duumbi check
+
+# See human-readable pseudo-code
+duumbi describe
+```
+
+## Build from source
 
 ```bash
 git clone git@github.com:hgahub/duumbi.git
@@ -131,19 +154,27 @@ Expected output: prints `8`, exits with code 8.
 
 ---
 
-## Phase 0 Op Set
+## Op Set
 
-| Op | Cranelift | Description |
-|----|-----------|-------------|
-| `duumbi:Const` | `iconst.i64` | Constant integer value |
-| `duumbi:Add` | `iadd` | Integer addition |
-| `duumbi:Sub` | `isub` | Integer subtraction |
-| `duumbi:Mul` | `imul` | Integer multiplication |
-| `duumbi:Div` | `sdiv` | Integer division (truncating) |
-| `duumbi:Print` | `call duumbi_print_i64` | Print value to stdout |
-| `duumbi:Return` | `return` | Return from function |
+| Op | Cranelift | Description | Phase |
+|----|-----------|-------------|-------|
+| `duumbi:Const` | `iconst.i64` | Constant integer value | 0 |
+| `duumbi:Add` | `iadd` / `fadd` | Addition (i64 or f64) | 0 |
+| `duumbi:Sub` | `isub` / `fsub` | Subtraction | 0 |
+| `duumbi:Mul` | `imul` / `fmul` | Multiplication | 0 |
+| `duumbi:Div` | `sdiv` / `fdiv` | Division | 0 |
+| `duumbi:Print` | `call duumbi_print_*` | Print value to stdout | 0 |
+| `duumbi:Return` | `return` | Return from function | 0 |
+| `duumbi:ConstF64` | `f64const` | Constant float value | 1 |
+| `duumbi:ConstBool` | `iconst.i8` | Constant boolean | 1 |
+| `duumbi:Compare` | `icmp` / `fcmp` | Comparison (eq, ne, lt, le, gt, ge) | 1 |
+| `duumbi:Branch` | `brif` | Conditional branch | 1 |
+| `duumbi:Call` | `call` | Function call | 1 |
+| `duumbi:Load` | `use_var` | Load named variable | 1 |
+| `duumbi:Store` | `def_var` | Store to named variable | 1 |
 
-Phase 1 adds: `f64`, `bool`, `Compare`, `Branch`, `Call`, `Load`, `Store`, multi-module.
+**Types:** `i64`, `f64`, `bool`, `void`
+
 Phase 2 adds: AI mutation (`duumbi add "..."`, `duumbi undo`).
 Phase 3 adds: WASM web visualizer (`duumbi viz`).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,29 +60,37 @@ Example: `duumbi:main/main/entry/2`
 
 ---
 
-## Phase 0 pipeline (current build target)
+## Build pipeline
 
 ```
-add.jsonld  →  parse  →  DiGraph  →  validate  →  Cranelift IR  →  output.o
-                                                                        │
-                                         cc output.o duumbi_runtime.o -o output
+.jsonld files  →  parse  →  StableGraph  →  validate  →  Cranelift IR  →  output.o
+                                                                              │
+                                            cc output.o duumbi_runtime.o -o output
 ```
 
-Kill criterion: `add(3, 5)` → binary prints `8`, exits with code 8.
+**Phase 0 kill criterion:** `add(3, 5)` → binary prints `8`, exits with code 8.
+**Phase 1 kill criterion:** External dev installs and runs fibonacci in < 10 min.
 
-**Phase 0 Op set:** `Const`, `Add`, `Sub`, `Mul`, `Div`, `Print`, `Return`
+**Full Op set:**
 
-**Cranelift lowering map:**
+| duumbi: Op | Cranelift IR | Phase |
+|------------|--------------|-------|
+| `Const` (i64) | `iconst` | 0 |
+| `ConstF64` (f64) | `f64const` | 1 |
+| `ConstBool` (bool) | `iconst` (i8) | 1 |
+| `Add` | `iadd` / `fadd` | 0 |
+| `Sub` | `isub` / `fsub` | 0 |
+| `Mul` | `imul` / `fmul` | 0 |
+| `Div` | `sdiv` / `fdiv` | 0 |
+| `Compare` | `icmp` / `fcmp` | 1 |
+| `Branch` | `brif` | 1 |
+| `Call` | `call` | 1 |
+| `Load` | `use_var` | 1 |
+| `Store` | `def_var` | 1 |
+| `Print` | `call duumbi_print_*` | 0 |
+| `Return` | `return` | 0 |
 
-| duumbi: Op | Cranelift IR |
-|------------|--------------|
-| `Const` (i64) | `iconst` |
-| `Add` | `iadd` |
-| `Sub` | `isub` |
-| `Mul` | `imul` |
-| `Div` | `sdiv` |
-| `Print` | `call duumbi_print_i64` |
-| `Return` | `return` |
+**Types:** `i64`, `f64`, `bool`, `void`
 
 ---
 

--- a/runtime/duumbi_runtime.c
+++ b/runtime/duumbi_runtime.c
@@ -4,3 +4,11 @@
 void duumbi_print_i64(int64_t val) {
     printf("%lld\n", (long long)val);
 }
+
+void duumbi_print_f64(double val) {
+    printf("%.15g\n", val);
+}
+
+void duumbi_print_bool(int8_t val) {
+    printf("%s\n", val ? "true" : "false");
+}

--- a/src/cli/describe.rs
+++ b/src/cli/describe.rs
@@ -1,0 +1,135 @@
+//! Describe command — prints human-readable pseudo-code from a semantic graph.
+//!
+//! Walks the graph's function/block/node structure and outputs a readable
+//! summary of the program.
+
+use petgraph::visit::EdgeRef;
+
+use crate::graph::{GraphEdge, SemanticGraph};
+use crate::types::Op;
+
+/// Prints a human-readable pseudo-code description of the semantic graph.
+pub fn describe(graph: &SemanticGraph) {
+    for func in &graph.functions {
+        let params: Vec<String> = func
+            .params
+            .iter()
+            .map(|p| format!("{}: {}", p.name, p.param_type))
+            .collect();
+        println!(
+            "function {}({}) -> {} {{",
+            func.name,
+            params.join(", "),
+            func.return_type
+        );
+
+        for block in &func.blocks {
+            println!("  {}:", block.label);
+            for &node_idx in &block.nodes {
+                let node = &graph.graph[node_idx];
+                let desc = describe_op(graph, node_idx, &node.op);
+                println!("    %{} = {}", node.id, desc);
+            }
+        }
+        println!("}}");
+    }
+}
+
+/// Produces a string description of a single operation.
+fn describe_op(
+    graph: &SemanticGraph,
+    node_idx: petgraph::stable_graph::NodeIndex,
+    op: &Op,
+) -> String {
+    use petgraph::Direction;
+
+    let incoming: Vec<_> = graph
+        .graph
+        .edges_directed(node_idx, Direction::Incoming)
+        .collect();
+
+    match op {
+        Op::Const(v) => format!("Const({v})"),
+        Op::ConstF64(v) => format!("ConstF64({v})"),
+        Op::ConstBool(v) => format!("ConstBool({v})"),
+        Op::Add | Op::Sub | Op::Mul | Op::Div => {
+            let mut left = String::from("?");
+            let mut right = String::from("?");
+            for e in &incoming {
+                let src = &graph.graph[e.source()];
+                match e.weight() {
+                    GraphEdge::Left => left = format!("%{}", src.id),
+                    GraphEdge::Right => right = format!("%{}", src.id),
+                    _ => {}
+                }
+            }
+            format!("{op}({left}, {right})")
+        }
+        Op::Compare(cmp_op) => {
+            let mut left = String::from("?");
+            let mut right = String::from("?");
+            for e in &incoming {
+                let src = &graph.graph[e.source()];
+                match e.weight() {
+                    GraphEdge::Left => left = format!("%{}", src.id),
+                    GraphEdge::Right => right = format!("%{}", src.id),
+                    _ => {}
+                }
+            }
+            format!("Compare({left}, {right}, {cmp_op})")
+        }
+        Op::Branch => {
+            let mut cond = String::from("?");
+            if let Some((true_lbl, false_lbl)) = graph.branch_targets.get(&graph.graph[node_idx].id)
+            {
+                for e in &incoming {
+                    if matches!(e.weight(), GraphEdge::Condition) {
+                        cond = format!("%{}", graph.graph[e.source()].id);
+                    }
+                }
+                format!("Branch({cond}, {true_lbl}, {false_lbl})")
+            } else {
+                format!("Branch({cond}, ?, ?)")
+            }
+        }
+        Op::Call { function } => {
+            let mut args: Vec<(usize, String)> = Vec::new();
+            for e in &incoming {
+                if let GraphEdge::Arg(i) = e.weight() {
+                    args.push((*i, format!("%{}", graph.graph[e.source()].id)));
+                }
+            }
+            args.sort_by_key(|(i, _)| *i);
+            let arg_strs: Vec<String> = args.into_iter().map(|(_, s)| s).collect();
+            format!("Call({function}, [{}])", arg_strs.join(", "))
+        }
+        Op::Load { variable } => format!("Load({variable})"),
+        Op::Store { variable } => {
+            let mut val = String::from("?");
+            for e in &incoming {
+                if matches!(e.weight(), GraphEdge::Operand) {
+                    val = format!("%{}", graph.graph[e.source()].id);
+                }
+            }
+            format!("Store({variable}, {val})")
+        }
+        Op::Print => {
+            let mut val = String::from("?");
+            for e in &incoming {
+                if matches!(e.weight(), GraphEdge::Operand) {
+                    val = format!("%{}", graph.graph[e.source()].id);
+                }
+            }
+            format!("Print({val})")
+        }
+        Op::Return => {
+            let mut val = String::from("?");
+            for e in &incoming {
+                if matches!(e.weight(), GraphEdge::Operand) {
+                    val = format!("%{}", graph.graph[e.source()].id);
+                }
+            }
+            format!("Return({val})")
+        }
+    }
+}

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,0 +1,131 @@
+//! Workspace initialization command.
+//!
+//! Creates the `.duumbi/` directory structure with default configuration,
+//! schema, and a skeleton `main.jsonld` program.
+
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+/// Skeleton `main.jsonld` — a simple `add(3, 5)` program.
+const SKELETON_MAIN: &str = r#"{
+  "@context": {
+    "duumbi": "https://duumbi.dev/ns/core#"
+  },
+  "@type": "duumbi:Module",
+  "@id": "duumbi:main",
+  "duumbi:name": "main",
+  "duumbi:functions": [
+    {
+      "@type": "duumbi:Function",
+      "@id": "duumbi:main/main",
+      "duumbi:name": "main",
+      "duumbi:returnType": "i64",
+      "duumbi:blocks": [
+        {
+          "@type": "duumbi:Block",
+          "@id": "duumbi:main/main/entry",
+          "duumbi:label": "entry",
+          "duumbi:ops": [
+            {
+              "@type": "duumbi:Const",
+              "@id": "duumbi:main/main/entry/0",
+              "duumbi:value": 3,
+              "duumbi:resultType": "i64"
+            },
+            {
+              "@type": "duumbi:Const",
+              "@id": "duumbi:main/main/entry/1",
+              "duumbi:value": 5,
+              "duumbi:resultType": "i64"
+            },
+            {
+              "@type": "duumbi:Add",
+              "@id": "duumbi:main/main/entry/2",
+              "duumbi:left": { "@id": "duumbi:main/main/entry/0" },
+              "duumbi:right": { "@id": "duumbi:main/main/entry/1" },
+              "duumbi:resultType": "i64"
+            },
+            {
+              "@type": "duumbi:Print",
+              "@id": "duumbi:main/main/entry/3",
+              "duumbi:operand": { "@id": "duumbi:main/main/entry/2" }
+            },
+            {
+              "@type": "duumbi:Return",
+              "@id": "duumbi:main/main/entry/4",
+              "duumbi:operand": { "@id": "duumbi:main/main/entry/2" }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+"#;
+
+/// Default `config.toml` template.
+const DEFAULT_CONFIG: &str = r#"[compiler]
+version = "0.1"
+
+[build]
+output_dir = "build"
+"#;
+
+/// Initializes a new duumbi workspace at the given base path.
+///
+/// Creates `.duumbi/` with subdirectories for config, graph, schema, build,
+/// and telemetry. Fails if `.duumbi/` already exists.
+pub fn run_init(base: &Path) -> Result<()> {
+    let duumbi_dir = base.join(".duumbi");
+
+    if duumbi_dir.exists() {
+        anyhow::bail!("Workspace already exists at '{}'", duumbi_dir.display());
+    }
+
+    // Create directory structure
+    fs::create_dir_all(duumbi_dir.join("graph")).context("Failed to create .duumbi/graph/")?;
+    fs::create_dir_all(duumbi_dir.join("schema")).context("Failed to create .duumbi/schema/")?;
+    fs::create_dir_all(duumbi_dir.join("build")).context("Failed to create .duumbi/build/")?;
+    fs::create_dir_all(duumbi_dir.join("telemetry"))
+        .context("Failed to create .duumbi/telemetry/")?;
+
+    // Write config
+    fs::write(duumbi_dir.join("config.toml"), DEFAULT_CONFIG)
+        .context("Failed to write config.toml")?;
+
+    // Write skeleton main.jsonld
+    fs::write(duumbi_dir.join("graph").join("main.jsonld"), SKELETON_MAIN)
+        .context("Failed to write main.jsonld")?;
+
+    eprintln!("Project initialized at {}", duumbi_dir.display());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn init_creates_workspace_structure() {
+        let tmp = TempDir::new().expect("invariant: temp dir must be created");
+        run_init(tmp.path()).expect("invariant: init should succeed");
+
+        let d = tmp.path().join(".duumbi");
+        assert!(d.join("config.toml").exists());
+        assert!(d.join("graph/main.jsonld").exists());
+        assert!(d.join("schema").is_dir());
+        assert!(d.join("build").is_dir());
+        assert!(d.join("telemetry").is_dir());
+    }
+
+    #[test]
+    fn init_fails_if_already_exists() {
+        let tmp = TempDir::new().expect("invariant: temp dir must be created");
+        run_init(tmp.path()).expect("invariant: first init should succeed");
+        let result = run_init(tmp.path());
+        assert!(result.is_err());
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,6 +2,9 @@
 //!
 //! Command-line interface using `clap` for the duumbi compiler.
 
+pub mod describe;
+pub mod init;
+
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
@@ -18,13 +21,38 @@ pub struct Cli {
 /// Available CLI commands.
 #[derive(Subcommand, Debug)]
 pub enum Commands {
+    /// Initialize a new duumbi workspace.
+    Init {
+        /// Optional project name (defaults to current directory name).
+        name: Option<String>,
+    },
+
     /// Compile a JSON-LD graph to a native binary.
     Build {
-        /// Path to the input `.jsonld` file.
-        input: PathBuf,
+        /// Path to the input `.jsonld` file (optional if in a workspace).
+        input: Option<PathBuf>,
 
         /// Path for the output binary (default: `output`).
-        #[arg(short, long, default_value = "output")]
-        output: PathBuf,
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+    },
+
+    /// Build and run the compiled binary.
+    Run {
+        /// Arguments to pass to the compiled binary.
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// Parse and validate without compiling.
+    Check {
+        /// Path to the input `.jsonld` file (optional if in a workspace).
+        input: Option<PathBuf>,
+    },
+
+    /// Describe the program as human-readable pseudo-code.
+    Describe {
+        /// Path to the input `.jsonld` file (optional if in a workspace).
+        input: Option<PathBuf>,
     },
 }

--- a/src/compiler/lowering.rs
+++ b/src/compiler/lowering.rs
@@ -1,30 +1,64 @@
 //! Cranelift IR lowering — graph nodes to Cranelift instructions.
 //!
 //! Compiles a validated `SemanticGraph` into a native object file
-//! using the Cranelift code generator.
+//! using the Cranelift code generator. Supports multi-function,
+//! multi-block compilation with f64/bool types, Compare, Branch,
+//! Call, Load, and Store operations.
 
 use std::collections::HashMap;
 
+use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
 use cranelift_codegen::ir::types;
-use cranelift_codegen::ir::{AbiParam, InstBuilder};
+use cranelift_codegen::ir::{AbiParam, InstBuilder, Value};
 use cranelift_codegen::settings::{self, Configurable};
 use cranelift_codegen::{self, Context, isa};
-use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
-use cranelift_module::{Linkage, Module};
+use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext, Variable};
+use cranelift_module::{FuncId, Linkage, Module};
 use cranelift_object::{ObjectBuilder, ObjectModule};
 use petgraph::visit::EdgeRef;
 use target_lexicon::Triple;
 
-use crate::graph::{GraphEdge, SemanticGraph};
-use crate::types::{NodeId, Op};
+use crate::graph::{FunctionInfo, GraphEdge, SemanticGraph};
+use crate::types::{CompareOp, DuumbiType, NodeId, Op};
 
 use super::CompileError;
 
-/// Compiles a validated semantic graph to a native object file.
-///
-/// Returns the raw bytes of the object file (Mach-O on macOS, ELF on Linux).
-#[must_use = "compilation errors should be handled"]
-pub fn compile_to_object(graph: &SemanticGraph) -> Result<Vec<u8>, CompileError> {
+/// Converts a `DuumbiType` to a Cranelift IR type.
+fn duumbi_type_to_cl(ty: DuumbiType) -> cranelift_codegen::ir::Type {
+    match ty {
+        DuumbiType::I64 => types::I64,
+        DuumbiType::F64 => types::F64,
+        DuumbiType::Bool => types::I8,
+        DuumbiType::Void => types::I64, // should not be used for values
+    }
+}
+
+/// Converts a `CompareOp` to Cranelift integer condition code.
+fn compare_op_to_intcc(op: &CompareOp) -> IntCC {
+    match op {
+        CompareOp::Eq => IntCC::Equal,
+        CompareOp::Ne => IntCC::NotEqual,
+        CompareOp::Lt => IntCC::SignedLessThan,
+        CompareOp::Le => IntCC::SignedLessThanOrEqual,
+        CompareOp::Gt => IntCC::SignedGreaterThan,
+        CompareOp::Ge => IntCC::SignedGreaterThanOrEqual,
+    }
+}
+
+/// Converts a `CompareOp` to Cranelift float condition code.
+fn compare_op_to_floatcc(op: &CompareOp) -> FloatCC {
+    match op {
+        CompareOp::Eq => FloatCC::Equal,
+        CompareOp::Ne => FloatCC::NotEqual,
+        CompareOp::Lt => FloatCC::LessThan,
+        CompareOp::Le => FloatCC::LessThanOrEqual,
+        CompareOp::Gt => FloatCC::GreaterThan,
+        CompareOp::Ge => FloatCC::GreaterThanOrEqual,
+    }
+}
+
+/// Creates the ISA and ObjectModule shared setup.
+fn create_object_module() -> Result<ObjectModule, CompileError> {
     let triple = Triple::host();
 
     let mut settings_builder = settings::builder();
@@ -33,7 +67,6 @@ pub fn compile_to_object(graph: &SemanticGraph) -> Result<Vec<u8>, CompileError>
         .map_err(|e| CompileError::Cranelift {
             message: format!("Failed to set opt_level: {e}"),
         })?;
-    // Enable PIC for macOS linker compatibility
     settings_builder
         .set("is_pic", "true")
         .map_err(|e| CompileError::Cranelift {
@@ -60,94 +93,105 @@ pub fn compile_to_object(graph: &SemanticGraph) -> Result<Vec<u8>, CompileError>
         message: format!("ObjectBuilder creation failed: {e}"),
     })?;
 
-    let mut obj_module = ObjectModule::new(obj_builder);
+    Ok(ObjectModule::new(obj_builder))
+}
 
-    // Declare external function: duumbi_print_i64(i64) -> void
-    let mut print_sig = obj_module.make_signature();
-    print_sig.params.push(AbiParam::new(types::I64));
-    let print_func_id = obj_module
-        .declare_function("duumbi_print_i64", Linkage::Import, &print_sig)
+/// Declares a function signature in the Cranelift module.
+fn make_func_signature(
+    obj_module: &ObjectModule,
+    func_info: &FunctionInfo,
+) -> cranelift_codegen::ir::Signature {
+    let mut sig = obj_module.make_signature();
+    for param in &func_info.params {
+        sig.params
+            .push(AbiParam::new(duumbi_type_to_cl(param.param_type)));
+    }
+    if func_info.return_type != DuumbiType::Void {
+        sig.returns
+            .push(AbiParam::new(duumbi_type_to_cl(func_info.return_type)));
+    }
+    sig
+}
+
+/// Compiles a validated semantic graph to a native object file.
+///
+/// Returns the raw bytes of the object file (Mach-O on macOS, ELF on Linux).
+#[must_use = "compilation errors should be handled"]
+pub fn compile_to_object(graph: &SemanticGraph) -> Result<Vec<u8>, CompileError> {
+    let mut obj_module = create_object_module()?;
+
+    // Declare external print functions
+    let mut print_i64_sig = obj_module.make_signature();
+    print_i64_sig.params.push(AbiParam::new(types::I64));
+    let print_i64_id = obj_module
+        .declare_function("duumbi_print_i64", Linkage::Import, &print_i64_sig)
         .map_err(|e| CompileError::Cranelift {
             message: format!("Failed to declare duumbi_print_i64: {e}"),
         })?;
 
-    // Declare main function: () -> i64
-    let mut main_sig = obj_module.make_signature();
-    main_sig.returns.push(AbiParam::new(types::I64));
-    let main_func_id = obj_module
-        .declare_function("main", Linkage::Export, &main_sig)
+    let mut print_f64_sig = obj_module.make_signature();
+    print_f64_sig.params.push(AbiParam::new(types::F64));
+    let print_f64_id = obj_module
+        .declare_function("duumbi_print_f64", Linkage::Import, &print_f64_sig)
         .map_err(|e| CompileError::Cranelift {
-            message: format!("Failed to declare main: {e}"),
+            message: format!("Failed to declare duumbi_print_f64: {e}"),
         })?;
 
-    // Build main function IR
-    let mut ctx = Context::new();
-    ctx.func.signature = main_sig;
+    let mut print_bool_sig = obj_module.make_signature();
+    print_bool_sig.params.push(AbiParam::new(types::I8));
+    let print_bool_id = obj_module
+        .declare_function("duumbi_print_bool", Linkage::Import, &print_bool_sig)
+        .map_err(|e| CompileError::Cranelift {
+            message: format!("Failed to declare duumbi_print_bool: {e}"),
+        })?;
 
-    let mut fn_builder_ctx = FunctionBuilderContext::new();
-    {
-        let mut builder = FunctionBuilder::new(&mut ctx.func, &mut fn_builder_ctx);
-        let entry_block = builder.create_block();
-        builder.switch_to_block(entry_block);
-        builder.seal_block(entry_block);
-
-        // Import the print function reference
-        let print_func_ref = obj_module.declare_func_in_func(print_func_id, builder.func);
-
-        // Walk the graph in topological order, building SSA values
-        let mut value_map: HashMap<NodeId, cranelift_codegen::ir::Value> = HashMap::new();
-
-        // Process blocks in order for each function
-        for func_info in &graph.functions {
-            if func_info.name.0 != "main" {
-                continue;
-            }
-            for block_info in &func_info.blocks {
-                for &node_idx in &block_info.nodes {
-                    let node = &graph.graph[node_idx];
-
-                    match &node.op {
-                        Op::Const(val) => {
-                            let cl_val = builder.ins().iconst(types::I64, *val);
-                            value_map.insert(node.id.clone(), cl_val);
-                        }
-                        Op::Add | Op::Sub | Op::Mul | Op::Div => {
-                            let (left_val, right_val) =
-                                get_binary_operands(graph, node_idx, &value_map)?;
-
-                            let result = match node.op {
-                                Op::Add => builder.ins().iadd(left_val, right_val),
-                                Op::Sub => builder.ins().isub(left_val, right_val),
-                                Op::Mul => builder.ins().imul(left_val, right_val),
-                                Op::Div => builder.ins().sdiv(left_val, right_val),
-                                _ => unreachable!(),
-                            };
-                            value_map.insert(node.id.clone(), result);
-                        }
-                        Op::Print => {
-                            let operand_val = get_unary_operand(graph, node_idx, &value_map)?;
-                            builder.ins().call(print_func_ref, &[operand_val]);
-                            // Print does not produce a value
-                        }
-                        Op::Return => {
-                            let operand_val = get_unary_operand(graph, node_idx, &value_map)?;
-                            builder.ins().return_(&[operand_val]);
-                            // Return does not produce a value
-                        }
-                    }
-                }
-            }
-        }
-
-        builder.finalize();
+    // Phase 1: Declare all functions first (needed for cross-function calls)
+    let mut func_ids: HashMap<String, FuncId> = HashMap::new();
+    let mut func_sigs: HashMap<String, cranelift_codegen::ir::Signature> = HashMap::new();
+    for func_info in &graph.functions {
+        let sig = make_func_signature(&obj_module, func_info);
+        let linkage = if func_info.name.0 == "main" {
+            Linkage::Export
+        } else {
+            Linkage::Local
+        };
+        let func_id = obj_module
+            .declare_function(&func_info.name.0, linkage, &sig)
+            .map_err(|e| CompileError::Cranelift {
+                message: format!("Failed to declare function '{}': {e}", func_info.name),
+            })?;
+        func_ids.insert(func_info.name.0.clone(), func_id);
+        func_sigs.insert(func_info.name.0.clone(), sig);
     }
 
-    // Define and emit the function
-    obj_module
-        .define_function(main_func_id, &mut ctx)
-        .map_err(|e| CompileError::Cranelift {
-            message: format!("Failed to define main: {e}"),
-        })?;
+    // Phase 2: Define each function
+    let mut fn_builder_ctx = FunctionBuilderContext::new();
+    for func_info in &graph.functions {
+        let func_id = func_ids[&func_info.name.0];
+        let sig = func_sigs[&func_info.name.0].clone();
+
+        let mut ctx = Context::new();
+        ctx.func.signature = sig;
+
+        compile_function(
+            graph,
+            func_info,
+            &mut ctx,
+            &mut fn_builder_ctx,
+            &mut obj_module,
+            &func_ids,
+            &func_sigs,
+            print_i64_id,
+            print_f64_id,
+            print_bool_id,
+        )?;
+
+        obj_module
+            .define_function(func_id, &mut ctx)
+            .map_err(|e| CompileError::Cranelift {
+                message: format!("Failed to define function '{}': {e}", func_info.name),
+            })?;
+    }
 
     // Finish and produce the object bytes
     let product = obj_module.finish();
@@ -158,12 +202,226 @@ pub fn compile_to_object(graph: &SemanticGraph) -> Result<Vec<u8>, CompileError>
     Ok(bytes)
 }
 
+/// Compiles a single function into Cranelift IR.
+#[allow(clippy::too_many_arguments)] // Internal helper with many Cranelift context params
+fn compile_function(
+    graph: &SemanticGraph,
+    func_info: &FunctionInfo,
+    ctx: &mut Context,
+    fn_builder_ctx: &mut FunctionBuilderContext,
+    obj_module: &mut ObjectModule,
+    func_ids: &HashMap<String, FuncId>,
+    func_sigs: &HashMap<String, cranelift_codegen::ir::Signature>,
+    print_i64_id: FuncId,
+    print_f64_id: FuncId,
+    print_bool_id: FuncId,
+) -> Result<(), CompileError> {
+    let mut builder = FunctionBuilder::new(&mut ctx.func, fn_builder_ctx);
+
+    // Import print function references
+    let print_i64_ref = obj_module.declare_func_in_func(print_i64_id, builder.func);
+    let print_f64_ref = obj_module.declare_func_in_func(print_f64_id, builder.func);
+    let print_bool_ref = obj_module.declare_func_in_func(print_bool_id, builder.func);
+
+    // Import all callable function references
+    let mut func_refs: HashMap<String, cranelift_codegen::ir::FuncRef> = HashMap::new();
+    for (name, &fid) in func_ids {
+        let fref = obj_module.declare_func_in_func(fid, builder.func);
+        func_refs.insert(name.clone(), fref);
+    }
+
+    // Create all blocks up front (needed for forward branch references)
+    let mut block_map: HashMap<String, cranelift_codegen::ir::Block> = HashMap::new();
+    for block_info in &func_info.blocks {
+        let cl_block = builder.create_block();
+        block_map.insert(block_info.label.0.clone(), cl_block);
+    }
+
+    // Add entry block params for function parameters
+    let entry_block = block_map
+        .get(func_info.blocks.first().map_or("entry", |b| &b.label.0))
+        .copied()
+        .ok_or_else(|| CompileError::Cranelift {
+            message: format!("No blocks in function '{}'", func_info.name),
+        })?;
+
+    for param in &func_info.params {
+        builder.append_block_param(entry_block, duumbi_type_to_cl(param.param_type));
+    }
+
+    // SSA value map: NodeId -> Cranelift Value
+    let mut value_map: HashMap<NodeId, Value> = HashMap::new();
+
+    // Variable map for Load/Store and function params
+    let mut var_map: HashMap<String, Variable> = HashMap::new();
+
+    // Process each block
+    for (block_idx, block_info) in func_info.blocks.iter().enumerate() {
+        let cl_block = block_map[&block_info.label.0];
+        builder.switch_to_block(cl_block);
+
+        // Make function parameters available as named variables in the entry block
+        if block_idx == 0 {
+            for (i, param) in func_info.params.iter().enumerate() {
+                let param_val = builder.block_params(cl_block)[i];
+                let cl_type = duumbi_type_to_cl(param.param_type);
+                let var = builder.declare_var(cl_type);
+                builder.def_var(var, param_val);
+                var_map.insert(param.name.clone(), var);
+            }
+        }
+
+        // Emit instructions for each node
+        for &node_idx in &block_info.nodes {
+            let node = &graph.graph[node_idx];
+
+            match &node.op {
+                Op::Const(val) => {
+                    let cl_val = builder.ins().iconst(types::I64, *val);
+                    value_map.insert(node.id.clone(), cl_val);
+                }
+                Op::ConstF64(val) => {
+                    let cl_val = builder.ins().f64const(*val);
+                    value_map.insert(node.id.clone(), cl_val);
+                }
+                Op::ConstBool(val) => {
+                    let cl_val = builder.ins().iconst(types::I8, i64::from(*val as u8));
+                    value_map.insert(node.id.clone(), cl_val);
+                }
+                Op::Add | Op::Sub | Op::Mul | Op::Div => {
+                    let (left_val, right_val) = get_binary_operands(graph, node_idx, &value_map)?;
+
+                    let is_float = node.result_type == Some(DuumbiType::F64);
+
+                    let result = if is_float {
+                        match &node.op {
+                            Op::Add => builder.ins().fadd(left_val, right_val),
+                            Op::Sub => builder.ins().fsub(left_val, right_val),
+                            Op::Mul => builder.ins().fmul(left_val, right_val),
+                            Op::Div => builder.ins().fdiv(left_val, right_val),
+                            _ => unreachable!(),
+                        }
+                    } else {
+                        match &node.op {
+                            Op::Add => builder.ins().iadd(left_val, right_val),
+                            Op::Sub => builder.ins().isub(left_val, right_val),
+                            Op::Mul => builder.ins().imul(left_val, right_val),
+                            Op::Div => builder.ins().sdiv(left_val, right_val),
+                            _ => unreachable!(),
+                        }
+                    };
+                    value_map.insert(node.id.clone(), result);
+                }
+                Op::Compare(cmp_op) => {
+                    let (left_val, right_val) = get_binary_operands(graph, node_idx, &value_map)?;
+
+                    // Determine operand type from left edge source
+                    let left_is_float =
+                        get_left_operand_type(graph, node_idx) == Some(DuumbiType::F64);
+
+                    let result = if left_is_float {
+                        let cc = compare_op_to_floatcc(cmp_op);
+                        builder.ins().fcmp(cc, left_val, right_val)
+                    } else {
+                        let cc = compare_op_to_intcc(cmp_op);
+                        builder.ins().icmp(cc, left_val, right_val)
+                    };
+                    value_map.insert(node.id.clone(), result);
+                }
+                Op::Branch => {
+                    let cond_val = get_condition_operand(graph, node_idx, &value_map)?;
+                    let (true_label, false_label) = get_branch_targets(graph, node_idx)?;
+
+                    let true_block = block_map.get(&true_label).copied().ok_or_else(|| {
+                        CompileError::Cranelift {
+                            message: format!("Branch true target block '{true_label}' not found"),
+                        }
+                    })?;
+                    let false_block = block_map.get(&false_label).copied().ok_or_else(|| {
+                        CompileError::Cranelift {
+                            message: format!("Branch false target block '{false_label}' not found"),
+                        }
+                    })?;
+
+                    builder
+                        .ins()
+                        .brif(cond_val, true_block, &[], false_block, &[]);
+                }
+                Op::Call { function } => {
+                    let func_ref = func_refs.get(function).copied().ok_or_else(|| {
+                        CompileError::Cranelift {
+                            message: format!("Function '{function}' not found for call"),
+                        }
+                    })?;
+
+                    let args = get_call_args(graph, node_idx, &value_map)?;
+                    let call_inst = builder.ins().call(func_ref, &args);
+
+                    // Get return value if the called function returns something
+                    if let Some(target_sig) = func_sigs.get(function)
+                        && !target_sig.returns.is_empty()
+                    {
+                        let ret_val = builder.inst_results(call_inst)[0];
+                        value_map.insert(node.id.clone(), ret_val);
+                    }
+                }
+                Op::Load { variable } => {
+                    let var =
+                        var_map
+                            .get(variable)
+                            .copied()
+                            .ok_or_else(|| CompileError::Cranelift {
+                                message: format!("Variable '{variable}' not declared for Load"),
+                            })?;
+                    let val = builder.use_var(var);
+                    value_map.insert(node.id.clone(), val);
+                }
+                Op::Store { variable } => {
+                    let operand_val = get_unary_operand(graph, node_idx, &value_map)?;
+                    if let Some(&var) = var_map.get(variable) {
+                        builder.def_var(var, operand_val);
+                    } else {
+                        // Infer type from the operand's output type
+                        let cl_type = get_operand_output_type(graph, node_idx)
+                            .map_or(types::I64, duumbi_type_to_cl);
+                        let var = builder.declare_var(cl_type);
+                        builder.def_var(var, operand_val);
+                        var_map.insert(variable.clone(), var);
+                    }
+                }
+                Op::Print => {
+                    let operand_val = get_unary_operand(graph, node_idx, &value_map)?;
+
+                    // Determine which print function to call based on operand type
+                    let operand_type = get_operand_output_type(graph, node_idx);
+                    let print_ref = match operand_type {
+                        Some(DuumbiType::F64) => print_f64_ref,
+                        Some(DuumbiType::Bool) => print_bool_ref,
+                        _ => print_i64_ref,
+                    };
+                    builder.ins().call(print_ref, &[operand_val]);
+                }
+                Op::Return => {
+                    let operand_val = get_unary_operand(graph, node_idx, &value_map)?;
+                    builder.ins().return_(&[operand_val]);
+                }
+            }
+        }
+    }
+
+    // Seal all blocks
+    builder.seal_all_blocks();
+    builder.finalize();
+
+    Ok(())
+}
+
 /// Resolves the left and right operand SSA values for a binary operation node.
 fn get_binary_operands(
     graph: &SemanticGraph,
     node_idx: petgraph::stable_graph::NodeIndex,
-    value_map: &HashMap<NodeId, cranelift_codegen::ir::Value>,
-) -> Result<(cranelift_codegen::ir::Value, cranelift_codegen::ir::Value), CompileError> {
+    value_map: &HashMap<NodeId, Value>,
+) -> Result<(Value, Value), CompileError> {
     let mut left_val = None;
     let mut right_val = None;
 
@@ -184,7 +442,7 @@ fn get_binary_operands(
         match edge_ref.weight() {
             GraphEdge::Left => left_val = Some(*val),
             GraphEdge::Right => right_val = Some(*val),
-            GraphEdge::Operand => {}
+            _ => {}
         }
     }
 
@@ -204,12 +462,12 @@ fn get_binary_operands(
     Ok((left, right))
 }
 
-/// Resolves the single operand SSA value for a unary operation node (Print, Return).
+/// Resolves the single operand SSA value for a unary operation node.
 fn get_unary_operand(
     graph: &SemanticGraph,
     node_idx: petgraph::stable_graph::NodeIndex,
-    value_map: &HashMap<NodeId, cranelift_codegen::ir::Value>,
-) -> Result<cranelift_codegen::ir::Value, CompileError> {
+    value_map: &HashMap<NodeId, Value>,
+) -> Result<Value, CompileError> {
     for edge_ref in graph
         .graph
         .edges_directed(node_idx, petgraph::Direction::Incoming)
@@ -232,6 +490,178 @@ fn get_unary_operand(
     })
 }
 
+/// Resolves the condition operand for a Branch node.
+fn get_condition_operand(
+    graph: &SemanticGraph,
+    node_idx: petgraph::stable_graph::NodeIndex,
+    value_map: &HashMap<NodeId, Value>,
+) -> Result<Value, CompileError> {
+    for edge_ref in graph
+        .graph
+        .edges_directed(node_idx, petgraph::Direction::Incoming)
+    {
+        if matches!(edge_ref.weight(), GraphEdge::Condition) {
+            let source_node = &graph.graph[edge_ref.source()];
+            return value_map.get(&source_node.id).copied().ok_or_else(|| {
+                CompileError::Cranelift {
+                    message: format!(
+                        "SSA value not found for condition '{}' of node '{}'",
+                        source_node.id, graph.graph[node_idx].id
+                    ),
+                }
+            });
+        }
+    }
+
+    Err(CompileError::Cranelift {
+        message: format!(
+            "Missing condition for Branch node '{}'",
+            graph.graph[node_idx].id
+        ),
+    })
+}
+
+/// Gets the branch target block labels from a Branch node's AST data.
+fn get_branch_targets(
+    graph: &SemanticGraph,
+    node_idx: petgraph::stable_graph::NodeIndex,
+) -> Result<(String, String), CompileError> {
+    // The branch targets are stored in the Op::Branch node's associated AST,
+    // but since the graph only stores Op::Branch without the labels,
+    // we need to find TrueBlock/FalseBlock edges or store labels differently.
+    // In our design, Branch targets come from OpAst.true_block/false_block
+    // which aren't stored in the graph node directly. We need another approach.
+    //
+    // Solution: Walk outgoing edges looking for TrueBlock/FalseBlock edge types
+    // that were stored during graph building. But we didn't add those edges since
+    // they point to blocks, not nodes. Instead, we'll look at the graph node's
+    // metadata. Since we don't store labels in GraphNode, we need to extract them
+    // from the AST-level data that was preserved during parsing.
+    //
+    // Actually, the proper approach is: the builder should have stored the
+    // true_block/false_block labels somewhere accessible. For now, we'll
+    // scan the AST info stored in the OpAst. But we don't have the AST at
+    // compile time — only the graph.
+    //
+    // Revised approach: Store branch target labels directly in the GraphNode
+    // or in a side table. For Phase 1, let's use a simple approach:
+    // We look at the node's ID and find the corresponding function/block
+    // to look up target labels from the original parse data.
+    //
+    // Simplest approach: Add the target labels to the graph node somehow.
+    // Since we already have the block_map built, let's store target info
+    // in a new field. But we can't modify GraphNode now without breaking things.
+    //
+    // PRAGMATIC FIX: We'll store branch metadata in the Op enum itself.
+    // But Op::Branch has no fields. Let's check if we can get the info
+    // another way.
+
+    // In the current design, branch targets should be found by looking at
+    // the AST. Since we don't have direct AST access here, we need to
+    // refactor. For now, scan for nodes in target blocks that have edges.
+    //
+    // ACTUAL SOLUTION: We need to modify the graph builder to store branch
+    // target block labels. We'll use a side-table approach in SemanticGraph.
+
+    let _node = &graph.graph[node_idx];
+
+    // Look up branch targets from the branch_targets map
+    if let Some(targets) = graph.branch_targets.get(&graph.graph[node_idx].id) {
+        return Ok((targets.0.clone(), targets.1.clone()));
+    }
+
+    Err(CompileError::Cranelift {
+        message: format!(
+            "Branch target labels not found for node '{}'",
+            graph.graph[node_idx].id
+        ),
+    })
+}
+
+/// Gets the output type of the operand connected to a node via Operand edge.
+fn get_operand_output_type(
+    graph: &SemanticGraph,
+    node_idx: petgraph::stable_graph::NodeIndex,
+) -> Option<DuumbiType> {
+    for edge_ref in graph
+        .graph
+        .edges_directed(node_idx, petgraph::Direction::Incoming)
+    {
+        if matches!(edge_ref.weight(), GraphEdge::Operand) {
+            let source_node = &graph.graph[edge_ref.source()];
+            return resolve_node_output_type(source_node);
+        }
+    }
+    None
+}
+
+/// Gets the output type of the left operand of a binary/compare node.
+fn get_left_operand_type(
+    graph: &SemanticGraph,
+    node_idx: petgraph::stable_graph::NodeIndex,
+) -> Option<DuumbiType> {
+    for edge_ref in graph
+        .graph
+        .edges_directed(node_idx, petgraph::Direction::Incoming)
+    {
+        if matches!(edge_ref.weight(), GraphEdge::Left) {
+            let source_node = &graph.graph[edge_ref.source()];
+            return resolve_node_output_type(source_node);
+        }
+    }
+    None
+}
+
+/// Resolves the output type of a graph node for lowering decisions.
+fn resolve_node_output_type(node: &crate::graph::GraphNode) -> Option<DuumbiType> {
+    match &node.op {
+        Op::Const(_)
+        | Op::ConstF64(_)
+        | Op::ConstBool(_)
+        | Op::Add
+        | Op::Sub
+        | Op::Mul
+        | Op::Div
+        | Op::Load { .. }
+        | Op::Call { .. } => node.result_type,
+        Op::Compare(_) => Some(DuumbiType::Bool),
+        Op::Print | Op::Store { .. } => Some(DuumbiType::Void),
+        Op::Return | Op::Branch => None,
+    }
+}
+
+/// Collects Call argument values in order.
+fn get_call_args(
+    graph: &SemanticGraph,
+    node_idx: petgraph::stable_graph::NodeIndex,
+    value_map: &HashMap<NodeId, Value>,
+) -> Result<Vec<Value>, CompileError> {
+    let mut args: Vec<(usize, Value)> = Vec::new();
+
+    for edge_ref in graph
+        .graph
+        .edges_directed(node_idx, petgraph::Direction::Incoming)
+    {
+        if let GraphEdge::Arg(idx) = edge_ref.weight() {
+            let source_node = &graph.graph[edge_ref.source()];
+            let val =
+                value_map
+                    .get(&source_node.id)
+                    .copied()
+                    .ok_or_else(|| CompileError::Cranelift {
+                        message: format!(
+                            "SSA value not found for arg '{}' of Call node '{}'",
+                            source_node.id, graph.graph[node_idx].id
+                        ),
+                    })?;
+            args.push((*idx, val));
+        }
+    }
+
+    args.sort_by_key(|(idx, _)| *idx);
+    Ok(args.into_iter().map(|(_, v)| v).collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -243,15 +673,8 @@ mod tests {
             .expect("invariant: add.jsonld fixture must exist")
     }
 
-    #[test]
-    fn compile_add_graph_produces_object() {
-        let module = parse_jsonld(&fixture_add()).expect("invariant: fixture must parse");
-        let sg = build_graph(&module).expect("invariant: fixture must build");
-        let obj_bytes = compile_to_object(&sg).expect("compilation should succeed");
-
-        // Object file should not be empty and should have a valid header
+    fn assert_valid_object(obj_bytes: &[u8]) {
         assert!(!obj_bytes.is_empty());
-        // Mach-O magic: 0xFEEDFACF (64-bit) or ELF magic: 0x7F454C46
         let is_macho = obj_bytes.len() >= 4
             && (obj_bytes[0..4] == [0xCF, 0xFA, 0xED, 0xFE]
                 || obj_bytes[0..4] == [0xFE, 0xED, 0xFA, 0xCF]);
@@ -263,8 +686,15 @@ mod tests {
     }
 
     #[test]
+    fn compile_add_graph_produces_object() {
+        let module = parse_jsonld(&fixture_add()).expect("invariant: fixture must parse");
+        let sg = build_graph(&module).expect("invariant: fixture must build");
+        let obj_bytes = compile_to_object(&sg).expect("compilation should succeed");
+        assert_valid_object(&obj_bytes);
+    }
+
+    #[test]
     fn compile_const_return() {
-        // Minimal graph: Const(42) -> Return
         use crate::graph::*;
         use crate::types::*;
         use petgraph::stable_graph::StableGraph;
@@ -292,14 +722,73 @@ mod tests {
             functions: vec![FunctionInfo {
                 name: FunctionName("main".to_string()),
                 return_type: DuumbiType::I64,
+                params: vec![],
                 blocks: vec![BlockInfo {
                     label: BlockLabel("entry".to_string()),
                     nodes: vec![c, r],
                 }],
             }],
+            branch_targets: HashMap::new(),
         };
 
         let obj_bytes = compile_to_object(&sg).expect("compilation should succeed");
+        assert!(!obj_bytes.is_empty());
+    }
+
+    #[test]
+    fn compile_f64_const_return() {
+        use crate::graph::*;
+        use crate::types::*;
+        use petgraph::stable_graph::StableGraph;
+
+        let mut g = StableGraph::new();
+        let c = g.add_node(GraphNode {
+            id: NodeId("c".to_string()),
+            op: Op::ConstF64(2.5),
+            result_type: Some(DuumbiType::F64),
+            function: FunctionName("main".to_string()),
+            block: BlockLabel("entry".to_string()),
+        });
+        let print = g.add_node(GraphNode {
+            id: NodeId("p".to_string()),
+            op: Op::Print,
+            result_type: None,
+            function: FunctionName("main".to_string()),
+            block: BlockLabel("entry".to_string()),
+        });
+        let zero = g.add_node(GraphNode {
+            id: NodeId("z".to_string()),
+            op: Op::Const(0),
+            result_type: Some(DuumbiType::I64),
+            function: FunctionName("main".to_string()),
+            block: BlockLabel("entry".to_string()),
+        });
+        let r = g.add_node(GraphNode {
+            id: NodeId("r".to_string()),
+            op: Op::Return,
+            result_type: None,
+            function: FunctionName("main".to_string()),
+            block: BlockLabel("entry".to_string()),
+        });
+        g.add_edge(c, print, GraphEdge::Operand);
+        g.add_edge(zero, r, GraphEdge::Operand);
+
+        let sg = SemanticGraph {
+            graph: g,
+            node_map: HashMap::new(),
+            functions: vec![FunctionInfo {
+                name: FunctionName("main".to_string()),
+                return_type: DuumbiType::I64,
+                params: vec![],
+                blocks: vec![BlockInfo {
+                    label: BlockLabel("entry".to_string()),
+                    nodes: vec![c, print, zero, r],
+                }],
+            }],
+            branch_targets: HashMap::new(),
+        };
+
+        let obj_bytes = compile_to_object(&sg).expect("f64 compilation should succeed");
         assert!(!obj_bytes.is_empty());
     }
 }

--- a/src/graph/builder.rs
+++ b/src/graph/builder.rs
@@ -12,7 +12,7 @@ use crate::errors::codes;
 use crate::parser::ast::ModuleAst;
 use crate::types::NodeId;
 
-use super::{BlockInfo, FunctionInfo, GraphEdge, GraphError, GraphNode, SemanticGraph};
+use super::{BlockInfo, FunctionInfo, GraphEdge, GraphError, GraphNode, ParamInfo, SemanticGraph};
 
 /// Builds a semantic graph from a parsed module AST.
 ///
@@ -25,6 +25,11 @@ pub fn build_graph(module: &ModuleAst) -> Result<SemanticGraph, Vec<GraphError>>
     let mut errors = Vec::new();
     let mut functions = Vec::new();
     let mut has_main = false;
+    let mut branch_targets: HashMap<NodeId, (String, String)> = HashMap::new();
+
+    // Collect all function names for Call target validation
+    let function_names: std::collections::HashSet<&str> =
+        module.functions.iter().map(|f| f.name.0.as_str()).collect();
 
     // Pass 1: Create all nodes
     for func_ast in &module.functions {
@@ -46,6 +51,17 @@ pub fn build_graph(module: &ModuleAst) -> Result<SemanticGraph, Vec<GraphError>>
                     continue;
                 }
 
+                // Validate Call targets
+                if let crate::types::Op::Call { ref function } = op_ast.op
+                    && !function_names.contains(function.as_str())
+                {
+                    errors.push(GraphError::OrphanRef {
+                        code: codes::E004_ORPHAN_REF,
+                        from_node: op_ast.id.0.clone(),
+                        target: function.clone(),
+                    });
+                }
+
                 let node = GraphNode {
                     id: op_ast.id.clone(),
                     op: op_ast.op.clone(),
@@ -53,6 +69,13 @@ pub fn build_graph(module: &ModuleAst) -> Result<SemanticGraph, Vec<GraphError>>
                     function: func_ast.name.clone(),
                     block: block_ast.label.clone(),
                 };
+
+                // Store branch target labels for later lowering
+                if matches!(op_ast.op, crate::types::Op::Branch)
+                    && let (Some(tb), Some(fb)) = (&op_ast.true_block, &op_ast.false_block)
+                {
+                    branch_targets.insert(op_ast.id.clone(), (tb.0.clone(), fb.0.clone()));
+                }
 
                 let idx = graph.add_node(node);
                 node_map.insert(op_ast.id.clone(), idx);
@@ -65,9 +88,19 @@ pub fn build_graph(module: &ModuleAst) -> Result<SemanticGraph, Vec<GraphError>>
             });
         }
 
+        let params = func_ast
+            .params
+            .iter()
+            .map(|p| ParamInfo {
+                name: p.name.clone(),
+                param_type: p.param_type,
+            })
+            .collect();
+
         functions.push(FunctionInfo {
             name: func_ast.name.clone(),
             return_type: func_ast.return_type,
+            params,
             blocks: block_infos,
         });
     }
@@ -86,6 +119,7 @@ pub fn build_graph(module: &ModuleAst) -> Result<SemanticGraph, Vec<GraphError>>
                     continue; // Skip duplicates already reported
                 };
 
+                // Left operand edge
                 if let Some(ref left) = op_ast.left {
                     match node_map.get(&left.id) {
                         Some(&target_idx) => {
@@ -99,6 +133,7 @@ pub fn build_graph(module: &ModuleAst) -> Result<SemanticGraph, Vec<GraphError>>
                     }
                 }
 
+                // Right operand edge
                 if let Some(ref right) = op_ast.right {
                     match node_map.get(&right.id) {
                         Some(&target_idx) => {
@@ -112,6 +147,7 @@ pub fn build_graph(module: &ModuleAst) -> Result<SemanticGraph, Vec<GraphError>>
                     }
                 }
 
+                // Single operand edge (Print, Return, Store)
                 if let Some(ref operand) = op_ast.operand {
                     match node_map.get(&operand.id) {
                         Some(&target_idx) => {
@@ -124,6 +160,34 @@ pub fn build_graph(module: &ModuleAst) -> Result<SemanticGraph, Vec<GraphError>>
                         }),
                     }
                 }
+
+                // Condition edge (Branch)
+                if let Some(ref condition) = op_ast.condition {
+                    match node_map.get(&condition.id) {
+                        Some(&target_idx) => {
+                            graph.add_edge(target_idx, src_idx, GraphEdge::Condition);
+                        }
+                        None => errors.push(GraphError::OrphanRef {
+                            code: codes::E004_ORPHAN_REF,
+                            from_node: op_ast.id.0.clone(),
+                            target: condition.id.0.clone(),
+                        }),
+                    }
+                }
+
+                // Call argument edges
+                for (i, arg_ref) in op_ast.args.iter().enumerate() {
+                    match node_map.get(&arg_ref.id) {
+                        Some(&target_idx) => {
+                            graph.add_edge(target_idx, src_idx, GraphEdge::Arg(i));
+                        }
+                        None => errors.push(GraphError::OrphanRef {
+                            code: codes::E004_ORPHAN_REF,
+                            from_node: op_ast.id.0.clone(),
+                            target: arg_ref.id.0.clone(),
+                        }),
+                    }
+                }
             }
         }
     }
@@ -133,6 +197,7 @@ pub fn build_graph(module: &ModuleAst) -> Result<SemanticGraph, Vec<GraphError>>
             graph,
             node_map,
             functions,
+            branch_targets,
         })
     } else {
         Err(errors)
@@ -160,7 +225,6 @@ mod tests {
 
     #[test]
     fn duplicate_id_detected() {
-        // Manually construct an AST with duplicate IDs
         use crate::parser::ast::*;
         use crate::types::*;
 
@@ -171,6 +235,7 @@ mod tests {
                 id: NodeId("duumbi:test/main".to_string()),
                 name: FunctionName("main".to_string()),
                 return_type: DuumbiType::I64,
+                params: vec![],
                 blocks: vec![BlockAst {
                     id: NodeId("duumbi:test/main/entry".to_string()),
                     label: BlockLabel("entry".to_string()),
@@ -182,6 +247,10 @@ mod tests {
                             left: None,
                             right: None,
                             operand: None,
+                            condition: None,
+                            true_block: None,
+                            false_block: None,
+                            args: Vec::new(),
                         },
                         OpAst {
                             id: NodeId("duumbi:test/main/entry/0".to_string()), // duplicate!
@@ -190,6 +259,10 @@ mod tests {
                             left: None,
                             right: None,
                             operand: None,
+                            condition: None,
+                            true_block: None,
+                            false_block: None,
+                            args: Vec::new(),
                         },
                     ],
                 }],
@@ -215,6 +288,7 @@ mod tests {
                 id: NodeId("duumbi:test/main".to_string()),
                 name: FunctionName("main".to_string()),
                 return_type: DuumbiType::I64,
+                params: vec![],
                 blocks: vec![BlockAst {
                     id: NodeId("duumbi:test/main/entry".to_string()),
                     label: BlockLabel("entry".to_string()),
@@ -227,6 +301,10 @@ mod tests {
                         operand: Some(NodeRef {
                             id: NodeId("duumbi:nonexistent".to_string()),
                         }),
+                        condition: None,
+                        true_block: None,
+                        false_block: None,
+                        args: Vec::new(),
                     }],
                 }],
             }],
@@ -251,6 +329,7 @@ mod tests {
                 id: NodeId("duumbi:test/helper".to_string()),
                 name: FunctionName("helper".to_string()),
                 return_type: DuumbiType::I64,
+                params: vec![],
                 blocks: vec![BlockAst {
                     id: NodeId("duumbi:test/helper/entry".to_string()),
                     label: BlockLabel("entry".to_string()),
@@ -261,6 +340,10 @@ mod tests {
                         left: None,
                         right: None,
                         operand: None,
+                        condition: None,
+                        true_block: None,
+                        false_block: None,
+                        args: Vec::new(),
                     }],
                 }],
             }],
@@ -268,5 +351,106 @@ mod tests {
 
         let errs = build_graph(&module).unwrap_err();
         assert!(errs.iter().any(|e| matches!(e, GraphError::NoEntry { .. })));
+    }
+
+    #[test]
+    fn call_unknown_function_detected() {
+        use crate::parser::ast::*;
+        use crate::types::*;
+
+        let module = ModuleAst {
+            id: NodeId("duumbi:test".to_string()),
+            name: ModuleName("test".to_string()),
+            functions: vec![FunctionAst {
+                id: NodeId("duumbi:test/main".to_string()),
+                name: FunctionName("main".to_string()),
+                return_type: DuumbiType::I64,
+                params: vec![],
+                blocks: vec![BlockAst {
+                    id: NodeId("duumbi:test/main/entry".to_string()),
+                    label: BlockLabel("entry".to_string()),
+                    ops: vec![OpAst {
+                        id: NodeId("duumbi:test/main/entry/0".to_string()),
+                        op: Op::Call {
+                            function: "nonexistent".to_string(),
+                        },
+                        result_type: Some(DuumbiType::I64),
+                        left: None,
+                        right: None,
+                        operand: None,
+                        condition: None,
+                        true_block: None,
+                        false_block: None,
+                        args: Vec::new(),
+                    }],
+                }],
+            }],
+        };
+
+        let errs = build_graph(&module).unwrap_err();
+        assert!(errs.iter().any(|e| matches!(e, GraphError::OrphanRef {
+                target, ..
+            } if target == "nonexistent")));
+    }
+
+    #[test]
+    fn function_params_preserved() {
+        use crate::types::DuumbiType;
+        let json = r#"{
+            "@type": "duumbi:Module", "@id": "duumbi:t", "duumbi:name": "t",
+            "duumbi:functions": [{
+                "@type": "duumbi:Function", "@id": "duumbi:t/main",
+                "duumbi:name": "main", "duumbi:returnType": "i64",
+                "duumbi:params": [{"duumbi:name": "n", "duumbi:paramType": "i64"}],
+                "duumbi:blocks": [{
+                    "@type": "duumbi:Block", "@id": "duumbi:t/main/e",
+                    "duumbi:label": "entry",
+                    "duumbi:ops": [
+                        {"@type": "duumbi:Const", "@id": "duumbi:t/main/e/0", "duumbi:value": 0, "duumbi:resultType": "i64"},
+                        {"@type": "duumbi:Return", "@id": "duumbi:t/main/e/1", "duumbi:operand": {"@id": "duumbi:t/main/e/0"}}
+                    ]
+                }]
+            }]
+        }"#;
+        let module = parse_jsonld(json).expect("parse should succeed");
+        let sg = build_graph(&module).expect("build should succeed");
+        assert_eq!(sg.functions[0].params.len(), 1);
+        assert_eq!(sg.functions[0].params[0].name, "n");
+        assert_eq!(sg.functions[0].params[0].param_type, DuumbiType::I64);
+    }
+
+    #[test]
+    fn multi_block_graph() {
+        let json = r#"{
+            "@type": "duumbi:Module", "@id": "duumbi:t", "duumbi:name": "t",
+            "duumbi:functions": [{
+                "@type": "duumbi:Function", "@id": "duumbi:t/main",
+                "duumbi:name": "main", "duumbi:returnType": "i64",
+                "duumbi:blocks": [
+                    {
+                        "@type": "duumbi:Block", "@id": "duumbi:t/main/entry",
+                        "duumbi:label": "entry",
+                        "duumbi:ops": [
+                            {"@type": "duumbi:Const", "@id": "duumbi:t/main/entry/0", "duumbi:value": 1, "duumbi:resultType": "i64"},
+                            {"@type": "duumbi:Return", "@id": "duumbi:t/main/entry/1", "duumbi:operand": {"@id": "duumbi:t/main/entry/0"}}
+                        ]
+                    },
+                    {
+                        "@type": "duumbi:Block", "@id": "duumbi:t/main/alt",
+                        "duumbi:label": "alt",
+                        "duumbi:ops": [
+                            {"@type": "duumbi:Const", "@id": "duumbi:t/main/alt/0", "duumbi:value": 2, "duumbi:resultType": "i64"},
+                            {"@type": "duumbi:Return", "@id": "duumbi:t/main/alt/1", "duumbi:operand": {"@id": "duumbi:t/main/alt/0"}}
+                        ]
+                    }
+                ]
+            }]
+        }"#;
+        let module = parse_jsonld(json).expect("parse should succeed");
+        let sg = build_graph(&module).expect("build should succeed");
+        assert_eq!(sg.functions[0].blocks.len(), 2);
+        assert_eq!(sg.functions[0].blocks[0].label.0, "entry");
+        assert_eq!(sg.functions[0].blocks[1].label.0, "alt");
+        assert_eq!(sg.graph.node_count(), 4);
     }
 }

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -75,22 +75,44 @@ pub struct GraphNode {
 
 /// Edge label in the semantic graph.
 #[derive(Debug, Clone)]
+#[allow(dead_code)] // Phase 1 variants used once compiler handles them
 pub enum GraphEdge {
     /// Left operand of a binary operation.
     Left,
     /// Right operand of a binary operation.
     Right,
-    /// Single operand (for Print, Return).
+    /// Single operand (for Print, Return, Store).
     Operand,
+    /// Condition edge (for Branch → condition node).
+    Condition,
+    /// True branch target (Branch → true block first node).
+    TrueBlock,
+    /// False branch target (Branch → false block first node).
+    FalseBlock,
+    /// Call argument by position.
+    Arg(usize),
+}
+
+/// Parameter info for a function.
+#[allow(dead_code)] // Used by compiler in Phase 1
+#[derive(Debug, Clone)]
+pub struct ParamInfo {
+    /// Parameter name.
+    pub name: String,
+    /// Parameter type.
+    pub param_type: DuumbiType,
 }
 
 /// Information about a function in the graph.
+#[allow(dead_code)] // Fields used by compiler in Phase 1
 #[derive(Debug, Clone)]
 pub struct FunctionInfo {
     /// Function name.
     pub name: FunctionName,
     /// Declared return type.
     pub return_type: DuumbiType,
+    /// Function parameters.
+    pub params: Vec<ParamInfo>,
     /// Blocks in this function, in order.
     pub blocks: Vec<BlockInfo>,
 }
@@ -118,4 +140,6 @@ pub struct SemanticGraph {
     pub node_map: HashMap<NodeId, NodeIndex>,
     /// Function metadata, in order.
     pub functions: Vec<FunctionInfo>,
+    /// Branch target labels: NodeId → (true_block_label, false_block_label).
+    pub branch_targets: HashMap<NodeId, (String, String)>,
 }

--- a/src/graph/validator.rs
+++ b/src/graph/validator.rs
@@ -25,6 +25,7 @@ pub fn validate(graph: &SemanticGraph) -> Vec<Diagnostic> {
     check_cycles(graph, &mut diagnostics);
     check_types(graph, &mut diagnostics);
     check_return_types(graph, &mut diagnostics);
+    check_branch_conditions(graph, &mut diagnostics);
 
     diagnostics
 }
@@ -43,8 +44,8 @@ fn check_cycles(graph: &SemanticGraph, diagnostics: &mut Vec<Diagnostic>) {
 fn check_types(graph: &SemanticGraph, diagnostics: &mut Vec<Diagnostic>) {
     for node_idx in graph.graph.node_indices() {
         let node = &graph.graph[node_idx];
-        match node.op {
-            Op::Add | Op::Sub | Op::Mul | Op::Div => {
+        match &node.op {
+            Op::Add | Op::Sub | Op::Mul | Op::Div | Op::Compare(_) => {
                 let mut left_type: Option<DuumbiType> = None;
                 let mut right_type: Option<DuumbiType> = None;
 
@@ -58,7 +59,7 @@ fn check_types(graph: &SemanticGraph, diagnostics: &mut Vec<Diagnostic>) {
                     match edge_ref.weight() {
                         GraphEdge::Left => left_type = source_type,
                         GraphEdge::Right => right_type = source_type,
-                        GraphEdge::Operand => {}
+                        _ => {}
                     }
                 }
 
@@ -91,7 +92,7 @@ fn check_return_types(graph: &SemanticGraph, diagnostics: &mut Vec<Diagnostic>) 
         for block_info in &func_info.blocks {
             for &node_idx in &block_info.nodes {
                 let node = &graph.graph[node_idx];
-                if !matches!(node.op, Op::Return) {
+                if !matches!(&node.op, Op::Return) {
                     continue;
                 }
 
@@ -128,12 +129,53 @@ fn check_return_types(graph: &SemanticGraph, diagnostics: &mut Vec<Diagnostic>) 
     }
 }
 
+/// Checks that Branch condition operands are boolean.
+fn check_branch_conditions(graph: &SemanticGraph, diagnostics: &mut Vec<Diagnostic>) {
+    for node_idx in graph.graph.node_indices() {
+        let node = &graph.graph[node_idx];
+        if !matches!(&node.op, Op::Branch) {
+            continue;
+        }
+
+        for edge_ref in graph
+            .graph
+            .edges_directed(node_idx, petgraph::Direction::Incoming)
+        {
+            if !matches!(edge_ref.weight(), GraphEdge::Condition) {
+                continue;
+            }
+            let source_node = &graph.graph[edge_ref.source()];
+            if let Some(actual_type) = resolve_output_type(source_node)
+                && actual_type != DuumbiType::Bool
+            {
+                let mut details = HashMap::new();
+                details.insert("expected".to_string(), "bool".to_string());
+                details.insert("found".to_string(), actual_type.to_string());
+                diagnostics.push(
+                    Diagnostic::error(codes::E001_TYPE_MISMATCH, "Branch condition must be bool")
+                        .with_node(&node.id)
+                        .with_details(details),
+                );
+            }
+        }
+    }
+}
+
 /// Resolves the output type of a graph node.
 fn resolve_output_type(node: &super::GraphNode) -> Option<DuumbiType> {
-    match node.op {
-        Op::Const(_) | Op::Add | Op::Sub | Op::Mul | Op::Div => node.result_type,
-        Op::Print => Some(DuumbiType::Void),
-        Op::Return => None,
+    match &node.op {
+        Op::Const(_)
+        | Op::ConstF64(_)
+        | Op::ConstBool(_)
+        | Op::Add
+        | Op::Sub
+        | Op::Mul
+        | Op::Div
+        | Op::Load { .. } => node.result_type,
+        Op::Compare(_) => Some(DuumbiType::Bool),
+        Op::Call { .. } => node.result_type,
+        Op::Print | Op::Store { .. } => Some(DuumbiType::Void),
+        Op::Return | Op::Branch => None,
     }
 }
 
@@ -141,7 +183,10 @@ fn resolve_output_type(node: &super::GraphNode) -> Option<DuumbiType> {
 mod tests {
     use super::*;
     use crate::graph::builder::build_graph;
+    use crate::graph::*;
     use crate::parser::parse_jsonld;
+    use crate::types::*;
+    use petgraph::stable_graph::StableGraph;
 
     fn fixture_add() -> String {
         std::fs::read_to_string("tests/fixtures/add.jsonld")
@@ -158,9 +203,6 @@ mod tests {
 
     #[test]
     fn type_mismatch_binary_op() {
-        use crate::graph::*;
-        use petgraph::stable_graph::StableGraph;
-
         let mut graph = StableGraph::new();
         let a = graph.add_node(GraphNode {
             id: NodeId("a".to_string()),
@@ -190,6 +232,7 @@ mod tests {
             graph,
             node_map: std::collections::HashMap::new(),
             functions: vec![],
+            branch_targets: std::collections::HashMap::new(),
         };
 
         let diags = validate(&sg);
@@ -200,10 +243,48 @@ mod tests {
     }
 
     #[test]
-    fn cycle_detected() {
-        use crate::graph::*;
-        use petgraph::stable_graph::StableGraph;
+    fn type_mismatch_f64_mixed_operands() {
+        let mut graph = StableGraph::new();
+        let a = graph.add_node(GraphNode {
+            id: NodeId("a".to_string()),
+            op: Op::Const(1),
+            result_type: Some(DuumbiType::I64),
+            function: FunctionName("main".to_string()),
+            block: BlockLabel("entry".to_string()),
+        });
+        let b = graph.add_node(GraphNode {
+            id: NodeId("b".to_string()),
+            op: Op::ConstF64(2.0),
+            result_type: Some(DuumbiType::F64),
+            function: FunctionName("main".to_string()),
+            block: BlockLabel("entry".to_string()),
+        });
+        let add = graph.add_node(GraphNode {
+            id: NodeId("add".to_string()),
+            op: Op::Add,
+            result_type: Some(DuumbiType::F64),
+            function: FunctionName("main".to_string()),
+            block: BlockLabel("entry".to_string()),
+        });
+        graph.add_edge(a, add, GraphEdge::Left);
+        graph.add_edge(b, add, GraphEdge::Right);
 
+        let sg = SemanticGraph {
+            graph,
+            node_map: std::collections::HashMap::new(),
+            functions: vec![],
+            branch_targets: std::collections::HashMap::new(),
+        };
+
+        let diags = validate(&sg);
+        assert!(
+            diags.iter().any(|d| d.code == codes::E001_TYPE_MISMATCH),
+            "Expected E001 for mixed i64/f64 operands"
+        );
+    }
+
+    #[test]
+    fn cycle_detected() {
         let mut graph = StableGraph::new();
         let a = graph.add_node(GraphNode {
             id: NodeId("a".to_string()),
@@ -226,6 +307,7 @@ mod tests {
             graph,
             node_map: std::collections::HashMap::new(),
             functions: vec![],
+            branch_targets: std::collections::HashMap::new(),
         };
 
         let diags = validate(&sg);
@@ -237,8 +319,7 @@ mod tests {
 
     #[test]
     fn return_type_mismatch() {
-        use crate::graph::*;
-        use petgraph::stable_graph::{NodeIndex, StableGraph};
+        use petgraph::stable_graph::NodeIndex;
 
         let mut graph = StableGraph::new();
         let void_node = graph.add_node(GraphNode {
@@ -263,17 +344,126 @@ mod tests {
             functions: vec![FunctionInfo {
                 name: FunctionName("main".to_string()),
                 return_type: DuumbiType::I64,
+                params: vec![],
                 blocks: vec![BlockInfo {
                     label: BlockLabel("entry".to_string()),
                     nodes: vec![NodeIndex::new(0), NodeIndex::new(1)],
                 }],
             }],
+            branch_targets: std::collections::HashMap::new(),
         };
 
         let diags = validate(&sg);
         assert!(
             diags.iter().any(|d| d.code == codes::E001_TYPE_MISMATCH),
             "Expected E001 return type mismatch"
+        );
+    }
+
+    #[test]
+    fn branch_condition_not_bool() {
+        let mut graph = StableGraph::new();
+        let cond = graph.add_node(GraphNode {
+            id: NodeId("cond".to_string()),
+            op: Op::Const(1),
+            result_type: Some(DuumbiType::I64), // not bool!
+            function: FunctionName("main".to_string()),
+            block: BlockLabel("entry".to_string()),
+        });
+        let branch = graph.add_node(GraphNode {
+            id: NodeId("branch".to_string()),
+            op: Op::Branch,
+            result_type: None,
+            function: FunctionName("main".to_string()),
+            block: BlockLabel("entry".to_string()),
+        });
+        graph.add_edge(cond, branch, GraphEdge::Condition);
+
+        let sg = SemanticGraph {
+            graph,
+            node_map: std::collections::HashMap::new(),
+            functions: vec![],
+            branch_targets: std::collections::HashMap::new(),
+        };
+
+        let diags = validate(&sg);
+        assert!(
+            diags.iter().any(|d| d.code == codes::E001_TYPE_MISMATCH),
+            "Expected E001 for non-bool Branch condition"
+        );
+    }
+
+    #[test]
+    fn branch_condition_bool_is_valid() {
+        let mut graph = StableGraph::new();
+        let cond = graph.add_node(GraphNode {
+            id: NodeId("cond".to_string()),
+            op: Op::ConstBool(true),
+            result_type: Some(DuumbiType::Bool),
+            function: FunctionName("main".to_string()),
+            block: BlockLabel("entry".to_string()),
+        });
+        let branch = graph.add_node(GraphNode {
+            id: NodeId("branch".to_string()),
+            op: Op::Branch,
+            result_type: None,
+            function: FunctionName("main".to_string()),
+            block: BlockLabel("entry".to_string()),
+        });
+        graph.add_edge(cond, branch, GraphEdge::Condition);
+
+        let sg = SemanticGraph {
+            graph,
+            node_map: std::collections::HashMap::new(),
+            functions: vec![],
+            branch_targets: std::collections::HashMap::new(),
+        };
+
+        let diags = validate(&sg);
+        assert!(
+            !diags.iter().any(|d| d.code == codes::E001_TYPE_MISMATCH),
+            "Expected no E001 for bool Branch condition"
+        );
+    }
+
+    #[test]
+    fn compare_operands_type_mismatch() {
+        let mut graph = StableGraph::new();
+        let a = graph.add_node(GraphNode {
+            id: NodeId("a".to_string()),
+            op: Op::Const(1),
+            result_type: Some(DuumbiType::I64),
+            function: FunctionName("main".to_string()),
+            block: BlockLabel("entry".to_string()),
+        });
+        let b = graph.add_node(GraphNode {
+            id: NodeId("b".to_string()),
+            op: Op::ConstF64(2.0),
+            result_type: Some(DuumbiType::F64),
+            function: FunctionName("main".to_string()),
+            block: BlockLabel("entry".to_string()),
+        });
+        let cmp = graph.add_node(GraphNode {
+            id: NodeId("cmp".to_string()),
+            op: Op::Compare(CompareOp::Eq),
+            result_type: Some(DuumbiType::Bool),
+            function: FunctionName("main".to_string()),
+            block: BlockLabel("entry".to_string()),
+        });
+        graph.add_edge(a, cmp, GraphEdge::Left);
+        graph.add_edge(b, cmp, GraphEdge::Right);
+
+        let sg = SemanticGraph {
+            graph,
+            node_map: std::collections::HashMap::new(),
+            functions: vec![],
+            branch_targets: std::collections::HashMap::new(),
+        };
+
+        let diags = validate(&sg);
+        assert!(
+            diags.iter().any(|d| d.code == codes::E001_TYPE_MISMATCH),
+            "Expected E001 for Compare with mismatched operand types"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ mod parser;
 mod types;
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process;
 
 use anyhow::{Context, Result};
@@ -37,12 +37,81 @@ fn main() {
 
 fn run(cli: Cli) -> Result<()> {
     match cli.command {
-        Commands::Build { input, output } => build(&input, &output),
+        Commands::Init { name } => {
+            let base = match name {
+                Some(ref n) => {
+                    let p = PathBuf::from(n);
+                    fs::create_dir_all(&p)
+                        .with_context(|| format!("Failed to create directory '{n}'"))?;
+                    p
+                }
+                None => PathBuf::from("."),
+            };
+            cli::init::run_init(&base)
+        }
+        Commands::Build { input, output } => {
+            let input_path = resolve_input(input.as_deref())?;
+            let output_path = resolve_output(output.as_deref())?;
+            build(&input_path, &output_path)
+        }
+        Commands::Run { args } => {
+            let binary = resolve_output(None)?;
+            if !binary.exists() {
+                anyhow::bail!(
+                    "Binary not found at '{}'. Run `duumbi build` first.",
+                    binary.display()
+                );
+            }
+            let status = process::Command::new(&binary)
+                .args(&args)
+                .status()
+                .with_context(|| format!("Failed to execute '{}'", binary.display()))?;
+            process::exit(status.code().unwrap_or(1));
+        }
+        Commands::Check { input } => {
+            let input_path = resolve_input(input.as_deref())?;
+            check(&input_path)
+        }
+        Commands::Describe { input } => {
+            let input_path = resolve_input(input.as_deref())?;
+            describe(&input_path)
+        }
     }
 }
 
-fn build(input: &Path, output: &Path) -> Result<()> {
-    // 1. Parse
+/// Resolves the input file path: explicit path or workspace discovery.
+fn resolve_input(explicit: Option<&Path>) -> Result<PathBuf> {
+    if let Some(p) = explicit {
+        return Ok(p.to_path_buf());
+    }
+
+    let workspace_main = PathBuf::from(".duumbi/graph/main.jsonld");
+    if workspace_main.exists() {
+        return Ok(workspace_main);
+    }
+
+    anyhow::bail!(
+        "No input file specified and no workspace found. \
+         Use `duumbi init` to create a workspace or specify an input file."
+    )
+}
+
+/// Resolves the output path: explicit path or workspace default.
+fn resolve_output(explicit: Option<&Path>) -> Result<PathBuf> {
+    if let Some(p) = explicit {
+        return Ok(p.to_path_buf());
+    }
+
+    let workspace_build = PathBuf::from(".duumbi/build");
+    if workspace_build.exists() {
+        return Ok(workspace_build.join("output"));
+    }
+
+    Ok(PathBuf::from("output"))
+}
+
+/// Parses and validates a source file, returning the semantic graph on success.
+fn parse_and_validate(input: &Path) -> Result<graph::SemanticGraph> {
     let source = fs::read_to_string(input)
         .with_context(|| format!("Failed to read input file '{}'", input.display()))?;
 
@@ -68,7 +137,6 @@ fn build(input: &Path, output: &Path) -> Result<()> {
         }
     };
 
-    // 2. Build graph
     let semantic_graph = match builder::build_graph(&module_ast) {
         Ok(sg) => sg,
         Err(errors) => {
@@ -80,7 +148,6 @@ fn build(input: &Path, output: &Path) -> Result<()> {
         }
     };
 
-    // 3. Validate
     let diagnostics = validator::validate(&semantic_graph);
     if !diagnostics.is_empty() {
         for diag in &diagnostics {
@@ -89,35 +156,66 @@ fn build(input: &Path, output: &Path) -> Result<()> {
         anyhow::bail!("Validation failed with {} error(s)", diagnostics.len());
     }
 
-    // 4. Compile to object
+    Ok(semantic_graph)
+}
+
+fn build(input: &Path, output: &Path) -> Result<()> {
+    let semantic_graph = parse_and_validate(input)?;
+
+    // Compile to object
     let obj_bytes =
         lowering::compile_to_object(&semantic_graph).context("Cranelift compilation failed")?;
 
-    // 5. Write object file to temp
-    let tmp_dir = std::env::temp_dir().join("duumbi_build");
+    // Write object file to a unique temp directory (avoid race conditions)
+    let unique_id = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    let tmp_dir =
+        std::env::temp_dir().join(format!("duumbi_build_{}_{}", std::process::id(), unique_id));
     fs::create_dir_all(&tmp_dir).context("Failed to create temp build directory")?;
 
     let obj_path = tmp_dir.join("output.o");
     fs::write(&obj_path, &obj_bytes).context("Failed to write object file")?;
 
-    // 6. Compile C runtime
+    // Compile C runtime
     let runtime_c = find_runtime_c()?;
     let runtime_o = tmp_dir.join("duumbi_runtime.o");
     linker::compile_runtime(&runtime_c, &runtime_o).context("Failed to compile C runtime")?;
 
-    // 7. Link
+    // Link
     linker::link(&obj_path, &runtime_o, output).context("Failed to link binary")?;
+
+    // Clean up temp build artifacts
+    let _ = fs::remove_dir_all(&tmp_dir);
 
     eprintln!("Build successful: {}", output.display());
     Ok(())
 }
 
-/// Locates the `duumbi_runtime.c` file.
+fn check(input: &Path) -> Result<()> {
+    match parse_and_validate(input) {
+        Ok(_) => {
+            eprintln!("Validation passed.");
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+fn describe(input: &Path) -> Result<()> {
+    let semantic_graph = parse_and_validate(input)?;
+    cli::describe::describe(&semantic_graph);
+    Ok(())
+}
+
+/// The C runtime source, embedded at compile time.
+const RUNTIME_C_SOURCE: &str = include_str!("../runtime/duumbi_runtime.c");
+
+/// Provides the `duumbi_runtime.c` file, writing it to a temp location if needed.
 ///
-/// Searches relative to the executable, then falls back to `runtime/` in the
-/// current working directory.
+/// First checks for the file on disk (relative to CWD or executable), then
+/// falls back to writing the embedded source to a temp file.
 fn find_runtime_c() -> Result<std::path::PathBuf> {
-    // Try relative to the cargo manifest dir (for development)
     let candidates = [
         std::path::PathBuf::from("runtime/duumbi_runtime.c"),
         std::env::current_exe()
@@ -132,14 +230,12 @@ fn find_runtime_c() -> Result<std::path::PathBuf> {
         }
     }
 
-    anyhow::bail!(
-        "Could not find duumbi_runtime.c. Searched: {}",
-        candidates
-            .iter()
-            .map(|p| p.display().to_string())
-            .collect::<Vec<_>>()
-            .join(", ")
-    )
+    // Fall back to writing the embedded runtime source
+    let tmp_dir = std::env::temp_dir().join("duumbi_build");
+    fs::create_dir_all(&tmp_dir).context("Failed to create temp build directory")?;
+    let runtime_path = tmp_dir.join("duumbi_runtime.c");
+    fs::write(&runtime_path, RUNTIME_C_SOURCE).context("Failed to write embedded runtime")?;
+    Ok(runtime_path)
 }
 
 /// Emits a diagnostic as JSONL to stdout and a human summary to stderr.

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -13,8 +13,18 @@ pub struct NodeRef {
     pub id: NodeId,
 }
 
+/// A parsed function parameter.
+#[allow(dead_code)] // Fields used once graph builder handles params
+#[derive(Debug, Clone)]
+pub struct ParamAst {
+    /// Parameter name.
+    pub name: String,
+    /// Parameter type.
+    pub param_type: DuumbiType,
+}
+
 /// A parsed operation within a block.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct OpAst {
     /// The `@id` of this operation node.
     pub id: NodeId,
@@ -26,8 +36,16 @@ pub struct OpAst {
     pub left: Option<NodeRef>,
     /// Right operand reference (for binary ops).
     pub right: Option<NodeRef>,
-    /// Single operand reference (for Print, Return).
+    /// Single operand reference (for Print, Return, Compare).
     pub operand: Option<NodeRef>,
+    /// Condition reference (for Branch).
+    pub condition: Option<NodeRef>,
+    /// True block label (for Branch).
+    pub true_block: Option<BlockLabel>,
+    /// False block label (for Branch).
+    pub false_block: Option<BlockLabel>,
+    /// Argument references (for Call).
+    pub args: Vec<NodeRef>,
 }
 
 /// A parsed basic block.
@@ -52,6 +70,8 @@ pub struct FunctionAst {
     pub name: FunctionName,
     /// Declared return type.
     pub return_type: DuumbiType,
+    /// Function parameters.
+    pub params: Vec<ParamAst>,
     /// Blocks in this function.
     pub blocks: Vec<BlockAst>,
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6,11 +6,11 @@
 
 pub mod ast;
 
-use ast::{BlockAst, FunctionAst, ModuleAst, NodeRef, OpAst};
+use ast::{BlockAst, FunctionAst, ModuleAst, NodeRef, OpAst, ParamAst};
 use thiserror::Error;
 
 use crate::errors::codes;
-use crate::types::{BlockLabel, DuumbiType, FunctionName, ModuleName, NodeId, Op};
+use crate::types::{BlockLabel, CompareOp, DuumbiType, FunctionName, ModuleName, NodeId, Op};
 
 /// Errors that can occur during JSON-LD parsing.
 #[derive(Debug, Error)]
@@ -101,10 +101,27 @@ fn get_array<'a>(
 fn parse_type_str(s: &str) -> Result<DuumbiType, ParseError> {
     match s {
         "i64" => Ok(DuumbiType::I64),
+        "f64" => Ok(DuumbiType::F64),
+        "bool" => Ok(DuumbiType::Bool),
         "void" => Ok(DuumbiType::Void),
         other => Err(ParseError::SchemaInvalid {
             code: codes::E009_SCHEMA_INVALID,
             message: format!("Unknown type '{other}'"),
+        }),
+    }
+}
+
+fn parse_compare_op(s: &str) -> Result<CompareOp, ParseError> {
+    match s {
+        "eq" => Ok(CompareOp::Eq),
+        "ne" => Ok(CompareOp::Ne),
+        "lt" => Ok(CompareOp::Lt),
+        "le" => Ok(CompareOp::Le),
+        "gt" => Ok(CompareOp::Gt),
+        "ge" => Ok(CompareOp::Ge),
+        other => Err(ParseError::SchemaInvalid {
+            code: codes::E009_SCHEMA_INVALID,
+            message: format!("Unknown compare operator '{other}'"),
         }),
     }
 }
@@ -173,6 +190,27 @@ fn parse_function(value: &serde_json::Value) -> Result<FunctionAst, ParseError> 
     let return_type = parse_type_str(return_type_str)?;
     let blocks_arr = get_array(value, "duumbi:blocks", node_id_str)?;
 
+    // Parse params (optional — Phase 0 functions may not have params)
+    let params = if let Some(params_val) = value.get("duumbi:params") {
+        if let Some(params_arr) = params_val.as_array() {
+            let mut params = Vec::with_capacity(params_arr.len());
+            for param_val in params_arr {
+                let param_name = get_str(param_val, "duumbi:name", node_id_str)?;
+                let param_type_str = get_str(param_val, "duumbi:paramType", node_id_str)?;
+                let param_type = parse_type_str(param_type_str)?;
+                params.push(ParamAst {
+                    name: param_name.to_string(),
+                    param_type,
+                });
+            }
+            params
+        } else {
+            Vec::new()
+        }
+    } else {
+        Vec::new()
+    };
+
     let mut blocks = Vec::with_capacity(blocks_arr.len());
     for block_val in blocks_arr {
         blocks.push(parse_block(block_val)?);
@@ -182,6 +220,7 @@ fn parse_function(value: &serde_json::Value) -> Result<FunctionAst, ParseError> 
         id: NodeId(node_id_str.to_string()),
         name: FunctionName(name.to_string()),
         return_type,
+        params,
         blocks,
     })
 }
@@ -211,6 +250,22 @@ fn parse_block(value: &serde_json::Value) -> Result<BlockAst, ParseError> {
     })
 }
 
+/// Creates a default OpAst with only id, op, and result_type set.
+fn make_op_ast(id: NodeId, op: Op, result_type: Option<DuumbiType>) -> OpAst {
+    OpAst {
+        id,
+        op,
+        result_type,
+        left: None,
+        right: None,
+        operand: None,
+        condition: None,
+        true_block: None,
+        false_block: None,
+        args: Vec::new(),
+    }
+}
+
 fn parse_op(value: &serde_json::Value) -> Result<OpAst, ParseError> {
     let node_id_str = get_str(value, "@id", "<unknown op>")?;
     let at_type = get_str(value, "@type", node_id_str)?;
@@ -223,22 +278,48 @@ fn parse_op(value: &serde_json::Value) -> Result<OpAst, ParseError> {
 
     match at_type {
         "duumbi:Const" => {
-            let val = value
-                .get("duumbi:value")
-                .and_then(|v| v.as_i64())
-                .ok_or_else(|| ParseError::MissingField {
-                    code: codes::E003_MISSING_FIELD,
-                    field: "duumbi:value".to_string(),
-                    node_id: node_id_str.to_string(),
-                })?;
-            Ok(OpAst {
-                id: NodeId(node_id_str.to_string()),
-                op: Op::Const(val),
+            // Determine const type from resultType
+            let rt = result_type.unwrap_or(DuumbiType::I64);
+            let op = match rt {
+                DuumbiType::F64 => {
+                    let val = value
+                        .get("duumbi:value")
+                        .and_then(|v| v.as_f64())
+                        .ok_or_else(|| ParseError::MissingField {
+                            code: codes::E003_MISSING_FIELD,
+                            field: "duumbi:value".to_string(),
+                            node_id: node_id_str.to_string(),
+                        })?;
+                    Op::ConstF64(val)
+                }
+                DuumbiType::Bool => {
+                    let val = value
+                        .get("duumbi:value")
+                        .and_then(|v| v.as_bool())
+                        .ok_or_else(|| ParseError::MissingField {
+                            code: codes::E003_MISSING_FIELD,
+                            field: "duumbi:value".to_string(),
+                            node_id: node_id_str.to_string(),
+                        })?;
+                    Op::ConstBool(val)
+                }
+                _ => {
+                    let val = value
+                        .get("duumbi:value")
+                        .and_then(|v| v.as_i64())
+                        .ok_or_else(|| ParseError::MissingField {
+                            code: codes::E003_MISSING_FIELD,
+                            field: "duumbi:value".to_string(),
+                            node_id: node_id_str.to_string(),
+                        })?;
+                    Op::Const(val)
+                }
+            };
+            Ok(make_op_ast(
+                NodeId(node_id_str.to_string()),
+                op,
                 result_type,
-                left: None,
-                right: None,
-                operand: None,
-            })
+            ))
         }
         "duumbi:Add" | "duumbi:Sub" | "duumbi:Mul" | "duumbi:Div" => {
             let left = parse_node_ref(value, "duumbi:left", node_id_str)?;
@@ -250,14 +331,91 @@ fn parse_op(value: &serde_json::Value) -> Result<OpAst, ParseError> {
                 "duumbi:Div" => Op::Div,
                 _ => unreachable!(),
             };
-            Ok(OpAst {
-                id: NodeId(node_id_str.to_string()),
-                op,
+            let mut ast = make_op_ast(NodeId(node_id_str.to_string()), op, result_type);
+            ast.left = Some(left);
+            ast.right = Some(right);
+            Ok(ast)
+        }
+        "duumbi:Compare" => {
+            let operator_str = get_str(value, "duumbi:operator", node_id_str)?;
+            let compare_op = parse_compare_op(operator_str)?;
+            let left = parse_node_ref(value, "duumbi:left", node_id_str)?;
+            let right = parse_node_ref(value, "duumbi:right", node_id_str)?;
+            let mut ast = make_op_ast(
+                NodeId(node_id_str.to_string()),
+                Op::Compare(compare_op),
                 result_type,
-                left: Some(left),
-                right: Some(right),
-                operand: None,
-            })
+            );
+            ast.left = Some(left);
+            ast.right = Some(right);
+            Ok(ast)
+        }
+        "duumbi:Branch" => {
+            let condition = parse_node_ref(value, "duumbi:condition", node_id_str)?;
+            let true_block_str = get_str(value, "duumbi:trueBlock", node_id_str)?;
+            let false_block_str = get_str(value, "duumbi:falseBlock", node_id_str)?;
+            let mut ast = make_op_ast(NodeId(node_id_str.to_string()), Op::Branch, result_type);
+            ast.condition = Some(condition);
+            ast.true_block = Some(BlockLabel(true_block_str.to_string()));
+            ast.false_block = Some(BlockLabel(false_block_str.to_string()));
+            Ok(ast)
+        }
+        "duumbi:Call" => {
+            let function_name = get_str(value, "duumbi:function", node_id_str)?;
+            let args = if let Some(args_val) = value.get("duumbi:args") {
+                if let Some(args_arr) = args_val.as_array() {
+                    let mut refs = Vec::with_capacity(args_arr.len());
+                    for arg_val in args_arr {
+                        let id = arg_val.get("@id").and_then(|v| v.as_str()).ok_or_else(|| {
+                            ParseError::MissingField {
+                                code: codes::E003_MISSING_FIELD,
+                                field: "duumbi:args.@id".to_string(),
+                                node_id: node_id_str.to_string(),
+                            }
+                        })?;
+                        refs.push(NodeRef {
+                            id: NodeId(id.to_string()),
+                        });
+                    }
+                    refs
+                } else {
+                    Vec::new()
+                }
+            } else {
+                Vec::new()
+            };
+            let mut ast = make_op_ast(
+                NodeId(node_id_str.to_string()),
+                Op::Call {
+                    function: function_name.to_string(),
+                },
+                result_type,
+            );
+            ast.args = args;
+            Ok(ast)
+        }
+        "duumbi:Load" => {
+            let variable = get_str(value, "duumbi:variable", node_id_str)?;
+            Ok(make_op_ast(
+                NodeId(node_id_str.to_string()),
+                Op::Load {
+                    variable: variable.to_string(),
+                },
+                result_type,
+            ))
+        }
+        "duumbi:Store" => {
+            let variable = get_str(value, "duumbi:variable", node_id_str)?;
+            let operand = parse_node_ref(value, "duumbi:operand", node_id_str)?;
+            let mut ast = make_op_ast(
+                NodeId(node_id_str.to_string()),
+                Op::Store {
+                    variable: variable.to_string(),
+                },
+                result_type,
+            );
+            ast.operand = Some(operand);
+            Ok(ast)
         }
         "duumbi:Print" | "duumbi:Return" => {
             let operand = parse_node_ref(value, "duumbi:operand", node_id_str)?;
@@ -266,14 +424,9 @@ fn parse_op(value: &serde_json::Value) -> Result<OpAst, ParseError> {
                 "duumbi:Return" => Op::Return,
                 _ => unreachable!(),
             };
-            Ok(OpAst {
-                id: NodeId(node_id_str.to_string()),
-                op,
-                result_type,
-                left: None,
-                right: None,
-                operand: Some(operand),
-            })
+            let mut ast = make_op_ast(NodeId(node_id_str.to_string()), op, result_type);
+            ast.operand = Some(operand);
+            Ok(ast)
         }
         other => Err(ParseError::UnknownOp {
             code: codes::E002_UNKNOWN_OP,
@@ -286,6 +439,7 @@ fn parse_op(value: &serde_json::Value) -> Result<OpAst, ParseError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::CompareOp;
 
     fn fixture_add() -> String {
         std::fs::read_to_string("tests/fixtures/add.jsonld")
@@ -380,5 +534,289 @@ mod tests {
     fn invalid_json() {
         let err = parse_jsonld("not json at all").unwrap_err();
         assert!(matches!(err, ParseError::Json { .. }));
+    }
+
+    #[test]
+    fn parse_compare_all_operators() {
+        for (op_str, expected) in [
+            ("eq", CompareOp::Eq),
+            ("ne", CompareOp::Ne),
+            ("lt", CompareOp::Lt),
+            ("le", CompareOp::Le),
+            ("gt", CompareOp::Gt),
+            ("ge", CompareOp::Ge),
+        ] {
+            let json = format!(
+                r#"{{
+                "@type": "duumbi:Module", "@id": "duumbi:t", "duumbi:name": "t",
+                "duumbi:functions": [{{
+                    "@type": "duumbi:Function", "@id": "duumbi:t/main",
+                    "duumbi:name": "main", "duumbi:returnType": "i64",
+                    "duumbi:blocks": [{{
+                        "@type": "duumbi:Block", "@id": "duumbi:t/main/e",
+                        "duumbi:label": "entry",
+                        "duumbi:ops": [
+                            {{"@type": "duumbi:Const", "@id": "duumbi:t/main/e/0", "duumbi:value": 1, "duumbi:resultType": "i64"}},
+                            {{"@type": "duumbi:Const", "@id": "duumbi:t/main/e/1", "duumbi:value": 2, "duumbi:resultType": "i64"}},
+                            {{
+                                "@type": "duumbi:Compare",
+                                "@id": "duumbi:t/main/e/2",
+                                "duumbi:operator": "{op_str}",
+                                "duumbi:left": {{"@id": "duumbi:t/main/e/0"}},
+                                "duumbi:right": {{"@id": "duumbi:t/main/e/1"}},
+                                "duumbi:resultType": "bool"
+                            }}
+                        ]
+                    }}]
+                }}]
+            }}"#
+            );
+            let module = parse_jsonld(&json)
+                .unwrap_or_else(|e| panic!("parse failed for operator '{op_str}': {e}"));
+            let op = &module.functions[0].blocks[0].ops[2].op;
+            assert_eq!(*op, Op::Compare(expected), "failed for operator '{op_str}'");
+        }
+    }
+
+    #[test]
+    fn parse_branch() {
+        let json = r#"{
+            "@type": "duumbi:Module", "@id": "duumbi:t", "duumbi:name": "t",
+            "duumbi:functions": [{
+                "@type": "duumbi:Function", "@id": "duumbi:t/main",
+                "duumbi:name": "main", "duumbi:returnType": "i64",
+                "duumbi:blocks": [{
+                    "@type": "duumbi:Block", "@id": "duumbi:t/main/e",
+                    "duumbi:label": "entry",
+                    "duumbi:ops": [
+                        {"@type": "duumbi:Const", "@id": "duumbi:t/main/e/0", "duumbi:value": true, "duumbi:resultType": "bool"},
+                        {
+                            "@type": "duumbi:Branch",
+                            "@id": "duumbi:t/main/e/1",
+                            "duumbi:condition": {"@id": "duumbi:t/main/e/0"},
+                            "duumbi:trueBlock": "then",
+                            "duumbi:falseBlock": "else"
+                        }
+                    ]
+                }]
+            }]
+        }"#;
+        let module = parse_jsonld(json).expect("parse should succeed");
+        let branch = &module.functions[0].blocks[0].ops[1];
+        assert_eq!(branch.op, Op::Branch);
+        assert!(branch.condition.is_some());
+        assert_eq!(
+            branch.true_block.as_ref().map(|b| &b.0),
+            Some(&"then".to_string())
+        );
+        assert_eq!(
+            branch.false_block.as_ref().map(|b| &b.0),
+            Some(&"else".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_branch_missing_true_block() {
+        let json = r#"{
+            "@type": "duumbi:Module", "@id": "duumbi:t", "duumbi:name": "t",
+            "duumbi:functions": [{
+                "@type": "duumbi:Function", "@id": "duumbi:t/main",
+                "duumbi:name": "main", "duumbi:returnType": "i64",
+                "duumbi:blocks": [{
+                    "@type": "duumbi:Block", "@id": "duumbi:t/main/e",
+                    "duumbi:label": "entry",
+                    "duumbi:ops": [{
+                        "@type": "duumbi:Branch",
+                        "@id": "duumbi:t/main/e/0",
+                        "duumbi:condition": {"@id": "duumbi:t/main/e/x"},
+                        "duumbi:falseBlock": "else"
+                    }]
+                }]
+            }]
+        }"#;
+        let err = parse_jsonld(json).unwrap_err();
+        assert!(
+            matches!(err, ParseError::MissingField { field, .. } if field == "duumbi:trueBlock")
+        );
+    }
+
+    #[test]
+    fn parse_call() {
+        let json = r#"{
+            "@type": "duumbi:Module", "@id": "duumbi:t", "duumbi:name": "t",
+            "duumbi:functions": [{
+                "@type": "duumbi:Function", "@id": "duumbi:t/main",
+                "duumbi:name": "main", "duumbi:returnType": "i64",
+                "duumbi:blocks": [{
+                    "@type": "duumbi:Block", "@id": "duumbi:t/main/e",
+                    "duumbi:label": "entry",
+                    "duumbi:ops": [
+                        {"@type": "duumbi:Const", "@id": "duumbi:t/main/e/0", "duumbi:value": 10, "duumbi:resultType": "i64"},
+                        {
+                            "@type": "duumbi:Call",
+                            "@id": "duumbi:t/main/e/1",
+                            "duumbi:function": "fib",
+                            "duumbi:args": [{"@id": "duumbi:t/main/e/0"}],
+                            "duumbi:resultType": "i64"
+                        }
+                    ]
+                }]
+            }]
+        }"#;
+        let module = parse_jsonld(json).expect("parse should succeed");
+        let call = &module.functions[0].blocks[0].ops[1];
+        assert_eq!(
+            call.op,
+            Op::Call {
+                function: "fib".to_string()
+            }
+        );
+        assert_eq!(call.args.len(), 1);
+        assert_eq!(call.args[0].id.0, "duumbi:t/main/e/0");
+    }
+
+    #[test]
+    fn parse_load_store() {
+        let json = r#"{
+            "@type": "duumbi:Module", "@id": "duumbi:t", "duumbi:name": "t",
+            "duumbi:functions": [{
+                "@type": "duumbi:Function", "@id": "duumbi:t/main",
+                "duumbi:name": "main", "duumbi:returnType": "i64",
+                "duumbi:blocks": [{
+                    "@type": "duumbi:Block", "@id": "duumbi:t/main/e",
+                    "duumbi:label": "entry",
+                    "duumbi:ops": [
+                        {"@type": "duumbi:Const", "@id": "duumbi:t/main/e/0", "duumbi:value": 42, "duumbi:resultType": "i64"},
+                        {
+                            "@type": "duumbi:Store",
+                            "@id": "duumbi:t/main/e/1",
+                            "duumbi:variable": "x",
+                            "duumbi:operand": {"@id": "duumbi:t/main/e/0"}
+                        },
+                        {
+                            "@type": "duumbi:Load",
+                            "@id": "duumbi:t/main/e/2",
+                            "duumbi:variable": "x",
+                            "duumbi:resultType": "i64"
+                        }
+                    ]
+                }]
+            }]
+        }"#;
+        let module = parse_jsonld(json).expect("parse should succeed");
+        let store = &module.functions[0].blocks[0].ops[1];
+        assert_eq!(
+            store.op,
+            Op::Store {
+                variable: "x".to_string()
+            }
+        );
+        assert!(store.operand.is_some());
+
+        let load = &module.functions[0].blocks[0].ops[2];
+        assert_eq!(
+            load.op,
+            Op::Load {
+                variable: "x".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_const_f64() {
+        let json = r#"{
+            "@type": "duumbi:Module", "@id": "duumbi:t", "duumbi:name": "t",
+            "duumbi:functions": [{
+                "@type": "duumbi:Function", "@id": "duumbi:t/main",
+                "duumbi:name": "main", "duumbi:returnType": "i64",
+                "duumbi:blocks": [{
+                    "@type": "duumbi:Block", "@id": "duumbi:t/main/e",
+                    "duumbi:label": "entry",
+                    "duumbi:ops": [{
+                        "@type": "duumbi:Const",
+                        "@id": "duumbi:t/main/e/0",
+                        "duumbi:value": 2.5,
+                        "duumbi:resultType": "f64"
+                    }]
+                }]
+            }]
+        }"#;
+        let module = parse_jsonld(json).expect("parse should succeed");
+        assert_eq!(module.functions[0].blocks[0].ops[0].op, Op::ConstF64(2.5));
+    }
+
+    #[test]
+    fn parse_const_bool() {
+        let json = r#"{
+            "@type": "duumbi:Module", "@id": "duumbi:t", "duumbi:name": "t",
+            "duumbi:functions": [{
+                "@type": "duumbi:Function", "@id": "duumbi:t/main",
+                "duumbi:name": "main", "duumbi:returnType": "i64",
+                "duumbi:blocks": [{
+                    "@type": "duumbi:Block", "@id": "duumbi:t/main/e",
+                    "duumbi:label": "entry",
+                    "duumbi:ops": [{
+                        "@type": "duumbi:Const",
+                        "@id": "duumbi:t/main/e/0",
+                        "duumbi:value": true,
+                        "duumbi:resultType": "bool"
+                    }]
+                }]
+            }]
+        }"#;
+        let module = parse_jsonld(json).expect("parse should succeed");
+        assert_eq!(module.functions[0].blocks[0].ops[0].op, Op::ConstBool(true));
+    }
+
+    #[test]
+    fn parse_function_params() {
+        let json = r#"{
+            "@type": "duumbi:Module", "@id": "duumbi:t", "duumbi:name": "t",
+            "duumbi:functions": [{
+                "@type": "duumbi:Function", "@id": "duumbi:t/fib",
+                "duumbi:name": "fib", "duumbi:returnType": "i64",
+                "duumbi:params": [
+                    {"duumbi:name": "n", "duumbi:paramType": "i64"}
+                ],
+                "duumbi:blocks": [{
+                    "@type": "duumbi:Block", "@id": "duumbi:t/fib/e",
+                    "duumbi:label": "entry",
+                    "duumbi:ops": [
+                        {"@type": "duumbi:Const", "@id": "duumbi:t/fib/e/0", "duumbi:value": 0, "duumbi:resultType": "i64"},
+                        {"@type": "duumbi:Return", "@id": "duumbi:t/fib/e/1", "duumbi:operand": {"@id": "duumbi:t/fib/e/0"}}
+                    ]
+                }]
+            }]
+        }"#;
+        let module = parse_jsonld(json).expect("parse should succeed");
+        let func = &module.functions[0];
+        assert_eq!(func.params.len(), 1);
+        assert_eq!(func.params[0].name, "n");
+        assert_eq!(func.params[0].param_type, DuumbiType::I64);
+    }
+
+    #[test]
+    fn missing_compare_operator() {
+        let json = r#"{
+            "@type": "duumbi:Module", "@id": "duumbi:t", "duumbi:name": "t",
+            "duumbi:functions": [{
+                "@type": "duumbi:Function", "@id": "duumbi:t/main",
+                "duumbi:name": "main", "duumbi:returnType": "i64",
+                "duumbi:blocks": [{
+                    "@type": "duumbi:Block", "@id": "duumbi:t/main/e",
+                    "duumbi:label": "entry",
+                    "duumbi:ops": [{
+                        "@type": "duumbi:Compare",
+                        "@id": "duumbi:t/main/e/0",
+                        "duumbi:left": {"@id": "duumbi:t/main/e/x"},
+                        "duumbi:right": {"@id": "duumbi:t/main/e/y"}
+                    }]
+                }]
+            }]
+        }"#;
+        let err = parse_jsonld(json).unwrap_err();
+        assert!(
+            matches!(err, ParseError::MissingField { field, .. } if field == "duumbi:operator")
+        );
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,7 @@
 //! Core types shared across all duumbi modules.
 //!
-//! Defines newtypes for identifiers, the Op enum for Phase 0 operations,
-//! and the `DuumbiType` representation.
+//! Defines newtypes for identifiers, the Op enum for operations,
+//! `CompareOp` for comparison operators, and the `DuumbiType` representation.
 
 use std::fmt;
 
@@ -52,13 +52,51 @@ impl fmt::Display for ModuleName {
     }
 }
 
-/// Phase 0 operation types.
+/// Comparison operator for `Compare` operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)] // Variants used in Phase 1 parser and compiler
+pub enum CompareOp {
+    /// Equal.
+    Eq,
+    /// Not equal.
+    Ne,
+    /// Less than.
+    Lt,
+    /// Less than or equal.
+    Le,
+    /// Greater than.
+    Gt,
+    /// Greater than or equal.
+    Ge,
+}
+
+impl fmt::Display for CompareOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CompareOp::Eq => f.write_str("eq"),
+            CompareOp::Ne => f.write_str("ne"),
+            CompareOp::Lt => f.write_str("lt"),
+            CompareOp::Le => f.write_str("le"),
+            CompareOp::Gt => f.write_str("gt"),
+            CompareOp::Ge => f.write_str("ge"),
+        }
+    }
+}
+
+/// Operation types in the duumbi instruction set.
 ///
 /// Each variant corresponds to a `duumbi:` prefixed `@type` in JSON-LD.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// Phase 0 ops: Const, Add, Sub, Mul, Div, Print, Return.
+/// Phase 1 ops: ConstF64, ConstBool, Compare, Branch, Call, Load, Store.
+#[derive(Debug, Clone, PartialEq)]
+#[allow(dead_code)] // Phase 1 variants used once parser/compiler are extended
 pub enum Op {
-    /// Integer constant: `duumbi:Const`
+    /// Integer constant: `duumbi:Const` with `resultType: "i64"`.
     Const(i64),
+    /// Float constant: `duumbi:Const` with `resultType: "f64"`.
+    ConstF64(f64),
+    /// Boolean constant: `duumbi:Const` with `resultType: "bool"`.
+    ConstBool(bool),
     /// Addition: `duumbi:Add`
     Add,
     /// Subtraction: `duumbi:Sub`
@@ -67,6 +105,25 @@ pub enum Op {
     Mul,
     /// Division: `duumbi:Div`
     Div,
+    /// Comparison: `duumbi:Compare`
+    Compare(CompareOp),
+    /// Conditional branch: `duumbi:Branch`
+    Branch,
+    /// Function call: `duumbi:Call`
+    Call {
+        /// Name of the function to call.
+        function: String,
+    },
+    /// Load variable: `duumbi:Load`
+    Load {
+        /// Name of the variable to load.
+        variable: String,
+    },
+    /// Store variable: `duumbi:Store`
+    Store {
+        /// Name of the variable to store into.
+        variable: String,
+    },
     /// Print value to stdout: `duumbi:Print`
     Print,
     /// Return value from function: `duumbi:Return`
@@ -77,10 +134,17 @@ impl fmt::Display for Op {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Op::Const(v) => write!(f, "Const({v})"),
+            Op::ConstF64(v) => write!(f, "ConstF64({v})"),
+            Op::ConstBool(v) => write!(f, "ConstBool({v})"),
             Op::Add => f.write_str("Add"),
             Op::Sub => f.write_str("Sub"),
             Op::Mul => f.write_str("Mul"),
             Op::Div => f.write_str("Div"),
+            Op::Compare(op) => write!(f, "Compare({op})"),
+            Op::Branch => f.write_str("Branch"),
+            Op::Call { function } => write!(f, "Call({function})"),
+            Op::Load { variable } => write!(f, "Load({variable})"),
+            Op::Store { variable } => write!(f, "Store({variable})"),
             Op::Print => f.write_str("Print"),
             Op::Return => f.write_str("Return"),
         }
@@ -88,12 +152,15 @@ impl fmt::Display for Op {
 }
 
 /// Type in the duumbi type system.
-///
-/// Phase 0 supports only `I64`. Future phases add `F64`, `Bool`, `Void`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)] // Phase 1 variants used once parser/compiler are extended
 pub enum DuumbiType {
     /// 64-bit signed integer.
     I64,
+    /// 64-bit floating point.
+    F64,
+    /// Boolean (true/false).
+    Bool,
     /// No return value (used by Print).
     Void,
 }
@@ -102,7 +169,59 @@ impl fmt::Display for DuumbiType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             DuumbiType::I64 => f.write_str("i64"),
+            DuumbiType::F64 => f.write_str("f64"),
+            DuumbiType::Bool => f.write_str("bool"),
             DuumbiType::Void => f.write_str("void"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compare_op_display() {
+        assert_eq!(CompareOp::Eq.to_string(), "eq");
+        assert_eq!(CompareOp::Ne.to_string(), "ne");
+        assert_eq!(CompareOp::Lt.to_string(), "lt");
+        assert_eq!(CompareOp::Le.to_string(), "le");
+        assert_eq!(CompareOp::Gt.to_string(), "gt");
+        assert_eq!(CompareOp::Ge.to_string(), "ge");
+    }
+
+    #[test]
+    fn op_display_phase1_variants() {
+        assert_eq!(Op::ConstF64(2.5).to_string(), "ConstF64(2.5)");
+        assert_eq!(Op::ConstBool(true).to_string(), "ConstBool(true)");
+        assert_eq!(Op::Compare(CompareOp::Lt).to_string(), "Compare(lt)");
+        assert_eq!(Op::Branch.to_string(), "Branch");
+        assert_eq!(
+            Op::Call {
+                function: "fib".to_string()
+            }
+            .to_string(),
+            "Call(fib)"
+        );
+        assert_eq!(
+            Op::Load {
+                variable: "x".to_string()
+            }
+            .to_string(),
+            "Load(x)"
+        );
+        assert_eq!(
+            Op::Store {
+                variable: "x".to_string()
+            }
+            .to_string(),
+            "Store(x)"
+        );
+    }
+
+    #[test]
+    fn duumbi_type_display_phase1() {
+        assert_eq!(DuumbiType::F64.to_string(), "f64");
+        assert_eq!(DuumbiType::Bool.to_string(), "bool");
     }
 }

--- a/tests/fixtures/fibonacci.jsonld
+++ b/tests/fixtures/fibonacci.jsonld
@@ -1,0 +1,243 @@
+{
+  "@context": {
+    "duumbi": "https://duumbi.dev/ns/core#"
+  },
+  "@type": "duumbi:Module",
+  "@id": "duumbi:main",
+  "duumbi:name": "main",
+  "duumbi:functions": [
+    {
+      "@type": "duumbi:Function",
+      "@id": "duumbi:main/fib",
+      "duumbi:name": "fib",
+      "duumbi:returnType": "i64",
+      "duumbi:params": [
+        {
+          "duumbi:name": "n",
+          "duumbi:paramType": "i64"
+        }
+      ],
+      "duumbi:blocks": [
+        {
+          "@type": "duumbi:Block",
+          "@id": "duumbi:main/fib/entry",
+          "duumbi:label": "entry",
+          "duumbi:ops": [
+            {
+              "@type": "duumbi:Load",
+              "@id": "duumbi:main/fib/entry/0",
+              "duumbi:variable": "n",
+              "duumbi:resultType": "i64"
+            },
+            {
+              "@type": "duumbi:Const",
+              "@id": "duumbi:main/fib/entry/1",
+              "duumbi:value": 0,
+              "duumbi:resultType": "i64"
+            },
+            {
+              "@type": "duumbi:Compare",
+              "@id": "duumbi:main/fib/entry/2",
+              "duumbi:operator": "eq",
+              "duumbi:left": { "@id": "duumbi:main/fib/entry/0" },
+              "duumbi:right": { "@id": "duumbi:main/fib/entry/1" },
+              "duumbi:resultType": "bool"
+            },
+            {
+              "@type": "duumbi:Branch",
+              "@id": "duumbi:main/fib/entry/3",
+              "duumbi:condition": { "@id": "duumbi:main/fib/entry/2" },
+              "duumbi:trueBlock": "return_zero",
+              "duumbi:falseBlock": "check_one"
+            }
+          ]
+        },
+        {
+          "@type": "duumbi:Block",
+          "@id": "duumbi:main/fib/check_one",
+          "duumbi:label": "check_one",
+          "duumbi:ops": [
+            {
+              "@type": "duumbi:Load",
+              "@id": "duumbi:main/fib/check_one/0",
+              "duumbi:variable": "n",
+              "duumbi:resultType": "i64"
+            },
+            {
+              "@type": "duumbi:Const",
+              "@id": "duumbi:main/fib/check_one/1",
+              "duumbi:value": 1,
+              "duumbi:resultType": "i64"
+            },
+            {
+              "@type": "duumbi:Compare",
+              "@id": "duumbi:main/fib/check_one/2",
+              "duumbi:operator": "eq",
+              "duumbi:left": { "@id": "duumbi:main/fib/check_one/0" },
+              "duumbi:right": { "@id": "duumbi:main/fib/check_one/1" },
+              "duumbi:resultType": "bool"
+            },
+            {
+              "@type": "duumbi:Branch",
+              "@id": "duumbi:main/fib/check_one/3",
+              "duumbi:condition": { "@id": "duumbi:main/fib/check_one/2" },
+              "duumbi:trueBlock": "return_one",
+              "duumbi:falseBlock": "recurse"
+            }
+          ]
+        },
+        {
+          "@type": "duumbi:Block",
+          "@id": "duumbi:main/fib/return_zero",
+          "duumbi:label": "return_zero",
+          "duumbi:ops": [
+            {
+              "@type": "duumbi:Const",
+              "@id": "duumbi:main/fib/return_zero/0",
+              "duumbi:value": 0,
+              "duumbi:resultType": "i64"
+            },
+            {
+              "@type": "duumbi:Return",
+              "@id": "duumbi:main/fib/return_zero/1",
+              "duumbi:operand": { "@id": "duumbi:main/fib/return_zero/0" }
+            }
+          ]
+        },
+        {
+          "@type": "duumbi:Block",
+          "@id": "duumbi:main/fib/return_one",
+          "duumbi:label": "return_one",
+          "duumbi:ops": [
+            {
+              "@type": "duumbi:Const",
+              "@id": "duumbi:main/fib/return_one/0",
+              "duumbi:value": 1,
+              "duumbi:resultType": "i64"
+            },
+            {
+              "@type": "duumbi:Return",
+              "@id": "duumbi:main/fib/return_one/1",
+              "duumbi:operand": { "@id": "duumbi:main/fib/return_one/0" }
+            }
+          ]
+        },
+        {
+          "@type": "duumbi:Block",
+          "@id": "duumbi:main/fib/recurse",
+          "duumbi:label": "recurse",
+          "duumbi:ops": [
+            {
+              "@type": "duumbi:Load",
+              "@id": "duumbi:main/fib/recurse/0",
+              "duumbi:variable": "n",
+              "duumbi:resultType": "i64"
+            },
+            {
+              "@type": "duumbi:Const",
+              "@id": "duumbi:main/fib/recurse/1",
+              "duumbi:value": 1,
+              "duumbi:resultType": "i64"
+            },
+            {
+              "@type": "duumbi:Sub",
+              "@id": "duumbi:main/fib/recurse/2",
+              "duumbi:left": { "@id": "duumbi:main/fib/recurse/0" },
+              "duumbi:right": { "@id": "duumbi:main/fib/recurse/1" },
+              "duumbi:resultType": "i64"
+            },
+            {
+              "@type": "duumbi:Call",
+              "@id": "duumbi:main/fib/recurse/3",
+              "duumbi:function": "fib",
+              "duumbi:args": [
+                { "@id": "duumbi:main/fib/recurse/2" }
+              ],
+              "duumbi:resultType": "i64"
+            },
+            {
+              "@type": "duumbi:Load",
+              "@id": "duumbi:main/fib/recurse/4",
+              "duumbi:variable": "n",
+              "duumbi:resultType": "i64"
+            },
+            {
+              "@type": "duumbi:Const",
+              "@id": "duumbi:main/fib/recurse/5",
+              "duumbi:value": 2,
+              "duumbi:resultType": "i64"
+            },
+            {
+              "@type": "duumbi:Sub",
+              "@id": "duumbi:main/fib/recurse/6",
+              "duumbi:left": { "@id": "duumbi:main/fib/recurse/4" },
+              "duumbi:right": { "@id": "duumbi:main/fib/recurse/5" },
+              "duumbi:resultType": "i64"
+            },
+            {
+              "@type": "duumbi:Call",
+              "@id": "duumbi:main/fib/recurse/7",
+              "duumbi:function": "fib",
+              "duumbi:args": [
+                { "@id": "duumbi:main/fib/recurse/6" }
+              ],
+              "duumbi:resultType": "i64"
+            },
+            {
+              "@type": "duumbi:Add",
+              "@id": "duumbi:main/fib/recurse/8",
+              "duumbi:left": { "@id": "duumbi:main/fib/recurse/3" },
+              "duumbi:right": { "@id": "duumbi:main/fib/recurse/7" },
+              "duumbi:resultType": "i64"
+            },
+            {
+              "@type": "duumbi:Return",
+              "@id": "duumbi:main/fib/recurse/9",
+              "duumbi:operand": { "@id": "duumbi:main/fib/recurse/8" }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "duumbi:Function",
+      "@id": "duumbi:main/main",
+      "duumbi:name": "main",
+      "duumbi:returnType": "i64",
+      "duumbi:blocks": [
+        {
+          "@type": "duumbi:Block",
+          "@id": "duumbi:main/main/entry",
+          "duumbi:label": "entry",
+          "duumbi:ops": [
+            {
+              "@type": "duumbi:Const",
+              "@id": "duumbi:main/main/entry/0",
+              "duumbi:value": 10,
+              "duumbi:resultType": "i64"
+            },
+            {
+              "@type": "duumbi:Call",
+              "@id": "duumbi:main/main/entry/1",
+              "duumbi:function": "fib",
+              "duumbi:args": [
+                { "@id": "duumbi:main/main/entry/0" }
+              ],
+              "duumbi:resultType": "i64"
+            },
+            {
+              "@type": "duumbi:Print",
+              "@id": "duumbi:main/main/entry/2",
+              "duumbi:operand": { "@id": "duumbi:main/main/entry/1" }
+            },
+            {
+              "@type": "duumbi:Return",
+              "@id": "duumbi:main/main/entry/3",
+              "duumbi:operand": { "@id": "duumbi:main/main/entry/1" }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/hello.jsonld
+++ b/tests/fixtures/hello.jsonld
@@ -1,0 +1,69 @@
+{
+  "@context": {
+    "duumbi": "https://duumbi.dev/ns/core#"
+  },
+  "@type": "duumbi:Module",
+  "@id": "duumbi:main",
+  "duumbi:name": "main",
+  "duumbi:functions": [
+    {
+      "@type": "duumbi:Function",
+      "@id": "duumbi:main/main",
+      "duumbi:name": "main",
+      "duumbi:returnType": "i64",
+      "duumbi:blocks": [
+        {
+          "@type": "duumbi:Block",
+          "@id": "duumbi:main/main/entry",
+          "duumbi:label": "entry",
+          "duumbi:ops": [
+            {
+              "@type": "duumbi:Const",
+              "@id": "duumbi:main/main/entry/0",
+              "duumbi:value": 72,
+              "duumbi:resultType": "i64"
+            },
+            {
+              "@type": "duumbi:Print",
+              "@id": "duumbi:main/main/entry/1",
+              "duumbi:operand": { "@id": "duumbi:main/main/entry/0" }
+            },
+            {
+              "@type": "duumbi:Const",
+              "@id": "duumbi:main/main/entry/2",
+              "duumbi:value": 101,
+              "duumbi:resultType": "i64"
+            },
+            {
+              "@type": "duumbi:Print",
+              "@id": "duumbi:main/main/entry/3",
+              "duumbi:operand": { "@id": "duumbi:main/main/entry/2" }
+            },
+            {
+              "@type": "duumbi:Const",
+              "@id": "duumbi:main/main/entry/4",
+              "duumbi:value": 108,
+              "duumbi:resultType": "i64"
+            },
+            {
+              "@type": "duumbi:Print",
+              "@id": "duumbi:main/main/entry/5",
+              "duumbi:operand": { "@id": "duumbi:main/main/entry/4" }
+            },
+            {
+              "@type": "duumbi:Const",
+              "@id": "duumbi:main/main/entry/6",
+              "duumbi:value": 0,
+              "duumbi:resultType": "i64"
+            },
+            {
+              "@type": "duumbi:Return",
+              "@id": "duumbi:main/main/entry/7",
+              "duumbi:operand": { "@id": "duumbi:main/main/entry/6" }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/integration_phase1.rs
+++ b/tests/integration_phase1.rs
@@ -1,0 +1,199 @@
+//! Phase 1 end-to-end integration tests.
+//!
+//! Tests multi-function, branching, recursive calls, and CLI commands.
+
+use std::process::Command;
+
+/// Helper: compile a fixture and return the output binary path.
+fn compile_fixture(fixture: &str, output_name: &str) -> std::path::PathBuf {
+    let tmp_dir = std::env::temp_dir().join("duumbi_phase1_tests");
+    std::fs::create_dir_all(&tmp_dir).expect("invariant: temp dir must be creatable");
+    let output_binary = tmp_dir.join(output_name);
+
+    let duumbi_output = Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--",
+            "build",
+            fixture,
+            "-o",
+            &output_binary.to_string_lossy(),
+        ])
+        .output()
+        .expect("invariant: cargo run must be runnable");
+
+    assert!(
+        duumbi_output.status.success(),
+        "duumbi build of {fixture} failed: {}",
+        String::from_utf8_lossy(&duumbi_output.stderr)
+    );
+
+    output_binary
+}
+
+#[test]
+fn phase1_fibonacci_prints_55() {
+    let binary = compile_fixture("tests/fixtures/fibonacci.jsonld", "fib_test");
+
+    let output = Command::new(&binary)
+        .output()
+        .expect("invariant: compiled binary must be runnable");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout.trim(),
+        "55",
+        "Expected fibonacci(10) = 55, got '{}'",
+        stdout.trim()
+    );
+
+    let exit_code = output
+        .status
+        .code()
+        .expect("invariant: binary must have an exit code");
+    assert_eq!(exit_code, 55, "Expected exit code 55, got {exit_code}");
+
+    let _ = std::fs::remove_file(&binary);
+}
+
+#[test]
+fn phase1_hello_prints_multiple_lines() {
+    let binary = compile_fixture("tests/fixtures/hello.jsonld", "hello_test");
+
+    let output = Command::new(&binary)
+        .output()
+        .expect("invariant: compiled binary must be runnable");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    assert_eq!(
+        lines.len(),
+        3,
+        "Expected 3 print lines, got {}",
+        lines.len()
+    );
+    assert_eq!(lines[0], "72");
+    assert_eq!(lines[1], "101");
+    assert_eq!(lines[2], "108");
+
+    let exit_code = output
+        .status
+        .code()
+        .expect("invariant: binary must have an exit code");
+    assert_eq!(exit_code, 0, "Expected exit code 0, got {exit_code}");
+
+    let _ = std::fs::remove_file(&binary);
+}
+
+#[test]
+fn phase1_check_valid_file() {
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--",
+            "check",
+            "tests/fixtures/fibonacci.jsonld",
+        ])
+        .output()
+        .expect("invariant: cargo run must be runnable");
+
+    assert!(
+        output.status.success(),
+        "duumbi check should succeed for valid fixture: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn phase1_describe_produces_output() {
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--",
+            "describe",
+            "tests/fixtures/add.jsonld",
+        ])
+        .output()
+        .expect("invariant: cargo run must be runnable");
+
+    assert!(
+        output.status.success(),
+        "duumbi describe failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("function main"),
+        "Describe output should contain 'function main'"
+    );
+    assert!(
+        stdout.contains("Const(3)"),
+        "Describe output should contain 'Const(3)'"
+    );
+}
+
+#[test]
+fn phase1_workspace_init_build_run() {
+    // First ensure duumbi is built
+    let build_status = Command::new("cargo")
+        .args(["build", "--quiet"])
+        .output()
+        .expect("invariant: cargo build must be runnable");
+    assert!(build_status.status.success(), "cargo build failed");
+
+    let duumbi_bin = std::path::PathBuf::from("target/debug/duumbi")
+        .canonicalize()
+        .expect("invariant: duumbi binary must exist after build");
+
+    let tmp_dir = std::env::temp_dir().join("duumbi_workspace_test");
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+
+    // Init
+    let init_output = Command::new(&duumbi_bin)
+        .args(["init", &tmp_dir.to_string_lossy()])
+        .output()
+        .expect("invariant: duumbi init must be runnable");
+
+    assert!(
+        init_output.status.success(),
+        "duumbi init failed: {}",
+        String::from_utf8_lossy(&init_output.stderr)
+    );
+
+    assert!(tmp_dir.join(".duumbi/config.toml").exists());
+    assert!(tmp_dir.join(".duumbi/graph/main.jsonld").exists());
+
+    // Build (workspace-aware — run duumbi from within the workspace dir)
+    let build_output = Command::new(&duumbi_bin)
+        .args(["build"])
+        .current_dir(&tmp_dir)
+        .output()
+        .expect("invariant: duumbi build must be runnable");
+
+    assert!(
+        build_output.status.success(),
+        "duumbi build in workspace failed: {}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+
+    assert!(tmp_dir.join(".duumbi/build/output").exists());
+
+    // Run the compiled binary
+    let binary_output = Command::new(tmp_dir.join(".duumbi/build/output"))
+        .output()
+        .expect("invariant: compiled binary must be runnable");
+
+    let stdout = String::from_utf8_lossy(&binary_output.stdout);
+    assert_eq!(
+        stdout.trim(),
+        "8",
+        "Workspace skeleton should output 8, got '{}'",
+        stdout.trim()
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+}


### PR DESCRIPTION
## Summary

Phase 1 teljes implementációja — a kill criterion teljesül: egy külső fejlesztő telepíti és futtat egy nem-triviális programot (fibonacci, elágazással + rekurzív függvényhívással) 10 percen belül.

### Elvégzett munkák

- **#14** — Típusrendszer bővítése: `CompareOp`, `DuumbiType::F64/Bool`, 7 új `Op` variáns
- **#15** — Parser: `Compare`, `Branch`, `Call`, `Load`, `Store`, f64/bool `Const`, function params
- **#16** — Graph: multi-block, paraméterek, új edge típusok, `branch_targets` side-table
- **#17** — Validator: f64/bool típuskonsistencia, Branch condition bool check, Compare validáció
- **#18** — Cranelift: f64/bool lowering, `icmp`/`fcmp`, `brif`, multi-block (`seal_all_blocks`)
- **#19** — Cranelift: `Call` (args), `Load`/`Store` (Variable API), multi-function compilation
- **#20** — Runtime: `duumbi_print_f64`, `duumbi_print_bool`; embedded via `include_str!`
- **#21** — CLI: `init`, `run`, `check`, `describe`; workspace-aware build
- **#22** — CI: GitHub Actions (fmt, clippy, build, test)
- **#23** — E2E: `fibonacci.jsonld` (fib(10)=55), `hello.jsonld`, 5 integrációs teszt
- **#24** — Docs: README quickstart, teljes op tábla, architecture.md frissítés

### Kill criterion

```bash
cargo install --path .
duumbi init myproject && cd myproject
duumbi build && duumbi run
# → "8" (skeleton)

# Fibonacci teszt:
duumbi build ../tests/fixtures/fibonacci.jsonld -o /tmp/fib
/tmp/fib
# → "55" (stdout), exit code 55
```

### Tesztek

| Kategória | Szám |
|-----------|------|
| Phase 0 (meglévő) | 23 |
| Phase 1 új unit tesztek | 21 |
| Phase 0 E2E | 1 |
| Phase 1 E2E | 5 |
| **Összesen** | **50** |

## Test plan

- [x] `cargo fmt --check` ✓
- [x] `cargo clippy --all-targets -- -D warnings` ✓
- [x] `cargo test --all` — 50/50 teszt zöld ✓
- [x] `fibonacci.jsonld` → `fib(10) = 55` ✓
- [x] Workspace init → build → run flow ✓
- [x] `duumbi check` / `describe` / `run` CLI parancsok ✓

Closes #14, #15, #16, #17, #18, #19, #20, #21, #22, #23, #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)