### PR TITLE
chore: remove slow Stop hook from project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,17 +50,6 @@
         ]
       }
     ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "if [ -f Cargo.toml ]; then cargo check --message-format short 2>&1 | tail -5; fi",
-            "timeout": 60
-          }
-        ]
-      }
-    ],
     "PreToolUse": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
## Summary
- Remove the `Stop` hook that ran `cargo check` on every Claude session end
- The hook caused 10-30s delays on stop because it compiled the entire ~80k LOC project
- The `PostToolUse` hook already runs `cargo fmt` + `cargo clippy` after every Rust file edit, making the Stop hook redundant

## Test plan
- [ ] Verify Claude Code sessions end without delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)