### PR TITLE
fix(intent): add explicit export hint to CreateModule task descriptions

### DIFF
--- a/src/intent/coordinator.rs
+++ b/src/intent/coordinator.rs
@@ -22,6 +22,27 @@ pub fn decompose(spec: &IntentSpec) -> Vec<Task> {
     let mut tasks = Vec::new();
     let mut id = 1;
 
+    // Build a shared exports hint from all non-main test_case functions.
+    // Used in both CreateModule and AddFunction tasks so the LLM is reminded
+    // to populate duumbi:exports at every mutation step.
+    let mut export_names: Vec<&str> = spec
+        .test_cases
+        .iter()
+        .map(|tc| tc.function.as_str())
+        .filter(|&f| f != "main")
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .collect();
+    export_names.sort_unstable();
+    let exports_hint = if export_names.is_empty() {
+        String::new()
+    } else {
+        format!(
+            " IMPORTANT: the duumbi:exports array MUST include ALL of these functions: [{}].",
+            export_names.join(", ")
+        )
+    };
+
     // Phase 1: Create new modules
     for module_name in &spec.modules.create {
         let criteria_summary = spec
@@ -31,28 +52,6 @@ pub fn decompose(spec: &IntentSpec) -> Vec<Task> {
             .cloned()
             .collect::<Vec<_>>()
             .join("; ");
-
-        // Collect all unique non-main function names from test_cases (global list).
-        // All showcases tested against a single module must appear in duumbi:exports.
-        // When multiple modules are created, each gets the full list — the LLM is
-        // expected to export only the functions it defines.
-        let mut export_names: Vec<&str> = spec
-            .test_cases
-            .iter()
-            .map(|tc| tc.function.as_str())
-            .filter(|&f| f != "main")
-            .collect::<std::collections::HashSet<_>>()
-            .into_iter()
-            .collect();
-        export_names.sort_unstable();
-        let exports_hint = if export_names.is_empty() {
-            String::new()
-        } else {
-            format!(
-                " IMPORTANT: the duumbi:exports array MUST include ALL of these functions: [{}].",
-                export_names.join(", ")
-            )
-        };
 
         let description = if criteria_summary.is_empty() {
             format!("Create module '{module_name}' as described in the intent.{exports_hint}")
@@ -78,17 +77,17 @@ pub fn decompose(spec: &IntentSpec) -> Vec<Task> {
             continue;
         }
 
+        let criteria = spec.acceptance_criteria.join("; ");
         let description = format!(
-            "Modify module '{}' to satisfy the acceptance criteria: {}",
-            module_name,
-            spec.acceptance_criteria.join("; ")
+            "Modify module '{}' to satisfy the acceptance criteria: {}{exports_hint}",
+            module_name, criteria,
         );
 
         tasks.push(Task {
             id,
             kind: TaskKind::AddFunction {
                 module_name: module_name.clone(),
-                description: spec.acceptance_criteria.join("; "),
+                description: format!("{criteria}{exports_hint}"),
             },
             description,
             status: TaskStatus::Pending,
@@ -247,6 +246,43 @@ mod tests {
             ),
             "create task must include sorted exports hint; got: {}",
             create_task.description
+        );
+    }
+
+    #[test]
+    fn add_function_task_includes_exports_hint() {
+        use crate::intent::spec::{IntentModules, TestCase};
+        // Spec with a non-main module in `modify` so Phase 2 generates an AddFunction task.
+        let spec = IntentSpec {
+            intent: "Test".to_string(),
+            version: 1,
+            status: IntentStatus::Pending,
+            acceptance_criteria: vec!["double(x) returns x * 2".to_string()],
+            modules: IntentModules {
+                create: vec![],
+                modify: vec!["math/ops".to_string()],
+            },
+            test_cases: vec![TestCase {
+                name: "t1".to_string(),
+                function: "double".to_string(),
+                args: vec![7],
+                expected_return: 14,
+            }],
+            dependencies: vec![],
+            created_at: None,
+            execution: None,
+        };
+        let tasks = decompose(&spec);
+        let add_task = tasks
+            .iter()
+            .find(|t| matches!(&t.kind, TaskKind::AddFunction { .. }))
+            .expect("must have add_function task");
+        assert!(
+            add_task.description.contains(
+                "IMPORTANT: the duumbi:exports array MUST include ALL of these functions: [double]"
+            ),
+            "add_function task must include exports hint; got: {}",
+            add_task.description
         );
     }
 


### PR DESCRIPTION
## Summary

- Coordinator now appends an explicit export requirement to every `CreateModule` task description
- Hint text: *"IMPORTANT: the duumbi:exports array MUST include ALL of these functions: [add, div, ...]"*
- Function names are collected from `spec.test_cases`, deduplicated, and sorted

## Motivation

Third benchmark run (Phase 9C) showed OpenAI failing on `calculator`, `multi_module`, and `sorting` showcases with E010 errors: *"add is referenced but not exported by any loaded module"*. The LLM created correct functions but omitted them from `duumbi:exports`, causing cross-module reference resolution to fail.

This fix makes the export requirement explicit in the task prompt so LLMs don't miss it.

## Test plan

- [x] All existing coordinator unit tests pass (6 tests)
- [x] Full test suite green (1045 tests)
- [ ] Re-run benchmark to verify OpenAI E010 failures resolved and kill criterion met (5/6 × 2+ providers ≥ 95%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)