### PR TITLE
feat(cli): redesign interactive REPL with brand-aligned dark theme

### DIFF
--- a/.agents/skills/jsonld-schema/SKILL.md
+++ b/.agents/skills/jsonld-schema/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: jsonld-schema
+description: Validate and edit DUUMBI JSON-LD files and core schema safely.
+compatibility: opencode
+---
+
+# DUUMBI JSON-LD Schema Skill
+
+ALWAYS use this skill when writing, editing, or validating `.jsonld` files
+or `core.schema.json`.
+
+---
+
+## Every .jsonld file must start with
+
+```json
+{
+  "@context": { "duumbi": "https://duumbi.dev/ns/core#" },
+  "@type": "duumbi:Module",
+  "@id": "duumbi:<module-name>",
+  "duumbi:name": "<module-name>",
+  "duumbi:functions": [...]
+}
+```
+
+## nodeId format (strict)
+
+`duumbi:<module>/<function>/<block>/<index>`
+
+- module: the Module name (e.g. `main`)
+- function: the Function name (e.g. `main`)
+- block: the Block label (e.g. `entry`)
+- index: zero-based integer within the block
+
+Example: `duumbi:main/main/entry/0`
+
+Indices must be sequential and unique within a block.
+Every `{"@id": "..."}` reference must point to an existing nodeId.
+
+## Phase 0 Op reference
+
+**Const**
+```json
+{
+  "@type": "duumbi:Const",
+  "@id": "duumbi:main/main/entry/0",
+  "duumbi:value": 3,
+  "duumbi:resultType": "i64"
+}
+```
+
+**Add / Sub / Mul / Div** (same structure)
+```json
+{
+  "@type": "duumbi:Add",
+  "@id": "duumbi:main/main/entry/2",
+  "duumbi:left":  { "@id": "duumbi:main/main/entry/0" },
+  "duumbi:right": { "@id": "duumbi:main/main/entry/1" },
+  "duumbi:resultType": "i64"
+}
+```
+Rule: left, right, and resultType must all be the same numeric type.
+
+**Print**
+```json
+{
+  "@type": "duumbi:Print",
+  "@id": "duumbi:main/main/entry/3",
+  "duumbi:operand": { "@id": "duumbi:main/main/entry/2" }
+}
+```
+
+**Return**
+```json
+{
+  "@type": "duumbi:Return",
+  "@id": "duumbi:main/main/entry/4",
+  "duumbi:operand": { "@id": "duumbi:main/main/entry/2" }
+}
+```
+
+## Validation checklist (run mentally before saving)
+
+- [ ] All `@id` values are unique within the file
+- [ ] All `{"@id": "..."}` references point to existing nodes
+- [ ] Ops within a block are ordered by index (0, 1, 2, ...)
+- [ ] Every block ends with Return or Branch (no fall-through)
+- [ ] A function named `main` exists at the top level
+- [ ] resultType is present on every value-producing Op
+- [ ] No cycles in data flow (a node's inputs must have lower indices)
+
+## The canonical Phase 0 example (add.jsonld)
+
+```json
+{
+  "@context": { "duumbi": "https://duumbi.dev/ns/core#" },
+  "@type": "duumbi:Module",
+  "@id": "duumbi:main",
+  "duumbi:name": "main",
+  "duumbi:functions": [
+    {
+      "@type": "duumbi:Function",
+      "@id": "duumbi:main/main",
+      "duumbi:name": "main",
+      "duumbi:params": [],
+      "duumbi:returnType": "i64",
+      "duumbi:blocks": [
+        {
+          "@type": "duumbi:Block",
+          "@id": "duumbi:main/main/entry",
+          "duumbi:label": "entry",
+          "duumbi:ops": [
+            { "@type": "duumbi:Const",  "@id": "duumbi:main/main/entry/0", "duumbi:value": 3, "duumbi:resultType": "i64" },
+            { "@type": "duumbi:Const",  "@id": "duumbi:main/main/entry/1", "duumbi:value": 5, "duumbi:resultType": "i64" },
+            { "@type": "duumbi:Add",    "@id": "duumbi:main/main/entry/2", "duumbi:left": {"@id": "duumbi:main/main/entry/0"}, "duumbi:right": {"@id": "duumbi:main/main/entry/1"}, "duumbi:resultType": "i64" },
+            { "@type": "duumbi:Print",  "@id": "duumbi:main/main/entry/3", "duumbi:operand": {"@id": "duumbi:main/main/entry/2"} },
+            { "@type": "duumbi:Return", "@id": "duumbi:main/main/entry/4", "duumbi:operand": {"@id": "duumbi:main/main/entry/2"} }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Expected: binary prints `8`, exits with code 8.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,85 @@
+# DUUMBI — AI-First Semantic Graph Compiler
+
+## About
+Next-generation JSON-LD semantic graph compiler in Rust. Cranelift backend
+for native code generation. petgraph for graph IR, serde_json for JSON-LD
+parsing. AI agent graph mutation (OpenAI/Anthropic APIs), intent-driven
+development, registry distribution, DUUMBI Studio web platform.
+
+## Repository layout
+- **`hgahub/duumbi`** (this repo) — Rust source code, compiler, CLI, tests, technical docs
+- **`hgahub/duumbi-vault`** — Obsidian planning vault (PRD, phase specs, roadmap, architecture diagrams)
+  - Lokálisan: `/Users/heizergabor/space/hgahub/duumbi-vault/Duumbi/`
+  - Obsidian MCP nincs használatban — a vault fájljai közvetlenül elérhetők: Read/Edit/Grep/Glob toolokkal
+
+## Project structure
+src/
+  parser/      # JSON-LD parsing (serde_json, json-ld crate) → typed AST
+  graph/       # Semantic graph IR using petgraph (StableGraph<Node, Edge>)
+  compiler/    # Graph → Cranelift IR lowering (cranelift-codegen, cranelift-frontend)
+                 # CodegenBackend trait — Cranelift types never leak outside src/compiler/
+  agents/      # AI agent framework for graph mutation (async, reqwest)
+               # Phase 12: analyzer, assembler, template, cost, merger, rollback
+               # agent_knowledge — strategy/failure-pattern persistence
+  mcp/         # MCP server + client (JSON-RPC, 10 tools, external server proxy)
+               # Phase 12: graph_query, graph_mutate, graph_validate, graph_describe
+  intent/      # Intent-Driven Development (Phase 5): spec, coordinator, verifier, execute
+  registry/    # Registry client, credentials, module packaging (Phase 7)
+  types.rs     # DuumbiType (I64, F64, Bool, Void, String, Array<T>, Struct, &T, &mut T), Op enum
+  deps.rs      # Dependency resolution, lockfile, vendor layer
+  hash.rs      # Semantic hashing (SHA-256, @id-independent)
+  manifest.rs  # Module manifest (manifest.toml)
+  config.rs    # Config v2: workspace, registries, dependencies, vendor
+  mcp/         # MCP server implementation (rmcp crate)
+  web/         # WASM visualizer + axum HTTP server
+  cli/         # CLI entry point (clap) — commands, deps, publish, yank, registry, repl
+runtime/       # C runtime (duumbi_runtime.c) — print, alloc, string/array/struct shims
+tests/         # Integration tests with .jsonld fixtures
+crates/        # duumbi-studio (Leptos SSR web platform)
+
+## Build and test
+cargo build                          # Debug build
+cargo build --release                # Release
+cargo test --all                     # All tests (~817 tests)
+cargo clippy --all-targets -- -D warnings  # Zero-warning lint policy
+cargo fmt --check                    # Format check
+
+## Code standards
+- Use `thiserror` per module, `anyhow` at application boundaries only
+- NEVER `.unwrap()` in library code; `.expect("invariant: ...")` for true invariants
+- Propagate errors with `?`; provide `.context()` messages at module boundaries
+- Newtypes for NodeId, EdgeId, GraphId — never raw u32/usize
+- All public items need doc comments; use `#[must_use]` on Result-returning fns
+- snake_case functions, PascalCase types, SCREAMING_SNAKE constants
+- Prefer `petgraph::stable_graph::StableGraph` when indices must survive mutation
+- Cranelift: use `FunctionBuilder` patterns, never raw `InstBuilder` calls
+- Async code: tokio runtime, no blocking in async contexts
+- Registry client: reqwest with retry, credentials from ~/.duumbi/credentials.toml
+
+## Architecture notes
+- Graph IR is the central data structure — all transformations are graph→graph
+- Cranelift compilation: Graph → Cranelift IR (one function per subgraph)
+- AI agents receive read-only graph snapshots, propose mutation plans
+- MCP server exposes graph query/mutation as tools
+- Intent system (Phase 5): YAML spec → Coordinator tasks → LLM mutations → Verifier
+- Registry (Phase 7): publish/download modules as .tar.gz, SemVer resolution,
+  lockfile v1 with integrity hashes, vendor layer for offline builds
+- Dependency resolution: workspace → vendor → cache → registry (E011 if not found)
+
+## CLI commands (Phase 7 + 12)
+- `duumbi mcp` — start the MCP server (JSON-RPC over stdio, 10 tools)
+- `duumbi search <query>` — search modules in configured registries
+- `duumbi publish [--registry R] [--dry-run] [-y]` — package and upload module
+- `duumbi yank <@scope/name@version> [--registry R] [-y]` — mark version as yanked
+- `duumbi deps install [--frozen]` — resolve and download all deps, update lockfile
+- `duumbi deps add <@scope/name[@ver]> [--registry R]` — add registry dependency
+- `duumbi deps update [name]` — update to latest compatible versions
+- `duumbi deps vendor [--all] [--include "pattern"]` — copy deps to vendor/
+- `duumbi deps audit` — verify lockfile integrity hashes
+- `duumbi deps tree [--depth N]` — display dependency tree
+- `duumbi registry add|list|remove|default|login|logout` — manage registries
+- `duumbi upgrade` — migrate Phase 4-5 workspace to Phase 7 format
+- `duumbi provider list|add|remove|set` — manage LLM provider configurations
+
+@docs/architecture.md
+@docs/coding-conventions.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,7 +1181,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "duumbi"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "duumbi-studio"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/duumbi-studio"]
 
 [package]
 name = "duumbi"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "MPL-2.0"
 

--- a/crates/duumbi-studio/Cargo.toml
+++ b/crates/duumbi-studio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "duumbi-studio"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "MPL-2.0"
 

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -928,13 +928,10 @@ impl ReplApp {
     /// anchored near the bottom. Transient menus render as overlays so the
     /// footer does not jump when assistance panels open.
     pub fn render(&self, frame: &mut Frame, textarea: &TextArea<'_>) {
-        // Two-pass canvas fill: outer frame area first (covers margins), then
-        // explicitly set the buffer style for every cell so subsequent
-        // Paragraph renders preserve the dark canvas background even on
-        // terminals that otherwise fall back to the default ANSI bg.
-        let area = frame.area();
-        frame.render_widget(Block::default().style(theme::canvas()), area);
-        frame.buffer_mut().set_style(area, theme::canvas());
+        // Paint the canvas first. Every subsequent widget renders with its
+        // own style on top; Spans without an explicit `bg` preserve the
+        // canvas colour set here.
+        frame.render_widget(Block::default().style(theme::canvas()), frame.area());
 
         let has_output = !self.output_lines.is_empty();
         let show_card = self.show_tip && !has_output;
@@ -1455,10 +1452,7 @@ impl ReplApp {
             spans.push(Span::styled(format!("{glyph} work"), theme::chevron()));
         }
 
-        frame.render_widget(
-            Paragraph::new(Line::from(spans)).style(theme::canvas()),
-            area,
-        );
+        frame.render_widget(Paragraph::new(Line::from(spans)), area);
     }
 
     /// Compact single-row status fallback for narrow terminals.
@@ -1479,7 +1473,7 @@ impl ReplApp {
             Span::styled(workspace_name.to_string(), theme::workspace_value()),
             Span::styled(activity.to_string(), theme::out_dim()),
         ]);
-        frame.render_widget(Paragraph::new(line).style(theme::canvas()), area);
+        frame.render_widget(Paragraph::new(line), area);
     }
 
     /// Renders the inline slash-command completion menu as an overlay.

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -147,6 +147,7 @@ pub struct Turn {
 #[derive(Debug, Clone)]
 struct ConversationVisualRow {
     line: Line<'static>,
+    plain_text: String,
     block_index: Option<usize>,
     menu_button_block: Option<usize>,
     menu_button_range: Option<(u16, u16)>,
@@ -154,6 +155,7 @@ struct ConversationVisualRow {
 
 #[derive(Debug, Clone)]
 struct VisibleConversationLayout {
+    start_index: usize,
     padding: usize,
     rows: Vec<ConversationVisualRow>,
 }
@@ -161,6 +163,39 @@ struct VisibleConversationLayout {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ConversationActionMenu {
     block_index: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ConversationSelectionPoint {
+    row: usize,
+    column: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ConversationTextSelection {
+    anchor: ConversationSelectionPoint,
+    focus: ConversationSelectionPoint,
+    dragged: bool,
+}
+
+fn copy_text_to_clipboard(text: &str) -> Result<(), String> {
+    let mut child = std::process::Command::new("pbcopy")
+        .stdin(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| e.to_string())?;
+
+    let stdin = child
+        .stdin
+        .as_mut()
+        .ok_or_else(|| "clipboard stdin closed".to_string())?;
+    std::io::Write::write_all(stdin, text.as_bytes()).map_err(|e| e.to_string())?;
+
+    let status = child.wait().map_err(|e| e.to_string())?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(status.to_string())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -200,6 +235,8 @@ pub struct ReplApp {
     selected_conversation_block: Option<usize>,
     /// Open action menu for a selected conversation user block.
     conversation_action_menu: Option<ConversationActionMenu>,
+    /// App-managed text selection inside the conversation pane.
+    conversation_text_selection: Option<ConversationTextSelection>,
     /// Selected row inside the open conversation action menu.
     conversation_action_selected: usize,
     /// Last rendered conversation pane rectangle, used for mouse hit testing.
@@ -265,6 +302,7 @@ impl ReplApp {
             current_output_block: None,
             selected_conversation_block: None,
             conversation_action_menu: None,
+            conversation_text_selection: None,
             conversation_action_selected: 0,
             last_conversation_area: Cell::new(None),
             output_scroll_offset: 0,
@@ -335,6 +373,8 @@ impl ReplApp {
         }
 
         match key.code {
+            KeyCode::Esc if self.conversation_text_selection.take().is_some() => Action::Continue,
+
             // Shift+Tab: toggle Agent ↔ Intent mode
             KeyCode::BackTab => {
                 self.mode = match self.mode {
@@ -468,8 +508,7 @@ impl ReplApp {
 
     /// Handles mouse events when the terminal delivers them.
     ///
-    /// The REPL enables only basic mouse reporting, avoiding drag-motion
-    /// capture so terminals can keep native text selection available.
+    /// Handles wheel scrolling, block clicks, and app-managed text selection.
     pub fn handle_mouse(&mut self, mouse: crossterm::event::MouseEvent) -> bool {
         use crossterm::event::MouseEventKind;
         match mouse.kind {
@@ -482,7 +521,13 @@ impl ReplApp {
                 true
             }
             MouseEventKind::Down(MouseButton::Left) => {
-                self.handle_conversation_click(mouse.column, mouse.row)
+                self.handle_conversation_mouse_down(mouse.column, mouse.row)
+            }
+            MouseEventKind::Drag(MouseButton::Left) => {
+                self.handle_conversation_mouse_drag(mouse.column, mouse.row)
+            }
+            MouseEventKind::Up(MouseButton::Left) => {
+                self.handle_conversation_mouse_up(mouse.column, mouse.row)
             }
             _ => false,
         }
@@ -1168,6 +1213,7 @@ impl ReplApp {
         self.current_output_block = None;
         self.selected_conversation_block = None;
         self.conversation_action_menu = None;
+        self.conversation_text_selection = None;
         self.output_scroll_offset = 0;
     }
 
@@ -1284,35 +1330,9 @@ impl ReplApp {
             return;
         };
 
-        match std::process::Command::new("pbcopy")
-            .stdin(std::process::Stdio::piped())
-            .spawn()
-        {
-            Ok(mut child) => {
-                let write_result = child.stdin.as_mut().map_or_else(
-                    || {
-                        Err(std::io::Error::new(
-                            std::io::ErrorKind::BrokenPipe,
-                            "stdin closed",
-                        ))
-                    },
-                    |stdin| std::io::Write::write_all(stdin, text.as_bytes()),
-                );
-                let wait_result = child.wait();
-                match (write_result, wait_result) {
-                    (Ok(()), Ok(status)) if status.success() => {
-                        self.push_feedback("Copied message.", OutputStyle::Success);
-                    }
-                    (Err(e), _) => {
-                        self.push_feedback(format!("Copy failed: {e}"), OutputStyle::Error);
-                    }
-                    (_, Ok(status)) => {
-                        self.push_feedback(format!("Copy failed: {status}"), OutputStyle::Error);
-                    }
-                    (_, Err(e)) => {
-                        self.push_feedback(format!("Copy failed: {e}"), OutputStyle::Error);
-                    }
-                }
+        match copy_text_to_clipboard(&text) {
+            Ok(()) => {
+                self.push_feedback("Copied message.", OutputStyle::Success);
             }
             Err(e) => {
                 self.push_feedback(format!("Copy failed: {e}"), OutputStyle::Error);
@@ -1399,6 +1419,81 @@ impl ReplApp {
         idx
     }
 
+    fn handle_conversation_mouse_down(&mut self, column: u16, row: u16) -> bool {
+        let Some(area) = self.last_conversation_area.get() else {
+            return false;
+        };
+
+        if let Some((menu_area, _)) = self.conversation_action_menu_rect(area)
+            && self.rect_contains(menu_area, column, row)
+        {
+            self.conversation_text_selection = None;
+            return self.handle_conversation_click(column, row);
+        }
+
+        let point = self.conversation_point_at(area, column, row);
+        self.conversation_text_selection = point.map(|anchor| ConversationTextSelection {
+            anchor,
+            focus: anchor,
+            dragged: false,
+        });
+        self.handle_conversation_click(column, row)
+    }
+
+    fn handle_conversation_mouse_drag(&mut self, column: u16, row: u16) -> bool {
+        let Some(area) = self.last_conversation_area.get() else {
+            return false;
+        };
+        let Some(focus) = self.conversation_point_at(area, column, row) else {
+            return false;
+        };
+        let Some(selection) = self.conversation_text_selection.as_mut() else {
+            self.conversation_text_selection = Some(ConversationTextSelection {
+                anchor: focus,
+                focus,
+                dragged: false,
+            });
+            return false;
+        };
+
+        selection.focus = focus;
+        selection.dragged = selection.anchor != focus;
+        selection.dragged
+    }
+
+    fn handle_conversation_mouse_up(&mut self, column: u16, row: u16) -> bool {
+        let Some(mut selection) = self.conversation_text_selection else {
+            return false;
+        };
+
+        if let Some(area) = self.last_conversation_area.get()
+            && let Some(focus) = self.conversation_point_at(area, column, row)
+        {
+            selection.focus = focus;
+            selection.dragged = selection.dragged || selection.anchor != focus;
+            self.conversation_text_selection = Some(selection);
+        }
+
+        if !selection.dragged {
+            self.conversation_text_selection = None;
+            return false;
+        }
+
+        let selected_text = self
+            .last_conversation_area
+            .get()
+            .and_then(|area| self.selected_conversation_text(area));
+        self.conversation_text_selection = None;
+
+        if let Some(text) = selected_text
+            && !text.trim().is_empty()
+            && let Err(e) = copy_text_to_clipboard(&text)
+        {
+            self.push_feedback(format!("Copy failed: {e}"), OutputStyle::Error);
+        }
+        true
+    }
+
     fn handle_conversation_click(&mut self, column: u16, row: u16) -> bool {
         let Some(area) = self.last_conversation_area.get() else {
             return false;
@@ -1463,6 +1558,84 @@ impl ReplApp {
             self.conversation_action_menu = None;
         }
         true
+    }
+
+    fn conversation_point_at(
+        &self,
+        area: Rect,
+        column: u16,
+        row: u16,
+    ) -> Option<ConversationSelectionPoint> {
+        if !self.rect_contains(area, column, row) {
+            return None;
+        }
+
+        let layout = self.visible_conversation_layout(area);
+        let relative_y = row.saturating_sub(area.y) as usize;
+        if relative_y < layout.padding {
+            return None;
+        }
+
+        let visible_row = relative_y - layout.padding;
+        let row_data = layout.rows.get(visible_row)?;
+        let max_column = row_data.plain_text.chars().count();
+        let column = column.saturating_sub(area.x) as usize;
+
+        Some(ConversationSelectionPoint {
+            row: layout.start_index + visible_row,
+            column: column.min(max_column),
+        })
+    }
+
+    fn selected_conversation_text(&self, area: Rect) -> Option<String> {
+        let selection = self.conversation_text_selection?;
+        let rows = if self.conversation_blocks.is_empty() {
+            self.legacy_output_rows()
+        } else {
+            self.conversation_visual_rows(area.width)
+        };
+        let (start, end) = Self::normalise_selection(selection);
+        if start.row >= rows.len() || end.row >= rows.len() {
+            return None;
+        }
+
+        let mut selected = Vec::new();
+        for (row_idx, row) in rows.iter().enumerate().take(end.row + 1).skip(start.row) {
+            let text_len = row.plain_text.chars().count();
+            let start_col = if row_idx == start.row {
+                start.column.min(text_len)
+            } else {
+                0
+            };
+            let end_col = if row_idx == end.row {
+                end.column.min(text_len)
+            } else {
+                text_len
+            };
+            let line = row
+                .plain_text
+                .chars()
+                .skip(start_col)
+                .take(end_col.saturating_sub(start_col))
+                .collect::<String>()
+                .trim_end()
+                .to_string();
+            selected.push(line);
+        }
+
+        Some(selected.join("\n"))
+    }
+
+    fn normalise_selection(
+        selection: ConversationTextSelection,
+    ) -> (ConversationSelectionPoint, ConversationSelectionPoint) {
+        if (selection.anchor.row, selection.anchor.column)
+            <= (selection.focus.row, selection.focus.column)
+        {
+            (selection.anchor, selection.focus)
+        } else {
+            (selection.focus, selection.anchor)
+        }
     }
 
     fn rect_contains(&self, rect: Rect, column: u16, row: u16) -> bool {
@@ -1764,7 +1937,13 @@ impl ReplApp {
         // Bottom-align: pad with empty lines above content so messages
         // appear just above the header, close to the prompt.
         let mut lines: Vec<Line<'_>> = (0..layout.padding).map(|_| Line::from("")).collect();
-        lines.extend(layout.rows.iter().map(|row| row.line.clone()));
+        lines.extend(
+            layout
+                .rows
+                .iter()
+                .enumerate()
+                .map(|(idx, row)| self.conversation_row_line(row, layout.start_index + idx)),
+        );
 
         frame.render_widget(Paragraph::new(lines), area);
         // The "Working…" spinner now lives in the status dock activity slot
@@ -1796,7 +1975,59 @@ impl ReplApp {
         let start = bottom.saturating_sub(max_lines);
         let rows = all_rows[start..bottom].to_vec();
         let padding = max_lines.saturating_sub(rows.len());
-        VisibleConversationLayout { padding, rows }
+        VisibleConversationLayout {
+            start_index: start,
+            padding,
+            rows,
+        }
+    }
+
+    fn conversation_row_line(
+        &self,
+        row: &ConversationVisualRow,
+        row_index: usize,
+    ) -> Line<'static> {
+        let Some(selection) = self.conversation_text_selection else {
+            return row.line.clone();
+        };
+        if !selection.dragged {
+            return row.line.clone();
+        }
+
+        let (start, end) = Self::normalise_selection(selection);
+        if row_index < start.row || row_index > end.row {
+            return row.line.clone();
+        }
+
+        let text_len = row.plain_text.chars().count();
+        let start_col = if row_index == start.row {
+            start.column.min(text_len)
+        } else {
+            0
+        };
+        let end_col = if row_index == end.row {
+            end.column.min(text_len)
+        } else {
+            text_len
+        };
+        if start_col == end_col {
+            return row.line.clone();
+        }
+
+        let before = row.plain_text.chars().take(start_col).collect::<String>();
+        let selected = row
+            .plain_text
+            .chars()
+            .skip(start_col)
+            .take(end_col.saturating_sub(start_col))
+            .collect::<String>();
+        let after = row.plain_text.chars().skip(end_col).collect::<String>();
+
+        Line::from(vec![
+            Span::raw(before),
+            Span::styled(selected, theme::conversation_text_selection()),
+            Span::raw(after),
+        ])
     }
 
     fn render_conversation_action_menu(&self, frame: &mut Frame, area: Rect) {
@@ -1867,6 +2098,7 @@ impl ReplApp {
             .iter()
             .map(|ol| ConversationVisualRow {
                 line: Self::line_from_output(ol),
+                plain_text: ol.text.clone(),
                 block_index: None,
                 menu_button_block: None,
                 menu_button_range: None,
@@ -1880,6 +2112,7 @@ impl ReplApp {
             if !rows.is_empty() {
                 rows.push(ConversationVisualRow {
                     line: Line::from(""),
+                    plain_text: String::new(),
                     block_index: None,
                     menu_button_block: None,
                     menu_button_range: None,
@@ -1893,6 +2126,7 @@ impl ReplApp {
                     for ol in &block.lines {
                         rows.push(ConversationVisualRow {
                             line: Self::line_from_output(ol),
+                            plain_text: ol.text.clone(),
                             block_index: Some(idx),
                             menu_button_block: None,
                             menu_button_range: None,
@@ -1901,6 +2135,7 @@ impl ReplApp {
                     if let Some(elapsed) = &block.elapsed {
                         rows.push(ConversationVisualRow {
                             line: Line::from(Span::styled(elapsed.clone(), theme::out_dim())),
+                            plain_text: elapsed.clone(),
                             block_index: Some(idx),
                             menu_button_block: None,
                             menu_button_range: None,
@@ -1927,18 +2162,21 @@ impl ReplApp {
         let submitted_at = block.submitted_at.as_deref().unwrap_or("");
         let selected = self.selected_conversation_block == Some(block_index);
         let action_trigger = if selected { "..." } else { "" };
-        let (line, range) = self.user_panel_line(input, action_trigger, width, true, selected);
+        let (line, range, plain_text) =
+            self.user_panel_line(input, action_trigger, width, true, selected);
+        let (meta_line, _, meta_plain_text) =
+            self.user_panel_line(submitted_at, "", width, false, selected);
         vec![
             ConversationVisualRow {
                 line,
+                plain_text,
                 block_index: Some(block_index),
                 menu_button_block: selected.then_some(block_index),
                 menu_button_range: range,
             },
             ConversationVisualRow {
-                line: self
-                    .user_panel_line(submitted_at, "", width, false, selected)
-                    .0,
+                line: meta_line,
+                plain_text: meta_plain_text,
                 block_index: Some(block_index),
                 menu_button_block: None,
                 menu_button_range: None,
@@ -1953,7 +2191,7 @@ impl ReplApp {
         width: usize,
         strong: bool,
         selected: bool,
-    ) -> (Line<'static>, Option<(u16, u16)>) {
+    ) -> (Line<'static>, Option<(u16, u16)>, String) {
         let accent = "\u{258f} ";
         let right_len = right.chars().count();
         let left_budget = width
@@ -1996,14 +2234,16 @@ impl ReplApp {
             right_start.min(u16::MAX as usize) as u16,
             (right_start + right_len).min(u16::MAX as usize) as u16,
         ));
+        let plain_text = format!("{accent}{left_text}{}{right}", " ".repeat(fill));
         (
             Line::from(vec![
                 Span::styled(accent.to_string(), accent_style),
-                Span::styled(left_text, left_style),
+                Span::styled(left_text.clone(), left_style),
                 Span::styled(" ".repeat(fill), surface_style),
                 Span::styled(right.to_string(), right_style),
             ]),
             right_range,
+            plain_text,
         )
     }
 
@@ -2996,6 +3236,79 @@ mod tests {
 
         let (rendered, _rows) = render_app_to_string(&app, &textarea, 120, 30);
         assert!(rendered.contains("Copy message"));
+    }
+
+    #[test]
+    fn conversation_drag_selection_collects_text() {
+        let (mut app, textarea) = make_app();
+        app.push_output("alpha beta gamma", OutputStyle::Normal);
+        let (_rendered, rows) = render_app_to_string(&app, &textarea, 120, 30);
+        let row = rows
+            .iter()
+            .position(|line| line.contains("alpha beta gamma"))
+            .expect("output row must render") as u16;
+        let start_col = rows[row as usize]
+            .find("beta")
+            .expect("selection start must be findable") as u16;
+        let end_col = start_col + "beta".len() as u16;
+
+        app.handle_mouse(crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::Down(MouseButton::Left),
+            column: start_col,
+            row,
+            modifiers: KeyModifiers::NONE,
+        });
+        app.handle_mouse(crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::Drag(MouseButton::Left),
+            column: end_col,
+            row,
+            modifiers: KeyModifiers::NONE,
+        });
+
+        let area = app
+            .last_conversation_area
+            .get()
+            .expect("conversation area must be cached");
+        assert_eq!(
+            app.selected_conversation_text(area).as_deref(),
+            Some("beta")
+        );
+    }
+
+    #[test]
+    fn conversation_mouse_up_clears_drag_selection() {
+        let (mut app, textarea) = make_app();
+        app.push_output("alpha beta gamma", OutputStyle::Normal);
+        let (_rendered, rows) = render_app_to_string(&app, &textarea, 120, 30);
+        let row = rows
+            .iter()
+            .position(|line| line.contains("alpha beta gamma"))
+            .expect("output row must render") as u16;
+        let col = rows[row as usize]
+            .find("beta")
+            .expect("selection point must be findable") as u16;
+        let area = app
+            .last_conversation_area
+            .get()
+            .expect("conversation area must be cached");
+        let point = app
+            .conversation_point_at(area, col, row)
+            .expect("point must map to conversation row");
+        app.conversation_text_selection = Some(ConversationTextSelection {
+            anchor: point,
+            focus: point,
+            dragged: true,
+        });
+
+        let redrew = app.handle_mouse(crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::Up(MouseButton::Left),
+            column: col,
+            row,
+            modifiers: KeyModifiers::NONE,
+        });
+
+        assert!(redrew);
+        assert!(app.conversation_text_selection.is_none());
     }
 
     #[test]

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -87,6 +87,28 @@ fn default_auth_token_env(kind: &crate::config::ProviderKind) -> &'static str {
     }
 }
 
+/// Truncates a path string to fit within `max_chars` columns by inserting
+/// a single ellipsis (`…`) into the middle. Returns the original string
+/// when it already fits.
+///
+/// Operates on Unicode scalar values, not bytes, so multi-byte path
+/// segments are not split mid-character.
+#[must_use]
+fn truncate_path(path: &str, max_chars: usize) -> String {
+    let total: usize = path.chars().count();
+    if total <= max_chars || max_chars < 4 {
+        return path.to_string();
+    }
+    // Reserve one column for the ellipsis; split the remaining budget
+    // unevenly to favour the basename (right side).
+    let budget = max_chars - 1;
+    let right = (budget * 2) / 3;
+    let left = budget - right;
+    let head: String = path.chars().take(left).collect();
+    let tail: String = path.chars().skip(total - right).collect();
+    format!("{head}\u{2026}{tail}")
+}
+
 /// Parses a provider kind by wizard list index.
 fn parse_provider_kind_by_index(idx: usize) -> Option<crate::config::ProviderKind> {
     use crate::config::ProviderKind;
@@ -940,49 +962,46 @@ impl ReplApp {
             },
         };
         let has_output = !self.output_lines.is_empty();
-        let header_height = if has_output { 0u16 } else { 1u16 };
-        let mid_height = if self.show_tip && !has_output {
-            5u16 // 1 empty + 3 tip lines + 1 empty
-        } else {
-            0
-        };
+        let show_card = self.show_tip && !has_output;
+        let card_height = if show_card { 5u16 } else { 0 };
+        let area_width = frame.area().width;
+        // Focus ring needs 3 rows (top + content + bottom border); narrow
+        // terminals collapse to a single-row prompt without a border.
+        let input_height = if area_width >= 60 { 3u16 } else { 1u16 };
 
+        // REPL-01..REPL-10 region order, top to bottom.
         let chunks = Layout::vertical([
-            Constraint::Min(0),                // 0 output area
-            Constraint::Length(header_height), // 1 header (duumbi line, hidden when output present)
-            Constraint::Length(mid_height),    // 2 tip block
-            Constraint::Length(1),             // 3 empty spacer above mode line (always)
-            Constraint::Length(1),             // 4 mode line
-            Constraint::Length(1),             // 5 top separator
-            Constraint::Length(1),             // 6 input
-            Constraint::Length(1),             // 7 bottom separator
-            Constraint::Length(1),             // 8 status bar
-            Constraint::Length(bottom_height), // 9 bottom zone (slash menu OR panel)
+            Constraint::Length(1),             // 0 REPL-01 brand header (always visible)
+            Constraint::Length(card_height),   // 1 REPL-02 empty-state card
+            Constraint::Min(0),                // 2 REPL-03 conversation pane (expanding)
+            Constraint::Length(1),             // 3 REPL-06 mode strip
+            Constraint::Length(1),             // 4 REPL-07 top hairline separator
+            Constraint::Length(input_height),  // 5 REPL-08 prompt well (with focus ring)
+            Constraint::Length(1),             // 6 REPL-09 bottom hairline separator
+            Constraint::Length(2),             // 7 REPL-10 status dock (label row + value row)
+            Constraint::Length(bottom_height), // 8 slash menu / model panel
         ])
         .split(frame.area());
 
-        self.render_output(frame, chunks[0]);
-        if header_height > 0 {
-            self.render_header(frame, chunks[1]);
+        self.render_brand_header(frame, chunks[0]);
+        if card_height > 0 {
+            self.render_empty_state_card(frame, chunks[1]);
         }
-        if mid_height > 0 {
-            self.render_tip(frame, chunks[2]);
-        }
-        // chunks[3] is always an empty spacer line — no render needed
-        self.render_mode_line(frame, chunks[4]);
-        self.render_separator(frame, chunks[5]);
-        self.render_input(frame, chunks[6], textarea);
-        self.render_separator(frame, chunks[7]);
-        self.render_status_bar(frame, chunks[8]);
+        self.render_conversation_pane(frame, chunks[2]);
+        self.render_mode_strip(frame, chunks[3]);
+        self.render_hairline_with_dots(frame, chunks[4]);
+        self.render_prompt_well(frame, chunks[5], textarea);
+        self.render_hairline_with_dots(frame, chunks[6]);
+        self.render_status_dock(frame, chunks[7]);
         if bottom_height > 0 {
             match &self.panel {
-                PanelState::None => self.render_slash_menu(frame, chunks[9]),
+                PanelState::None => self.render_slash_menu(frame, chunks[8]),
                 PanelState::ModelSelector {
                     selected,
                     input_mode,
                     status_msg,
                 } => {
-                    self.render_model_panel(frame, chunks[9], *selected, input_mode, status_msg);
+                    self.render_model_panel(frame, chunks[8], *selected, input_mode, status_msg);
                 }
             }
         }
@@ -992,8 +1011,8 @@ impl ReplApp {
     // Individual render helpers
     // -----------------------------------------------------------------------
 
-    /// Renders the top header bar.
-    fn render_header(&self, frame: &mut Frame, area: Rect) {
+    /// REPL-01 — brand header (always visible at the top).
+    fn render_brand_header(&self, frame: &mut Frame, area: Rect) {
         let version = env!("CARGO_PKG_VERSION");
 
         let line = Line::from(vec![
@@ -1009,45 +1028,69 @@ impl ReplApp {
         frame.render_widget(Paragraph::new(line), area);
     }
 
-    /// Renders the tip block (onboarding hint).
-    fn render_tip(&self, frame: &mut Frame, area: Rect) {
-        let tip = if !self.has_workspace {
-            // No .duumbi/ directory — suggest /init
-            vec![
-                Line::from(""),
+    /// REPL-02 — empty-state card with a rust ▌ left pillar.
+    ///
+    /// The card spans 5 rows: padding, badge, primary tip, secondary tip,
+    /// padding. The leftmost cell of every row is painted rust as a
+    /// vertical pillar; the rest of the row carries the content.
+    fn render_empty_state_card(&self, frame: &mut Frame, area: Rect) {
+        // Pillar | content split.
+        let cols = Layout::horizontal([Constraint::Length(2), Constraint::Min(1)]).split(area);
+        let pillar = cols[0];
+        let content = cols[1];
+
+        // Paint a `▌` pillar in every row of the card.
+        for row in 0..pillar.height {
+            let cell = Rect::new(pillar.x, pillar.y + row, pillar.width, 1);
+            frame.render_widget(
+                Paragraph::new(Span::styled("\u{258C}", theme::chevron())),
+                cell,
+            );
+        }
+
+        // Card body — 5 lines mapping to rows 0..4 of `content`.
+        let (badge_text, primary, secondary) = if !self.has_workspace {
+            (
+                " NO WORKSPACE ",
+                Line::from(vec![
+                    Span::styled("\u{203A} ", theme::chevron()),
+                    Span::styled("/init", theme::brand_word()),
+                    Span::styled("  initialise a new workspace here", theme::out_dim()),
+                ]),
                 Line::from(Span::styled(
-                    "Tip: No workspace found. Initialise one with:",
+                    "  or run `duumbi --help` to see all commands",
                     theme::out_dim(),
                 )),
-                Line::from(Span::styled("  /init", theme::chevron())),
-                Line::from(""),
-            ]
+            )
         } else {
-            // Empty workspace — suggest intent or direct mutation
-            vec![
-                Line::from(""),
+            (
+                " EMPTY WORKSPACE ",
+                Line::from(vec![
+                    Span::styled("\u{203A} ", theme::chevron()),
+                    Span::styled("/intent create \"build a calculator\"", theme::brand_word()),
+                ]),
                 Line::from(Span::styled(
-                    "Tip: This is an empty workspace. Try one of these:",
+                    "  or just describe what you want and press Enter",
                     theme::out_dim(),
                 )),
-                Line::from(Span::styled(
-                    "  /intent create  \"Build a calculator with add and multiply\"",
-                    theme::chevron(),
-                )),
-                Line::from(Span::styled(
-                    "  or type a request directly: \"Add a function that adds two numbers\"",
-                    theme::out_dim(),
-                )),
-            ]
+            )
         };
-        frame.render_widget(Paragraph::new(tip).wrap(Wrap { trim: false }), area);
+
+        let body = vec![
+            Line::from(""),
+            Line::from(vec![Span::styled(badge_text, theme::pill_rust())]),
+            Line::from(""),
+            primary,
+            secondary,
+        ];
+        frame.render_widget(Paragraph::new(body).wrap(Wrap { trim: false }), content);
     }
 
-    /// Renders the scrollable output area, bottom-aligned.
+    /// REPL-03 — scrollable conversation pane, bottom-aligned.
     ///
     /// When `output_scroll_offset > 0`, the view shifts upward to show
     /// older lines. PageUp/PageDown control the offset.
-    fn render_output(&self, frame: &mut Frame, area: Rect) {
+    fn render_conversation_pane(&self, frame: &mut Frame, area: Rect) {
         let max_lines = area.height as usize;
         let total = self.output_lines.len();
         let bottom = total.saturating_sub(self.output_scroll_offset);
@@ -1092,22 +1135,8 @@ impl ReplApp {
         }
 
         frame.render_widget(Paragraph::new(lines), area);
-
-        // Animated spinner when an async operation is in progress.
-        if self.working {
-            let frame_idx = (std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis()
-                / 120) as usize;
-            let ch = Self::SPINNER[frame_idx % Self::SPINNER.len()];
-            let spinner = format!("{ch} Working…");
-            let y = area.bottom().saturating_sub(1);
-            frame.render_widget(
-                Paragraph::new(Span::styled(spinner, theme::chevron())),
-                Rect::new(area.x, y, 12, 1),
-            );
-        }
+        // The "Working…" spinner now lives in the status dock activity slot
+        // (see render_activity_button). No inline spinner overlay here.
 
         // Scroll indicator overlay when scrolled up.
         if self.output_scroll_offset > 0 {
@@ -1121,8 +1150,8 @@ impl ReplApp {
         }
     }
 
-    /// Renders the mode indicator line below the output area.
-    fn render_mode_line(&self, frame: &mut Frame, area: Rect) {
+    /// REPL-06 — mode strip with active mode label and focused intent slug.
+    fn render_mode_strip(&self, frame: &mut Frame, area: Rect) {
         let hint = Span::styled("Shift+Tab switch mode", theme::mode_hint());
         let sep = Span::raw("  ");
         let mode_label = self.mode.label();
@@ -1148,73 +1177,182 @@ impl ReplApp {
         frame.render_widget(Paragraph::new(Line::from(spans)), area);
     }
 
-    /// Renders a full-width horizontal separator line.
-    fn render_separator(&self, frame: &mut Frame, area: Rect) {
+    /// REPL-07 / REPL-09 — hairline separator with rust dots at both edges.
+    ///
+    /// On terminals narrower than 4 columns, falls back to a plain dim line.
+    fn render_hairline_with_dots(&self, frame: &mut Frame, area: Rect) {
         let width = area.width as usize;
-        let line_str = "─".repeat(width);
-        frame.render_widget(
-            Paragraph::new(Span::styled(line_str, theme::hairline_dim())),
-            area,
-        );
+        if width < 4 {
+            let line_str = "─".repeat(width);
+            frame.render_widget(
+                Paragraph::new(Span::styled(line_str, theme::hairline_dim())),
+                area,
+            );
+            return;
+        }
+        // Body: dim hairline between the two rust dots.
+        let body = "─".repeat(width.saturating_sub(2));
+        let line = Line::from(vec![
+            Span::styled("\u{2022}", theme::chevron()),
+            Span::styled(body, theme::hairline_dim()),
+            Span::styled("\u{2022}", theme::chevron()),
+        ]);
+        frame.render_widget(Paragraph::new(line), area);
     }
 
-    /// Renders the single-line text input with a `❯ ` prefix.
-    fn render_input(&self, frame: &mut Frame, area: Rect, textarea: &TextArea<'_>) {
-        let chunks = Layout::horizontal([Constraint::Length(2), Constraint::Min(1)]).split(area);
+    /// REPL-08 — prompt input well with rust focus ring around the textarea.
+    ///
+    /// On terminals < 60 cols, the focus border is dropped and the prompt
+    /// renders as a single line with a `› ` prefix.
+    fn render_prompt_well(&self, frame: &mut Frame, area: Rect, textarea: &TextArea<'_>) {
+        use ratatui::widgets::{Block, BorderType, Borders};
 
-        // Chevron prefix
-        frame.render_widget(
-            Paragraph::new(Span::styled("\u{203A} ", theme::chevron())),
-            chunks[0],
-        );
+        if area.height >= 3 {
+            // Boxed input with rust focus ring (REPL-08 default).
+            let block = Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Plain)
+                .border_style(theme::focus_border());
+            let inner = block.inner(area);
+            frame.render_widget(block, area);
 
-        // Textarea (implements Widget)
-        frame.render_widget(textarea, chunks[1]);
+            let chunks =
+                Layout::horizontal([Constraint::Length(2), Constraint::Min(1)]).split(inner);
+            frame.render_widget(
+                Paragraph::new(Span::styled("\u{203A} ", theme::chevron())),
+                chunks[0],
+            );
+            frame.render_widget(textarea, chunks[1]);
+        } else {
+            // Compact single-row fallback for narrow terminals.
+            let chunks =
+                Layout::horizontal([Constraint::Length(2), Constraint::Min(1)]).split(area);
+            frame.render_widget(
+                Paragraph::new(Span::styled("\u{203A} ", theme::chevron())),
+                chunks[0],
+            );
+            frame.render_widget(textarea, chunks[1]);
+        }
     }
 
-    /// Renders the bottom status bar with time, workspace path, name, and model.
-    fn render_status_bar(&self, frame: &mut Frame, area: Rect) {
+    /// REPL-10 — two-row status dock (uppercase labels above values).
+    ///
+    /// Slots: TIME · WORKSPACE · CWD · ACTIVITY. The ACTIVITY slot is
+    /// blank when idle and shows the activity button when `working` is true
+    /// (rendered by [`Self::render_activity_button`]).
+    fn render_status_dock(&self, frame: &mut Frame, area: Rect) {
+        // Narrow-terminal fallback: single-row compact dock.
+        if area.height < 2 || area.width < 40 {
+            self.render_compact_status(frame, area);
+            return;
+        }
+
+        let rows = Layout::vertical([Constraint::Length(1), Constraint::Length(1)]).split(area);
+
+        // Four equal slots — labels and values share the same horizontal split.
+        let cols = Layout::horizontal([
+            Constraint::Ratio(1, 4),
+            Constraint::Ratio(1, 4),
+            Constraint::Ratio(1, 4),
+            Constraint::Ratio(1, 4),
+        ])
+        .split(rows[0]);
+        let value_cols = Layout::horizontal([
+            Constraint::Ratio(1, 4),
+            Constraint::Ratio(1, 4),
+            Constraint::Ratio(1, 4),
+            Constraint::Ratio(1, 4),
+        ])
+        .split(rows[1]);
+
+        // Label row.
+        for (i, label) in ["TIME", "WORKSPACE", "CWD", "ACTIVITY"].iter().enumerate() {
+            frame.render_widget(
+                Paragraph::new(Span::styled(*label, theme::label_caps())),
+                cols[i],
+            );
+        }
+
+        // Value row.
         let time_str = Local::now().format("%H:%M").to_string();
-        let full_path = self
-            .workspace_root
-            .canonicalize()
-            .unwrap_or_else(|_| self.workspace_root.clone())
-            .display()
-            .to_string();
-
         let workspace_name = self
             .config
             .workspace
             .as_ref()
             .map(|w| w.name.as_str())
             .unwrap_or("unnamed");
+        let cwd = self
+            .workspace_root
+            .canonicalize()
+            .unwrap_or_else(|_| self.workspace_root.clone())
+            .display()
+            .to_string();
+        let cwd_truncated = truncate_path(&cwd, value_cols[2].width.saturating_sub(1) as usize);
 
-        let model_str = {
-            let providers = self.config.effective_providers();
-            providers
-                .iter()
-                .find(|p| p.role == crate::config::ProviderRole::Primary)
-                .or(providers.first())
-                .map(|p| p.model.clone())
-                .unwrap_or_else(|| "no model".to_string())
-        };
+        frame.render_widget(
+            Paragraph::new(Span::styled(time_str, theme::dock_value())),
+            value_cols[0],
+        );
+        frame.render_widget(
+            Paragraph::new(Span::styled(
+                workspace_name.to_string(),
+                theme::workspace_value(),
+            )),
+            value_cols[1],
+        );
+        frame.render_widget(
+            Paragraph::new(Span::styled(cwd_truncated, theme::dock_value())),
+            value_cols[2],
+        );
 
-        let right_str = format!("workspace: {workspace_name}  {model_str}");
-        let left_str = format!("{time_str}  {full_path}");
-        let width = area.width as usize;
-        let padding = width.saturating_sub(left_str.len() + right_str.len());
+        if self.working {
+            self.render_activity_button(frame, value_cols[3]);
+        }
+    }
 
-        let spans: Vec<Span<'_>> = vec![
-            Span::styled(format!("{time_str}  "), theme::out_dim()),
-            Span::styled(full_path, theme::dock_value()),
-            Span::raw(" ".repeat(padding)),
-            Span::styled("workspace: ", theme::label_caps()),
-            Span::styled(workspace_name.to_string(), theme::workspace_value()),
+    /// Compact single-row status fallback for narrow terminals.
+    fn render_compact_status(&self, frame: &mut Frame, area: Rect) {
+        let time_str = Local::now().format("%H:%M").to_string();
+        let workspace_name = self
+            .config
+            .workspace
+            .as_ref()
+            .map(|w| w.name.as_str())
+            .unwrap_or("unnamed");
+        let activity = if self.working { " ⠹ working" } else { "" };
+        let line = Line::from(vec![
+            Span::styled(time_str, theme::dock_value()),
             Span::raw("  "),
-            Span::styled(model_str, theme::version_badge()),
-        ];
+            Span::styled(workspace_name.to_string(), theme::workspace_value()),
+            Span::styled(activity.to_string(), theme::chevron()),
+        ]);
+        frame.render_widget(Paragraph::new(line), area);
+    }
 
-        frame.render_widget(Paragraph::new(Line::from(spans)), area);
+    /// Renders the rust-pill activity button shown in the ACTIVITY slot.
+    fn render_activity_button(&self, frame: &mut Frame, area: Rect) {
+        let frame_idx = (std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+            / 80) as usize;
+        let glyph = Self::SPINNER[frame_idx % Self::SPINNER.len()];
+        // Pad to fill the slot so the rust background covers the entire pill.
+        let total = area.width as usize;
+        let label = format!(" {glyph} INTERRUPT \u{25A0} ");
+        let padded = if label.chars().count() < total {
+            format!(
+                "{label}{:width$}",
+                "",
+                width = total - label.chars().count()
+            )
+        } else {
+            label
+        };
+        frame.render_widget(
+            Paragraph::new(Span::styled(padded, theme::pill_rust())),
+            area,
+        );
     }
 
     /// Renders the inline slash-command completion menu with scrolling.

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use chrono::Local;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::prelude::*;
-use ratatui::widgets::{Clear, Paragraph, Wrap};
+use ratatui::widgets::{Block, Clear, Paragraph, Wrap};
 use ratatui_textarea::{CursorMove, TextArea};
 
 use crate::agents::LlmClient;
@@ -232,12 +232,6 @@ impl ReplApp {
     /// Braille spinner frames for the working indicator (80 ms per frame).
     const SPINNER: &'static [char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
-    /// Pulsing dot glyphs for the active mode indicator (2.6 s cycle).
-    const MODE_DOT_GLYPHS: &'static [&'static str] = &[" ", "\u{2219}", "\u{25CF}"];
-
-    /// Duration of one full pulse cycle for the mode dot, in milliseconds.
-    const MODE_DOT_CYCLE_MS: u128 = 2_600;
-
     // -----------------------------------------------------------------------
     // Animation
     // -----------------------------------------------------------------------
@@ -252,20 +246,22 @@ impl ReplApp {
             .as_millis()
     }
 
-    /// Returns the current pulsing-dot glyph for the active mode label.
+    /// Returns the static glyph for the active mode label.
+    ///
+    /// The dot is drawn solid and unchanging — pulsing felt distracting in
+    /// the user's terminal, so the animation was retired. The helper is kept
+    /// (rather than inlined) so re-introducing motion later is a one-line
+    /// change.
     fn mode_dot_glyph() -> &'static str {
-        let phase = (Self::animation_now_ms() % Self::MODE_DOT_CYCLE_MS) as f32
-            / Self::MODE_DOT_CYCLE_MS as f32;
-        let idx = (phase * Self::MODE_DOT_GLYPHS.len() as f32) as usize;
-        Self::MODE_DOT_GLYPHS[idx.min(Self::MODE_DOT_GLYPHS.len() - 1)]
+        "\u{25CF}"
     }
 
-    /// Returns `true` whenever the mode-dot animation should be redrawn.
-    /// Currently always animated; the wrapper exists so the event loop can
-    /// disable redraws for accessibility settings in the future.
+    /// Returns `true` whenever the mode-dot animation should drive a redraw.
+    /// Static dot now, so this is always `false` — only an active spinner
+    /// (`self.working`) keeps the event loop ticking.
     #[must_use]
     pub fn mode_dot_animated(&self) -> bool {
-        true
+        false
     }
 
     // -----------------------------------------------------------------------
@@ -932,6 +928,14 @@ impl ReplApp {
     /// anchored near the bottom. Transient menus render as overlays so the
     /// footer does not jump when assistance panels open.
     pub fn render(&self, frame: &mut Frame, textarea: &TextArea<'_>) {
+        // Two-pass canvas fill: outer frame area first (covers margins), then
+        // explicitly set the buffer style for every cell so subsequent
+        // Paragraph renders preserve the dark canvas background even on
+        // terminals that otherwise fall back to the default ANSI bg.
+        let area = frame.area();
+        frame.render_widget(Block::default().style(theme::canvas()), area);
+        frame.buffer_mut().set_style(area, theme::canvas());
+
         let has_output = !self.output_lines.is_empty();
         let show_card = self.show_tip && !has_output;
         let outer = frame.area();
@@ -1098,20 +1102,22 @@ impl ReplApp {
             return;
         }
 
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .border_style(theme::panel_border())
-            .padding(Padding::new(2, 2, 1, 1))
-            .style(theme::panel_surface());
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
+        let cols = Layout::horizontal([Constraint::Length(1), Constraint::Min(1)]).split(area);
+        let accent = cols[0];
+        let card_area = cols[1];
 
-        for row in area.y..area.bottom() {
-            frame.render_widget(
-                Paragraph::new(Span::styled("│", theme::panel_accent())),
-                Rect::new(area.x, row, 1, 1),
-            );
-        }
+        frame.render_widget(Block::default().style(theme::panel_accent_bar()), accent);
+
+        // Only top + bottom borders — the rust pillar on the left already
+        // visually anchors the card; a full border made the right edge feel
+        // too heavy in the rendered output.
+        let block = Block::default()
+            .borders(Borders::TOP | Borders::BOTTOM)
+            .border_style(theme::panel_border())
+            .padding(Padding::new(2, 2, 0, 0))
+            .style(theme::panel_surface());
+        let inner = block.inner(card_area);
+        frame.render_widget(block, card_area);
 
         let (badge_text, heading, left_lines, right_lines) = if !self.has_workspace {
             (
@@ -1400,8 +1406,28 @@ impl ReplApp {
             .unwrap_or_else(|_| self.workspace_root.clone())
             .display()
             .to_string();
-        let prefix_len = 5 + time_str.len() + 3 + 10 + workspace_name.len() + 3 + 4;
-        let activity_len = if self.working { 13 } else { 0 };
+        // Lowercase labels feel "smaller" than uppercase in monospace fonts;
+        // paired with the dim hairline colour they recede visually so the
+        // values (workspace name, time) remain the read targets.
+        let lbl_time = "time";
+        let lbl_ws = "workspace";
+        let lbl_cwd = "cwd";
+        let lbl_activity = "activity";
+        let prefix_len = lbl_time.len()
+            + 1
+            + time_str.len()
+            + 3
+            + lbl_ws.len()
+            + 1
+            + workspace_name.len()
+            + 3
+            + lbl_cwd.len()
+            + 1;
+        let activity_len = if self.working {
+            lbl_activity.len() + 1 + 6 + 3
+        } else {
+            0
+        };
         let cwd_budget = area
             .width
             .saturating_sub((prefix_len + activity_len) as u16)
@@ -1409,24 +1435,30 @@ impl ReplApp {
         let cwd_truncated = truncate_path(&cwd, cwd_budget);
 
         let mut spans = vec![
-            Span::styled("TIME ", theme::label_caps_inline()),
-            Span::styled(time_str, theme::dock_value()),
+            Span::styled(format!("{lbl_time} "), theme::label_caps_inline()),
+            Span::styled(time_str, theme::dock_value_muted()),
             Span::raw("   "),
-            Span::styled("WORKSPACE ", theme::label_caps_inline()),
+            Span::styled(format!("{lbl_ws} "), theme::label_caps_inline()),
             Span::styled(workspace_name.to_string(), theme::workspace_value()),
             Span::raw("   "),
-            Span::styled("CWD ", theme::label_caps_inline()),
-            Span::styled(cwd_truncated, theme::dock_value()),
+            Span::styled(format!("{lbl_cwd} "), theme::label_caps_inline()),
+            Span::styled(cwd_truncated, theme::dock_value_muted()),
         ];
         if self.working {
             let frame_idx = (Self::animation_now_ms() / 80) as usize;
             let glyph = Self::SPINNER[frame_idx % Self::SPINNER.len()];
             spans.push(Span::raw("   "));
-            spans.push(Span::styled("ACTIVITY ", theme::label_caps_inline()));
-            spans.push(Span::styled(format!("{glyph} working"), theme::chevron()));
+            spans.push(Span::styled(
+                format!("{lbl_activity} "),
+                theme::label_caps_inline(),
+            ));
+            spans.push(Span::styled(format!("{glyph} work"), theme::chevron()));
         }
 
-        frame.render_widget(Paragraph::new(Line::from(spans)), area);
+        frame.render_widget(
+            Paragraph::new(Line::from(spans)).style(theme::canvas()),
+            area,
+        );
     }
 
     /// Compact single-row status fallback for narrow terminals.
@@ -1438,16 +1470,16 @@ impl ReplApp {
             .as_ref()
             .map(|w| w.name.as_str())
             .unwrap_or("unnamed");
-        let activity = if self.working { "  working" } else { "" };
+        let activity = if self.working { "  work" } else { "" };
         let line = Line::from(vec![
-            Span::styled("TIME ", theme::label_caps_inline()),
-            Span::styled(time_str, theme::dock_value()),
-            Span::raw("  "),
-            Span::styled("WORKSPACE ", theme::label_caps_inline()),
+            Span::styled("time ", theme::label_caps_inline()),
+            Span::styled(time_str, theme::dock_value_muted()),
+            Span::raw("   "),
+            Span::styled("workspace ", theme::label_caps_inline()),
             Span::styled(workspace_name.to_string(), theme::workspace_value()),
             Span::styled(activity.to_string(), theme::out_dim()),
         ]);
-        frame.render_widget(Paragraph::new(line), area);
+        frame.render_widget(Paragraph::new(line).style(theme::canvas()), area);
     }
 
     /// Renders the inline slash-command completion menu as an overlay.
@@ -1867,9 +1899,9 @@ mod tests {
     }
 
     #[test]
-    fn mode_dot_glyph_returns_known_value() {
-        let g = ReplApp::mode_dot_glyph();
-        assert!(ReplApp::MODE_DOT_GLYPHS.contains(&g));
+    fn mode_dot_glyph_returns_solid_circle() {
+        // Static dot now; only the solid bullet (U+25CF) is allowed.
+        assert_eq!(ReplApp::mode_dot_glyph(), "\u{25CF}");
     }
 
     #[test]

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -104,6 +104,7 @@ use super::completion::SLASH_COMMANDS;
 use super::mode::{
     Action, OutputLine, OutputStyle, PanelInputMode, PanelState, ReplMode, SlashMatch,
 };
+use super::theme::tui as theme;
 
 // ---------------------------------------------------------------------------
 // Turn
@@ -996,17 +997,13 @@ impl ReplApp {
         let version = env!("CARGO_PKG_VERSION");
 
         let line = Line::from(vec![
-            Span::styled(
-                "duumbi",
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(
-                format!(" v{version}"),
-                Style::default().add_modifier(Modifier::DIM),
-            ),
-            Span::raw(" · Type a request or /help for commands. Ctrl+D to exit."),
+            Span::styled("duumbi", theme::brand_word()),
+            Span::raw(" "),
+            Span::styled(format!("v{version}"), theme::version_badge()),
+            Span::styled("  ·  ", theme::hairline()),
+            Span::styled("type /help", theme::helper()),
+            Span::raw("   "),
+            Span::styled(" Ctrl+D ", theme::keycap()),
         ]);
 
         frame.render_widget(Paragraph::new(line), area);
@@ -1020,9 +1017,9 @@ impl ReplApp {
                 Line::from(""),
                 Line::from(Span::styled(
                     "Tip: No workspace found. Initialise one with:",
-                    Style::default().add_modifier(Modifier::DIM),
+                    theme::out_dim(),
                 )),
-                Line::from(Span::styled("  /init", Style::default().fg(Color::Cyan))),
+                Line::from(Span::styled("  /init", theme::chevron())),
                 Line::from(""),
             ]
         } else {
@@ -1031,15 +1028,15 @@ impl ReplApp {
                 Line::from(""),
                 Line::from(Span::styled(
                     "Tip: This is an empty workspace. Try one of these:",
-                    Style::default().add_modifier(Modifier::DIM),
+                    theme::out_dim(),
                 )),
                 Line::from(Span::styled(
                     "  /intent create  \"Build a calculator with add and multiply\"",
-                    Style::default().fg(Color::Cyan),
+                    theme::chevron(),
                 )),
                 Line::from(Span::styled(
                     "  or type a request directly: \"Add a function that adds two numbers\"",
-                    Style::default().add_modifier(Modifier::DIM),
+                    theme::out_dim(),
                 )),
             ]
         };
@@ -1065,32 +1062,28 @@ impl ReplApp {
         for ol in visible {
             match ol.style {
                 OutputStyle::Help => {
-                    // Split at column 35: command in magenta, description in white.
+                    // Split at column 35: command in rust, description in parchment.
                     let text = &ol.text;
                     if text.len() > 35 {
                         let (cmd_part, desc_part) = text.split_at(35);
                         lines.push(Line::from(vec![
-                            Span::styled(cmd_part.to_string(), Style::default().fg(Color::Magenta)),
-                            Span::styled(desc_part.to_string(), Style::default().fg(Color::White)),
+                            Span::styled(cmd_part.to_string(), theme::out_help_cmd()),
+                            Span::styled(desc_part.to_string(), theme::out_help_desc()),
                         ]));
                     } else {
                         lines.push(Line::from(Span::styled(
                             text.clone(),
-                            Style::default().fg(Color::Magenta),
+                            theme::out_help_cmd(),
                         )));
                     }
                 }
                 _ => {
                     let style = match ol.style {
-                        OutputStyle::Normal => Style::default().fg(Color::White),
-                        OutputStyle::Error => {
-                            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
-                        }
-                        OutputStyle::Success => Style::default()
-                            .fg(Color::Green)
-                            .add_modifier(Modifier::BOLD),
-                        OutputStyle::Dim => Style::default().fg(Color::Gray),
-                        OutputStyle::Ai => Style::default().fg(Color::Cyan),
+                        OutputStyle::Normal => theme::out_normal(),
+                        OutputStyle::Error => theme::out_error(),
+                        OutputStyle::Success => theme::out_success(),
+                        OutputStyle::Dim => theme::out_dim(),
+                        OutputStyle::Ai => theme::out_ai(),
                         OutputStyle::Help => unreachable!(),
                     };
                     lines.push(Line::from(Span::styled(ol.text.clone(), style)));
@@ -1109,12 +1102,9 @@ impl ReplApp {
                 / 120) as usize;
             let ch = Self::SPINNER[frame_idx % Self::SPINNER.len()];
             let spinner = format!("{ch} Working…");
-            let style = Style::default()
-                .fg(Color::Yellow)
-                .add_modifier(Modifier::BOLD);
             let y = area.bottom().saturating_sub(1);
             frame.render_widget(
-                Paragraph::new(Span::styled(spinner, style)),
+                Paragraph::new(Span::styled(spinner, theme::chevron())),
                 Rect::new(area.x, y, 12, 1),
             );
         }
@@ -1122,11 +1112,10 @@ impl ReplApp {
         // Scroll indicator overlay when scrolled up.
         if self.output_scroll_offset > 0 {
             let indicator = format!(" \u{2191} {} lines above ", self.output_scroll_offset);
-            let style = Style::default().fg(Color::Gray);
             let x = area.right().saturating_sub(indicator.len() as u16);
             let indicator_area = Rect::new(x, area.y, indicator.len() as u16, 1);
             frame.render_widget(
-                Paragraph::new(Span::styled(indicator, style)),
+                Paragraph::new(Span::styled(indicator, theme::out_dim())),
                 indicator_area,
             );
         }
@@ -1134,13 +1123,10 @@ impl ReplApp {
 
     /// Renders the mode indicator line below the output area.
     fn render_mode_line(&self, frame: &mut Frame, area: Rect) {
-        let hint = Span::styled(
-            "Shift+Tab switch mode",
-            Style::default().add_modifier(Modifier::DIM),
-        );
+        let hint = Span::styled("Shift+Tab switch mode", theme::mode_hint());
         let sep = Span::raw("  ");
         let mode_label = self.mode.label();
-        let mode_span = Span::styled(mode_label, Style::default().fg(Color::Yellow));
+        let mode_span = Span::styled(mode_label, theme::mode_label());
 
         let right_text = if let Some(ref slug) = self.focused_intent {
             format!("[{slug}]")
@@ -1156,7 +1142,7 @@ impl ReplApp {
         let mut spans = vec![hint, sep, mode_span, Span::raw(" ".repeat(padding))];
 
         if !right_text.is_empty() {
-            spans.push(Span::styled(right_text, Style::default().fg(Color::Cyan)));
+            spans.push(Span::styled(right_text, theme::intent_slug()));
         }
 
         frame.render_widget(Paragraph::new(Line::from(spans)), area);
@@ -1167,10 +1153,7 @@ impl ReplApp {
         let width = area.width as usize;
         let line_str = "─".repeat(width);
         frame.render_widget(
-            Paragraph::new(Span::styled(
-                line_str,
-                Style::default().add_modifier(Modifier::DIM),
-            )),
+            Paragraph::new(Span::styled(line_str, theme::hairline_dim())),
             area,
         );
     }
@@ -1181,7 +1164,7 @@ impl ReplApp {
 
         // Chevron prefix
         frame.render_widget(
-            Paragraph::new(Span::styled("❯ ", Style::default().fg(Color::Cyan))),
+            Paragraph::new(Span::styled("\u{203A} ", theme::chevron())),
             chunks[0],
         );
 
@@ -1222,19 +1205,13 @@ impl ReplApp {
         let padding = width.saturating_sub(left_str.len() + right_str.len());
 
         let spans: Vec<Span<'_>> = vec![
-            Span::styled(
-                format!("{time_str}  "),
-                Style::default().add_modifier(Modifier::DIM),
-            ),
-            Span::styled(full_path, Style::default().fg(Color::Green)),
+            Span::styled(format!("{time_str}  "), theme::out_dim()),
+            Span::styled(full_path, theme::dock_value()),
             Span::raw(" ".repeat(padding)),
-            Span::styled("workspace: ", Style::default().add_modifier(Modifier::DIM)),
-            Span::styled(
-                workspace_name.to_string(),
-                Style::default().fg(Color::Yellow),
-            ),
+            Span::styled("workspace: ", theme::label_caps()),
+            Span::styled(workspace_name.to_string(), theme::workspace_value()),
             Span::raw("  "),
-            Span::styled(model_str, Style::default().fg(Color::Magenta)),
+            Span::styled(model_str, theme::version_badge()),
         ];
 
         frame.render_widget(Paragraph::new(Line::from(spans)), area);
@@ -1275,11 +1252,9 @@ impl ReplApp {
             let text = format!("{prefix}{:<20}  {}", sm.command, sm.description);
 
             let style = if is_selected {
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD)
+                theme::slash_selected()
             } else {
-                Style::default().add_modifier(Modifier::DIM)
+                theme::out_dim()
             };
 
             frame.render_widget(Paragraph::new(Span::styled(text, style)), row_areas[i]);
@@ -1295,7 +1270,7 @@ impl ReplApp {
                 (false, false) => "",
             };
             let indicator = format!("  {pos}/{total}{arrows}");
-            let style = Style::default().add_modifier(Modifier::DIM);
+            let style = theme::out_dim();
             frame.render_widget(
                 Paragraph::new(Span::styled(indicator, style)),
                 row_areas[visible],
@@ -1317,15 +1292,9 @@ impl ReplApp {
 
         // Header
         lines.push(Line::from(vec![
-            Span::styled(
-                "  Select Model",
-                Style::default().add_modifier(Modifier::BOLD),
-            ),
+            Span::styled("  Select Model", theme::brand_word()),
             Span::raw(" ".repeat(area.width.saturating_sub(40) as usize)),
-            Span::styled(
-                "(Esc to close)",
-                Style::default().add_modifier(Modifier::DIM),
-            ),
+            Span::styled("(Esc to close)", theme::out_dim()),
         ]));
 
         // Empty line
@@ -1335,7 +1304,7 @@ impl ReplApp {
         if providers.is_empty() {
             lines.push(Line::from(Span::styled(
                 "  No providers configured. Press [A] to add one.",
-                Style::default().add_modifier(Modifier::DIM),
+                theme::out_dim(),
             )));
         } else {
             for (i, p) in providers.iter().enumerate() {
@@ -1360,11 +1329,9 @@ impl ReplApp {
                 );
 
                 let style = if is_sel {
-                    Style::default()
-                        .fg(Color::Cyan)
-                        .add_modifier(Modifier::BOLD)
+                    theme::slash_selected()
                 } else {
-                    Style::default().add_modifier(Modifier::DIM)
+                    theme::out_dim()
                 };
 
                 lines.push(Line::from(Span::styled(text, style)));
@@ -1378,36 +1345,24 @@ impl ReplApp {
         match input_mode {
             Some(PanelInputMode::AddProvider(buf)) => {
                 lines.push(Line::from(vec![
-                    Span::styled("  Add: ", Style::default().fg(Color::Cyan)),
-                    Span::styled(
-                        format!("{buf}\u{2588}"),
-                        Style::default().add_modifier(Modifier::BOLD),
-                    ),
-                    Span::styled(
-                        "  (provider model api_key_env)",
-                        Style::default().add_modifier(Modifier::DIM),
-                    ),
+                    Span::styled("  Add: ", theme::out_help_cmd()),
+                    Span::styled(format!("{buf}\u{2588}"), theme::brand_word()),
+                    Span::styled("  (provider model api_key_env)", theme::out_dim()),
                 ]));
             }
             Some(PanelInputMode::ConfirmDelete) => {
                 lines.push(Line::from(Span::styled(
                     format!("  Delete provider #{}? [y/N]", selected + 1),
-                    Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+                    theme::out_error(),
                 )));
             }
             Some(PanelInputMode::AddStep1Provider { selected: step_sel }) => {
                 // Replace entire panel with provider selection.
                 lines.clear();
                 lines.push(Line::from(vec![
-                    Span::styled(
-                        "  Add Provider",
-                        Style::default().add_modifier(Modifier::BOLD),
-                    ),
+                    Span::styled("  Add Provider", theme::brand_word()),
                     Span::raw(" ".repeat(area.width.saturating_sub(45) as usize)),
-                    Span::styled(
-                        "(Esc to cancel)",
-                        Style::default().add_modifier(Modifier::DIM),
-                    ),
+                    Span::styled("(Esc to cancel)", theme::out_dim()),
                 ]));
                 lines.push(Line::from(""));
                 for (i, (name, desc)) in PROVIDER_KINDS.iter().enumerate() {
@@ -1415,11 +1370,9 @@ impl ReplApp {
                     let prefix = if is_sel { "  \u{25cf} " } else { "    " };
                     let text = format!("{prefix}{}. {:<14} {}", i + 1, name, desc);
                     let style = if is_sel {
-                        Style::default()
-                            .fg(Color::Cyan)
-                            .add_modifier(Modifier::BOLD)
+                        theme::slash_selected()
                     } else {
-                        Style::default().add_modifier(Modifier::DIM)
+                        theme::out_dim()
                     };
                     lines.push(Line::from(Span::styled(text, style)));
                 }
@@ -1433,22 +1386,16 @@ impl ReplApp {
                 lines.push(Line::from(vec![
                     Span::styled(
                         format!("  Select Model for {provider}"),
-                        Style::default().add_modifier(Modifier::BOLD),
+                        theme::brand_word(),
                     ),
                     Span::raw(" ".repeat(area.width.saturating_sub(55) as usize)),
-                    Span::styled(
-                        "(Esc to go back)",
-                        Style::default().add_modifier(Modifier::DIM),
-                    ),
+                    Span::styled("(Esc to go back)", theme::out_dim()),
                 ]));
                 lines.push(Line::from(""));
                 if let Some(manual) = manual_input {
                     lines.push(Line::from(vec![
-                        Span::styled("  Model: ", Style::default().fg(Color::Cyan)),
-                        Span::styled(
-                            format!("{manual}\u{2588}"),
-                            Style::default().add_modifier(Modifier::BOLD),
-                        ),
+                        Span::styled("  Model: ", theme::out_help_cmd()),
+                        Span::styled(format!("{manual}\u{2588}"), theme::brand_word()),
                     ]));
                 } else {
                     let models = recommended_models(provider);
@@ -1457,18 +1404,16 @@ impl ReplApp {
                         let prefix = if is_sel { "  \u{25cf} " } else { "    " };
                         let text = format!("{prefix}{}. {:<30} {}", i + 1, name, desc);
                         let style = if is_sel {
-                            Style::default()
-                                .fg(Color::Cyan)
-                                .add_modifier(Modifier::BOLD)
+                            theme::slash_selected()
                         } else {
-                            Style::default().add_modifier(Modifier::DIM)
+                            theme::out_dim()
                         };
                         lines.push(Line::from(Span::styled(text, style)));
                     }
                     lines.push(Line::from(""));
                     lines.push(Line::from(Span::styled(
                         "  [M] Enter model name manually",
-                        Style::default().add_modifier(Modifier::DIM),
+                        theme::out_dim(),
                     )));
                 }
             }
@@ -1481,13 +1426,10 @@ impl ReplApp {
                 lines.push(Line::from(vec![
                     Span::styled(
                         format!("  Authentication for {provider} ({model})"),
-                        Style::default().add_modifier(Modifier::BOLD),
+                        theme::brand_word(),
                     ),
                     Span::raw(" ".repeat(area.width.saturating_sub(60) as usize)),
-                    Span::styled(
-                        "(Esc to go back)",
-                        Style::default().add_modifier(Modifier::DIM),
-                    ),
+                    Span::styled("(Esc to go back)", theme::out_dim()),
                 ]));
                 lines.push(Line::from(""));
                 let options = [
@@ -1500,24 +1442,19 @@ impl ReplApp {
                 for (i, (label, hint)) in options.iter().enumerate() {
                     let marker = if i == *auth_sel { "> " } else { "  " };
                     let style = if i == *auth_sel {
-                        Style::default()
-                            .fg(Color::Cyan)
-                            .add_modifier(Modifier::BOLD)
+                        theme::slash_selected()
                     } else {
-                        Style::default().add_modifier(Modifier::DIM)
+                        theme::out_dim()
                     };
                     lines.push(Line::from(vec![
                         Span::styled(format!("  {marker}{label}"), style),
-                        Span::styled(
-                            format!("  \u{2014} {hint}"),
-                            Style::default().add_modifier(Modifier::DIM),
-                        ),
+                        Span::styled(format!("  \u{2014} {hint}"), theme::out_dim()),
                     ]));
                 }
                 lines.push(Line::from(""));
                 lines.push(Line::from(Span::styled(
                     "  [\u{2191}/\u{2193}] Select  [Enter] Continue  [Esc] Back",
-                    Style::default().add_modifier(Modifier::DIM),
+                    theme::out_dim(),
                 )));
             }
             Some(PanelInputMode::AddStep3Key {
@@ -1534,20 +1471,14 @@ impl ReplApp {
                 let key_set = std::env::var(env_name).is_ok();
                 lines.clear();
                 lines.push(Line::from(vec![
-                    Span::styled(
-                        format!("  {label} for {provider}"),
-                        Style::default().add_modifier(Modifier::BOLD),
-                    ),
+                    Span::styled(format!("  {label} for {provider}"), theme::brand_word()),
                     Span::raw(" ".repeat(area.width.saturating_sub(50) as usize)),
-                    Span::styled(
-                        "(Esc to go back)",
-                        Style::default().add_modifier(Modifier::DIM),
-                    ),
+                    Span::styled("(Esc to go back)", theme::out_dim()),
                 ]));
                 lines.push(Line::from(""));
                 lines.push(Line::from(Span::styled(
                     format!("  Model: {model}"),
-                    Style::default().add_modifier(Modifier::DIM),
+                    theme::out_dim(),
                 )));
                 let hint = if *is_subscription {
                     "  Tip: generate a token with `claude setup-token`"
@@ -1563,29 +1494,21 @@ impl ReplApp {
                             "\u{2717} not set \u{2014} enter below"
                         }
                     ),
-                    Style::default().add_modifier(Modifier::DIM),
+                    theme::out_dim(),
                 )));
                 if !hint.is_empty() {
-                    lines.push(Line::from(Span::styled(
-                        hint,
-                        Style::default()
-                            .fg(Color::Yellow)
-                            .add_modifier(Modifier::DIM),
-                    )));
+                    lines.push(Line::from(Span::styled(hint, theme::label_caps())));
                 }
                 lines.push(Line::from(""));
                 let masked = "\u{25cf}".repeat(key_buf.len());
                 lines.push(Line::from(vec![
-                    Span::styled(format!("  {label}: "), Style::default().fg(Color::Cyan)),
-                    Span::styled(
-                        format!("{masked}\u{2588}"),
-                        Style::default().add_modifier(Modifier::BOLD),
-                    ),
+                    Span::styled(format!("  {label}: "), theme::out_help_cmd()),
+                    Span::styled(format!("{masked}\u{2588}"), theme::brand_word()),
                 ]));
                 lines.push(Line::from(""));
                 lines.push(Line::from(Span::styled(
                     "  [Enter] Continue  [Esc] Back",
-                    Style::default().add_modifier(Modifier::DIM),
+                    theme::out_dim(),
                 )));
             }
             Some(PanelInputMode::AddStep3Confirm {
@@ -1602,32 +1525,28 @@ impl ReplApp {
                 lines.clear();
                 lines.push(Line::from(Span::styled(
                     format!("  Store {label} for {provider} ({model})?"),
-                    Style::default().add_modifier(Modifier::BOLD),
+                    theme::brand_word(),
                 )));
                 lines.push(Line::from(""));
                 lines.push(Line::from(Span::styled(
                     "  [K] Save to ~/.duumbi/credentials.toml  [E] Session only  [Esc] Back",
-                    Style::default().add_modifier(Modifier::DIM),
+                    theme::out_dim(),
                 )));
             }
             None => {
                 // Show status message if present (e.g. "Provider added").
                 if let Some((msg, style)) = status_msg {
                     let s = match style {
-                        OutputStyle::Success => Style::default()
-                            .fg(Color::Green)
-                            .add_modifier(Modifier::BOLD),
-                        OutputStyle::Error => {
-                            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
-                        }
-                        _ => Style::default().add_modifier(Modifier::DIM),
+                        OutputStyle::Success => theme::out_success(),
+                        OutputStyle::Error => theme::out_error(),
+                        _ => theme::out_dim(),
                     };
                     lines.push(Line::from(Span::styled(format!("  {msg}"), s)));
                     lines.push(Line::from(""));
                 }
                 lines.push(Line::from(Span::styled(
                     "  [A] Add  [D] Delete  [T] Toggle role  [Enter] Select primary",
-                    Style::default().add_modifier(Modifier::DIM),
+                    theme::out_dim(),
                 )));
             }
         }

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -4,11 +4,12 @@
 //! using ratatui. Key handling delegates to `handle_key` which returns an
 //! [`Action`] that the event loop acts on.
 
+use std::cell::Cell;
 use std::collections::HashSet;
 use std::path::PathBuf;
 
 use chrono::Local;
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton};
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Clear, Paragraph, Wrap};
 use ratatui_textarea::{CursorMove, TextArea};
@@ -125,8 +126,8 @@ fn parse_provider_kind_by_index(idx: usize) -> Option<crate::config::ProviderKin
 
 use super::completion::{SLASH_COMMANDS, SLASH_GROUPS, SlashGroup};
 use super::mode::{
-    Action, OutputLine, OutputStyle, PanelInputMode, PanelState, ReplMode, SlashMatch,
-    SlashMenuItem,
+    Action, ConversationAction, ConversationBlock, ConversationBlockKind, OutputLine, OutputStyle,
+    PanelInputMode, PanelState, ReplMode, SlashMatch, SlashMenuItem,
 };
 use super::theme::tui as theme;
 
@@ -141,6 +142,25 @@ pub struct Turn {
     pub request: String,
     /// Human-readable summary of the changes made.
     pub summary: String,
+}
+
+#[derive(Debug, Clone)]
+struct ConversationVisualRow {
+    line: Line<'static>,
+    block_index: Option<usize>,
+    menu_button_block: Option<usize>,
+    menu_button_range: Option<(u16, u16)>,
+}
+
+#[derive(Debug, Clone)]
+struct VisibleConversationLayout {
+    padding: usize,
+    rows: Vec<ConversationVisualRow>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ConversationActionMenu {
+    block_index: usize,
 }
 
 // ---------------------------------------------------------------------------
@@ -172,6 +192,18 @@ pub struct ReplApp {
     pub has_workspace: bool,
     /// Scrollable output buffer.
     pub output_lines: Vec<OutputLine>,
+    /// Scrollable conversation blocks rendered in the main pane.
+    pub conversation_blocks: Vec<ConversationBlock>,
+    /// Index of the active output block receiving `push_output` lines.
+    current_output_block: Option<usize>,
+    /// User block selected by clicking inside the conversation pane.
+    selected_conversation_block: Option<usize>,
+    /// Open action menu for a selected conversation user block.
+    conversation_action_menu: Option<ConversationActionMenu>,
+    /// Selected row inside the open conversation action menu.
+    conversation_action_selected: usize,
+    /// Last rendered conversation pane rectangle, used for mouse hit testing.
+    last_conversation_area: Cell<Option<Rect>>,
     /// Scroll offset for the output area (lines from the bottom; 0 = latest).
     pub output_scroll_offset: usize,
     /// All matching slash-command entries (untruncated).
@@ -229,6 +261,12 @@ impl ReplApp {
             session_mgr,
             has_workspace,
             output_lines: Vec::new(),
+            conversation_blocks: Vec::new(),
+            current_output_block: None,
+            selected_conversation_block: None,
+            conversation_action_menu: None,
+            conversation_action_selected: 0,
+            last_conversation_area: Cell::new(None),
             output_scroll_offset: 0,
             slash_matches: Vec::new(),
             slash_rows: Vec::new(),
@@ -292,6 +330,10 @@ impl ReplApp {
             return self.handle_model_panel_key(key, textarea);
         }
 
+        if self.conversation_action_menu.is_some() {
+            return self.handle_conversation_action_menu_key(key);
+        }
+
         match key.code {
             // Shift+Tab: toggle Agent ↔ Intent mode
             KeyCode::BackTab => {
@@ -345,6 +387,23 @@ impl ReplApp {
                 Action::Continue
             }
 
+            // Ctrl+Up/Ctrl+Down: move conversation block selection without mouse capture.
+            KeyCode::Up if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.select_previous_user_block();
+                Action::Continue
+            }
+
+            KeyCode::Down if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.select_next_user_block();
+                Action::Continue
+            }
+
+            // Ctrl+O: open the selected conversation block action menu.
+            KeyCode::Char('o') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.open_selected_conversation_action_menu();
+                Action::Continue
+            }
+
             // Tab: accept selected slash command without submitting
             KeyCode::Tab if !self.slash_rows.is_empty() => {
                 if let Some(cmd) = self.selected_slash_command() {
@@ -378,14 +437,13 @@ impl ReplApp {
 
             // PageUp: scroll output buffer up (toward older lines)
             KeyCode::PageUp => {
-                let max_scroll = self.output_lines.len().saturating_sub(1);
-                self.output_scroll_offset = (self.output_scroll_offset + 10).min(max_scroll);
+                self.scroll_conversation_up(10, 1, 80);
                 Action::Continue
             }
 
             // PageDown: scroll output buffer down (toward latest)
             KeyCode::PageDown => {
-                self.output_scroll_offset = self.output_scroll_offset.saturating_sub(10);
+                self.scroll_conversation_down(10);
                 Action::Continue
             }
 
@@ -394,7 +452,7 @@ impl ReplApp {
 
             // Ctrl+C: friendly quit reminder
             KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                self.push_output("(Use Ctrl+D to quit)", OutputStyle::Dim);
+                self.push_feedback("(Use Ctrl+D to quit)", OutputStyle::Dim);
                 Action::Continue
             }
 
@@ -408,23 +466,59 @@ impl ReplApp {
         }
     }
 
-    /// Handles mouse events (scroll wheel for output buffer scrolling).
+    /// Handles mouse events when the terminal delivers them.
     ///
-    /// Currently unused — mouse capture is disabled to allow native text
-    /// selection. Scroll is available via keyboard (PageUp/PageDown).
+    /// The REPL does not enable global mouse capture by default, so terminals
+    /// can keep native drag-selection available.
     #[allow(dead_code)]
     pub fn handle_mouse(&mut self, mouse: crossterm::event::MouseEvent) {
         use crossterm::event::MouseEventKind;
         match mouse.kind {
             MouseEventKind::ScrollUp => {
-                let max_scroll = self.output_lines.len().saturating_sub(1);
-                self.output_scroll_offset = (self.output_scroll_offset + 1).min(max_scroll);
+                self.scroll_conversation_up(3, 1, 80);
             }
             MouseEventKind::ScrollDown => {
-                self.output_scroll_offset = self.output_scroll_offset.saturating_sub(1);
+                self.scroll_conversation_down(3);
+            }
+            MouseEventKind::Down(MouseButton::Left) => {
+                self.handle_conversation_click(mouse.column, mouse.row);
             }
             _ => {}
         }
+    }
+
+    fn handle_conversation_action_menu_key(&mut self, key: KeyEvent) -> Action {
+        let Some(menu) = self.conversation_action_menu else {
+            return Action::Continue;
+        };
+        let actions = self.conversation_menu_actions(menu.block_index);
+        match key.code {
+            KeyCode::Esc => {
+                self.conversation_action_menu = None;
+            }
+            KeyCode::Up => {
+                self.conversation_action_selected =
+                    self.conversation_action_selected.saturating_sub(1);
+            }
+            KeyCode::Down => {
+                let max = actions.len().saturating_sub(1);
+                self.conversation_action_selected =
+                    (self.conversation_action_selected + 1).min(max);
+            }
+            KeyCode::Enter => {
+                if let Some(action) = actions.get(self.conversation_action_selected).copied() {
+                    self.execute_conversation_action(menu.block_index, action);
+                }
+            }
+            KeyCode::Char('c') => {
+                self.execute_conversation_action(menu.block_index, ConversationAction::Copy);
+            }
+            KeyCode::Char('r') if actions.contains(&ConversationAction::Revert) => {
+                self.execute_conversation_action(menu.block_index, ConversationAction::Revert);
+            }
+            _ => {}
+        }
+        Action::Continue
     }
 
     /// Handles key events when the model selector panel is active.
@@ -1041,9 +1135,13 @@ impl ReplApp {
     /// unbounded memory growth.
     pub fn push_output(&mut self, text: impl Into<String>, style: OutputStyle) {
         let text = text.into();
+        let output_idx = self.ensure_output_block();
         for line in text.split('\n') {
-            self.output_lines
-                .push(OutputLine::new(line.to_string(), style));
+            let output_line = OutputLine::new(line.to_string(), style);
+            self.output_lines.push(output_line.clone());
+            if let Some(block) = self.conversation_blocks.get_mut(output_idx) {
+                block.lines.push(output_line);
+            }
         }
         if self.output_lines.len() > Self::OUTPUT_BUFFER_MAX {
             let excess = self.output_lines.len() - Self::OUTPUT_BUFFER_MAX;
@@ -1051,6 +1149,321 @@ impl ReplApp {
         }
         // Reset scroll to bottom when new output arrives.
         self.output_scroll_offset = 0;
+    }
+
+    fn push_feedback(&mut self, text: impl Into<String>, style: OutputStyle) {
+        self.current_output_block = None;
+        self.push_output(text, style);
+        self.current_output_block = None;
+    }
+
+    /// Starts a new conversation turn with a persistent user input block.
+    pub fn begin_user_block(&mut self, input: &str) {
+        let submitted_at = Local::now().format("%H:%M").to_string();
+        self.conversation_blocks
+            .push(ConversationBlock::user(input.to_string(), submitted_at));
+        self.output_lines
+            .push(OutputLine::new(input.to_string(), OutputStyle::Dim));
+        self.current_output_block = None;
+        self.selected_conversation_block = None;
+        self.conversation_action_menu = None;
+        self.output_scroll_offset = 0;
+    }
+
+    fn user_block_indices(&self) -> Vec<usize> {
+        self.conversation_blocks
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, block)| (block.kind == ConversationBlockKind::User).then_some(idx))
+            .collect()
+    }
+
+    fn select_previous_user_block(&mut self) {
+        let indices = self.user_block_indices();
+        if indices.is_empty() {
+            return;
+        }
+
+        let next = self
+            .selected_conversation_block
+            .and_then(|selected| indices.iter().position(|idx| *idx == selected))
+            .and_then(|pos| pos.checked_sub(1))
+            .map_or_else(
+                || *indices.last().expect("invariant: non-empty indices"),
+                |pos| indices[pos],
+            );
+
+        self.selected_conversation_block = Some(next);
+        self.conversation_action_menu = None;
+        self.conversation_action_selected = 0;
+    }
+
+    fn select_next_user_block(&mut self) {
+        let indices = self.user_block_indices();
+        if indices.is_empty() {
+            return;
+        }
+
+        let next = self
+            .selected_conversation_block
+            .and_then(|selected| indices.iter().position(|idx| *idx == selected))
+            .and_then(|pos| indices.get(pos + 1).copied())
+            .unwrap_or(indices[0]);
+
+        self.selected_conversation_block = Some(next);
+        self.conversation_action_menu = None;
+        self.conversation_action_selected = 0;
+    }
+
+    fn open_selected_conversation_action_menu(&mut self) {
+        let Some(block_index) = self.selected_conversation_block else {
+            self.select_previous_user_block();
+            return;
+        };
+        if self.conversation_menu_actions(block_index).is_empty() {
+            return;
+        }
+        self.conversation_action_menu = Some(ConversationActionMenu { block_index });
+        self.conversation_action_selected = 0;
+    }
+
+    /// Marks the latest user block as revertable.
+    pub fn mark_latest_user_block_revertable(&mut self, snapshot_path: PathBuf) {
+        if let Some(block) = self
+            .conversation_blocks
+            .iter_mut()
+            .rev()
+            .find(|block| block.kind == ConversationBlockKind::User)
+        {
+            if !block.actions.contains(&ConversationAction::Revert) {
+                block.actions.push(ConversationAction::Revert);
+            }
+            block.revert_snapshot = Some(snapshot_path);
+        }
+    }
+
+    /// Adds a runtime footer to the active output block.
+    pub fn finish_current_output_elapsed(&mut self, elapsed: std::time::Duration) {
+        if let Some(idx) = self.current_output_block
+            && let Some(block) = self.conversation_blocks.get_mut(idx)
+        {
+            block.elapsed = Some(format!("completed in {:.2}s", elapsed.as_secs_f64()));
+        }
+    }
+
+    fn scroll_conversation_up(&mut self, amount: usize, fallback_height: u16, fallback_width: u16) {
+        let total = self.conversation_line_count(fallback_width);
+        let max_scroll = total.saturating_sub(fallback_height as usize);
+        self.output_scroll_offset = (self.output_scroll_offset + amount).min(max_scroll);
+    }
+
+    fn scroll_conversation_down(&mut self, amount: usize) {
+        self.output_scroll_offset = self.output_scroll_offset.saturating_sub(amount);
+    }
+
+    fn conversation_line_count(&self, width: u16) -> usize {
+        if self.conversation_blocks.is_empty() {
+            self.output_lines.len()
+        } else {
+            self.conversation_visual_rows(width).len()
+        }
+    }
+
+    fn user_block_text(&self, block_index: usize) -> Option<String> {
+        self.conversation_blocks
+            .get(block_index)
+            .filter(|block| block.kind == ConversationBlockKind::User)
+            .and_then(|block| block.lines.first())
+            .map(|line| line.text.clone())
+    }
+
+    fn copy_user_block(&mut self, block_index: usize) {
+        let Some(text) = self.user_block_text(block_index) else {
+            self.push_feedback("Nothing to copy.", OutputStyle::Dim);
+            return;
+        };
+
+        match std::process::Command::new("pbcopy")
+            .stdin(std::process::Stdio::piped())
+            .spawn()
+        {
+            Ok(mut child) => {
+                let write_result = child.stdin.as_mut().map_or_else(
+                    || {
+                        Err(std::io::Error::new(
+                            std::io::ErrorKind::BrokenPipe,
+                            "stdin closed",
+                        ))
+                    },
+                    |stdin| std::io::Write::write_all(stdin, text.as_bytes()),
+                );
+                let wait_result = child.wait();
+                match (write_result, wait_result) {
+                    (Ok(()), Ok(status)) if status.success() => {
+                        self.push_feedback("Copied message.", OutputStyle::Success);
+                    }
+                    (Err(e), _) => {
+                        self.push_feedback(format!("Copy failed: {e}"), OutputStyle::Error);
+                    }
+                    (_, Ok(status)) => {
+                        self.push_feedback(format!("Copy failed: {status}"), OutputStyle::Error);
+                    }
+                    (_, Err(e)) => {
+                        self.push_feedback(format!("Copy failed: {e}"), OutputStyle::Error);
+                    }
+                }
+            }
+            Err(e) => {
+                self.push_feedback(format!("Copy failed: {e}"), OutputStyle::Error);
+            }
+        }
+    }
+
+    fn latest_revertable_block_index(&self) -> Option<usize> {
+        self.conversation_blocks
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|(_, block)| {
+                block.kind == ConversationBlockKind::User
+                    && block.actions.contains(&ConversationAction::Revert)
+            })
+            .map(|(idx, _)| idx)
+    }
+
+    fn conversation_menu_actions(&self, block_index: usize) -> Vec<ConversationAction> {
+        let Some(block) = self.conversation_blocks.get(block_index) else {
+            return Vec::new();
+        };
+        if block.kind != ConversationBlockKind::User {
+            return Vec::new();
+        }
+
+        let mut actions = vec![ConversationAction::Copy];
+        if block.actions.contains(&ConversationAction::Revert)
+            && self.latest_revertable_block_index() == Some(block_index)
+        {
+            actions.push(ConversationAction::Revert);
+        }
+        actions
+    }
+
+    fn execute_conversation_action(&mut self, block_index: usize, action: ConversationAction) {
+        self.conversation_action_menu = None;
+        match action {
+            ConversationAction::Copy => self.copy_user_block(block_index),
+            ConversationAction::Revert => self.revert_user_block_change(block_index),
+        }
+    }
+
+    fn revert_user_block_change(&mut self, block_index: usize) {
+        if self.latest_revertable_block_index() != Some(block_index) {
+            self.push_feedback("Nothing to revert.", OutputStyle::Dim);
+            return;
+        }
+
+        match crate::snapshot::restore_latest(&self.workspace_root) {
+            Ok(true) => {
+                self.history.pop();
+                if let Some(block) = self.conversation_blocks.get_mut(block_index) {
+                    block
+                        .actions
+                        .retain(|action| *action != ConversationAction::Revert);
+                    block.revert_snapshot = None;
+                }
+                self.push_feedback("Reverted latest graph change.", OutputStyle::Success);
+            }
+            Ok(false) => {
+                self.push_feedback("Nothing to revert.", OutputStyle::Dim);
+            }
+            Err(e) => {
+                self.push_feedback(format!("Revert failed: {e:#}"), OutputStyle::Error);
+            }
+        }
+    }
+
+    fn ensure_output_block(&mut self) -> usize {
+        if let Some(idx) = self.current_output_block
+            && self
+                .conversation_blocks
+                .get(idx)
+                .is_some_and(|block| block.kind == ConversationBlockKind::Output)
+        {
+            return idx;
+        }
+
+        self.conversation_blocks.push(ConversationBlock::output());
+        let idx = self.conversation_blocks.len() - 1;
+        self.current_output_block = Some(idx);
+        idx
+    }
+
+    fn handle_conversation_click(&mut self, column: u16, row: u16) {
+        let Some(area) = self.last_conversation_area.get() else {
+            return;
+        };
+
+        if let Some((menu_area, actions)) = self.conversation_action_menu_rect(area)
+            && self.rect_contains(menu_area, column, row)
+        {
+            let action_idx = row.saturating_sub(menu_area.y + 1) as usize;
+            if let Some(action) = actions.get(action_idx).copied()
+                && let Some(menu) = self.conversation_action_menu
+            {
+                self.execute_conversation_action(menu.block_index, action);
+            }
+            return;
+        }
+
+        if self.conversation_action_menu.is_some() {
+            self.conversation_action_menu = None;
+        }
+
+        if !self.rect_contains(area, column, row) {
+            return;
+        }
+
+        let layout = self.visible_conversation_layout(area);
+        let relative_y = row.saturating_sub(area.y) as usize;
+        if relative_y < layout.padding {
+            return;
+        }
+        let Some(visual_row) = layout.rows.get(relative_y - layout.padding) else {
+            return;
+        };
+
+        if let (Some(block_index), Some((start, end))) =
+            (visual_row.menu_button_block, visual_row.menu_button_range)
+            && column >= area.x + start
+            && column < area.x + end
+            && self.selected_conversation_block == Some(block_index)
+        {
+            self.conversation_action_menu = Some(ConversationActionMenu { block_index });
+            return;
+        }
+
+        let Some(block_index) = visual_row.block_index else {
+            return;
+        };
+        if self
+            .conversation_blocks
+            .get(block_index)
+            .is_none_or(|block| block.kind != ConversationBlockKind::User)
+        {
+            return;
+        }
+
+        if self.selected_conversation_block == Some(block_index) {
+            self.selected_conversation_block = None;
+            self.conversation_action_menu = None;
+        } else {
+            self.selected_conversation_block = Some(block_index);
+            self.conversation_action_menu = None;
+        }
+    }
+
+    fn rect_contains(&self, rect: Rect, column: u16, row: u16) -> bool {
+        column >= rect.x && column < rect.right() && row >= rect.y && row < rect.bottom()
     }
 
     // -----------------------------------------------------------------------
@@ -1342,48 +1755,13 @@ impl ReplApp {
     /// When `output_scroll_offset > 0`, the view shifts upward to show
     /// older lines. PageUp/PageDown control the offset.
     fn render_conversation_pane(&self, frame: &mut Frame, area: Rect) {
-        let max_lines = area.height as usize;
-        let total = self.output_lines.len();
-        let bottom = total.saturating_sub(self.output_scroll_offset);
-        let start = bottom.saturating_sub(max_lines);
-        let visible = &self.output_lines[start..bottom];
+        self.last_conversation_area.set(Some(area));
+        let layout = self.visible_conversation_layout(area);
 
         // Bottom-align: pad with empty lines above content so messages
         // appear just above the header, close to the prompt.
-        let padding = max_lines.saturating_sub(visible.len());
-        let mut lines: Vec<Line<'_>> = (0..padding).map(|_| Line::from("")).collect();
-
-        for ol in visible {
-            match ol.style {
-                OutputStyle::Help => {
-                    // Split at column 35: command in rust, description in parchment.
-                    let text = &ol.text;
-                    if text.len() > 35 {
-                        let (cmd_part, desc_part) = text.split_at(35);
-                        lines.push(Line::from(vec![
-                            Span::styled(cmd_part.to_string(), theme::out_help_cmd()),
-                            Span::styled(desc_part.to_string(), theme::out_help_desc()),
-                        ]));
-                    } else {
-                        lines.push(Line::from(Span::styled(
-                            text.clone(),
-                            theme::out_help_cmd(),
-                        )));
-                    }
-                }
-                _ => {
-                    let style = match ol.style {
-                        OutputStyle::Normal => theme::out_normal(),
-                        OutputStyle::Error => theme::out_error(),
-                        OutputStyle::Success => theme::out_success(),
-                        OutputStyle::Dim => theme::out_dim(),
-                        OutputStyle::Ai => theme::out_ai(),
-                        OutputStyle::Help => unreachable!(),
-                    };
-                    lines.push(Line::from(Span::styled(ol.text.clone(), style)));
-                }
-            }
-        }
+        let mut lines: Vec<Line<'_>> = (0..layout.padding).map(|_| Line::from("")).collect();
+        lines.extend(layout.rows.iter().map(|row| row.line.clone()));
 
         frame.render_widget(Paragraph::new(lines), area);
         // The "Working…" spinner now lives in the status dock activity slot
@@ -1398,6 +1776,271 @@ impl ReplApp {
                 Paragraph::new(Span::styled(indicator, theme::out_dim())),
                 indicator_area,
             );
+        }
+
+        self.render_conversation_action_menu(frame, area);
+    }
+
+    fn visible_conversation_layout(&self, area: Rect) -> VisibleConversationLayout {
+        let max_lines = area.height as usize;
+        let all_rows = if self.conversation_blocks.is_empty() {
+            self.legacy_output_rows()
+        } else {
+            self.conversation_visual_rows(area.width)
+        };
+        let total = all_rows.len();
+        let bottom = total.saturating_sub(self.output_scroll_offset);
+        let start = bottom.saturating_sub(max_lines);
+        let rows = all_rows[start..bottom].to_vec();
+        let padding = max_lines.saturating_sub(rows.len());
+        VisibleConversationLayout { padding, rows }
+    }
+
+    fn render_conversation_action_menu(&self, frame: &mut Frame, area: Rect) {
+        let Some((menu_area, actions)) = self.conversation_action_menu_rect(area) else {
+            return;
+        };
+
+        let lines = actions
+            .iter()
+            .enumerate()
+            .map(|(idx, action)| {
+                let label = match action {
+                    ConversationAction::Copy => "Copy message",
+                    ConversationAction::Revert => "Revert change",
+                };
+                let style = if idx == self.conversation_action_selected {
+                    theme::conversation_action_menu_selected()
+                } else {
+                    theme::conversation_action_menu()
+                };
+                Line::from(Span::styled(format!(" {label:<18}"), style))
+            })
+            .collect::<Vec<_>>();
+
+        frame.render_widget(Clear, menu_area);
+        frame.render_widget(
+            Paragraph::new(lines)
+                .style(theme::conversation_action_menu())
+                .block(
+                    Block::bordered()
+                        .border_style(theme::conversation_action_menu_border())
+                        .style(theme::conversation_action_menu()),
+                ),
+            menu_area,
+        );
+    }
+
+    fn conversation_action_menu_rect(&self, area: Rect) -> Option<(Rect, Vec<ConversationAction>)> {
+        let menu = self.conversation_action_menu?;
+        if self.selected_conversation_block != Some(menu.block_index) {
+            return None;
+        }
+        let actions = self.conversation_menu_actions(menu.block_index);
+        if actions.is_empty() {
+            return None;
+        }
+
+        let layout = self.visible_conversation_layout(area);
+        let row_offset = layout
+            .rows
+            .iter()
+            .position(|row| row.block_index == Some(menu.block_index))?;
+        let anchor_y = area.y + layout.padding as u16 + row_offset as u16;
+        let width = 22_u16.min(area.width);
+        let height = (actions.len() as u16 + 2).min(area.height.max(1));
+        let x = area.right().saturating_sub(width);
+        let y = if anchor_y + height < area.bottom() {
+            anchor_y.saturating_add(1)
+        } else {
+            anchor_y.saturating_sub(height.saturating_sub(1))
+        };
+
+        Some((Rect::new(x, y, width, height), actions))
+    }
+
+    fn legacy_output_rows(&self) -> Vec<ConversationVisualRow> {
+        self.output_lines
+            .iter()
+            .map(|ol| ConversationVisualRow {
+                line: Self::line_from_output(ol),
+                block_index: None,
+                menu_button_block: None,
+                menu_button_range: None,
+            })
+            .collect()
+    }
+
+    fn conversation_visual_rows(&self, width: u16) -> Vec<ConversationVisualRow> {
+        let mut rows = Vec::new();
+        for (idx, block) in self.conversation_blocks.iter().enumerate() {
+            if !rows.is_empty() {
+                rows.push(ConversationVisualRow {
+                    line: Line::from(""),
+                    block_index: None,
+                    menu_button_block: None,
+                    menu_button_range: None,
+                });
+            }
+            match block.kind {
+                ConversationBlockKind::User => {
+                    rows.extend(self.user_block_rows(idx, block, width));
+                }
+                ConversationBlockKind::Output => {
+                    for ol in &block.lines {
+                        rows.push(ConversationVisualRow {
+                            line: Self::line_from_output(ol),
+                            block_index: Some(idx),
+                            menu_button_block: None,
+                            menu_button_range: None,
+                        });
+                    }
+                    if let Some(elapsed) = &block.elapsed {
+                        rows.push(ConversationVisualRow {
+                            line: Line::from(Span::styled(elapsed.clone(), theme::out_dim())),
+                            block_index: Some(idx),
+                            menu_button_block: None,
+                            menu_button_range: None,
+                        });
+                    }
+                }
+            }
+        }
+        rows
+    }
+
+    fn user_block_rows(
+        &self,
+        block_index: usize,
+        block: &ConversationBlock,
+        width: u16,
+    ) -> Vec<ConversationVisualRow> {
+        let width = width as usize;
+        let input = block
+            .lines
+            .first()
+            .map(|line| line.text.as_str())
+            .unwrap_or("");
+        let submitted_at = block.submitted_at.as_deref().unwrap_or("");
+        let selected = self.selected_conversation_block == Some(block_index);
+        let action_trigger = if selected { "..." } else { "" };
+        let (line, range) = self.user_panel_line(input, action_trigger, width, true, selected);
+        vec![
+            ConversationVisualRow {
+                line,
+                block_index: Some(block_index),
+                menu_button_block: selected.then_some(block_index),
+                menu_button_range: range,
+            },
+            ConversationVisualRow {
+                line: self
+                    .user_panel_line(submitted_at, "", width, false, selected)
+                    .0,
+                block_index: Some(block_index),
+                menu_button_block: None,
+                menu_button_range: None,
+            },
+        ]
+    }
+
+    fn user_panel_line(
+        &self,
+        left: &str,
+        right: &str,
+        width: usize,
+        strong: bool,
+        selected: bool,
+    ) -> (Line<'static>, Option<(u16, u16)>) {
+        let accent = "\u{258f} ";
+        let right_len = right.chars().count();
+        let left_budget = width
+            .saturating_sub(accent.chars().count())
+            .saturating_sub(right_len)
+            .saturating_sub(3);
+        let left_text = Self::truncate_inline(left, left_budget);
+        let left_len = left_text.chars().count();
+        let fill = width.saturating_sub(accent.chars().count() + left_len + right_len);
+        let left_style = if strong {
+            if selected {
+                theme::conversation_user_selected_text()
+            } else {
+                theme::conversation_user_text()
+            }
+        } else if selected {
+            theme::conversation_user_selected_meta()
+        } else {
+            theme::conversation_user_meta()
+        };
+        let surface_style = if selected {
+            theme::conversation_user_selected_surface()
+        } else {
+            theme::panel_surface()
+        };
+        let accent_style = if selected {
+            theme::conversation_user_selected_accent()
+        } else {
+            theme::panel_accent()
+        };
+        let right_style = if selected && !right.is_empty() {
+            theme::conversation_user_action()
+        } else if selected {
+            theme::conversation_user_selected_meta()
+        } else {
+            theme::conversation_user_meta()
+        };
+        let right_start = accent.chars().count() + left_len + fill;
+        let right_range = (!right.is_empty()).then_some((
+            right_start.min(u16::MAX as usize) as u16,
+            (right_start + right_len).min(u16::MAX as usize) as u16,
+        ));
+        (
+            Line::from(vec![
+                Span::styled(accent.to_string(), accent_style),
+                Span::styled(left_text, left_style),
+                Span::styled(" ".repeat(fill), surface_style),
+                Span::styled(right.to_string(), right_style),
+            ]),
+            right_range,
+        )
+    }
+
+    fn truncate_inline(text: &str, max_chars: usize) -> String {
+        if text.chars().count() <= max_chars {
+            return text.to_string();
+        }
+        if max_chars <= 1 {
+            return "\u{2026}".to_string();
+        }
+        let mut out = text.chars().take(max_chars - 1).collect::<String>();
+        out.push('\u{2026}');
+        out
+    }
+
+    fn line_from_output(ol: &OutputLine) -> Line<'static> {
+        match ol.style {
+            OutputStyle::Help => {
+                let text = &ol.text;
+                if text.len() > 35 {
+                    let (cmd_part, desc_part) = text.split_at(35);
+                    Line::from(vec![
+                        Span::styled(cmd_part.to_string(), theme::out_help_cmd()),
+                        Span::styled(desc_part.to_string(), theme::out_help_desc()),
+                    ])
+                } else {
+                    Line::from(Span::styled(text.clone(), theme::out_help_cmd()))
+                }
+            }
+            _ => {
+                let style = match ol.style {
+                    OutputStyle::Normal => theme::out_normal(),
+                    OutputStyle::Error => theme::out_error(),
+                    OutputStyle::Success => theme::out_success(),
+                    OutputStyle::Dim => theme::out_dim(),
+                    OutputStyle::Ai => theme::out_ai(),
+                    OutputStyle::Help => unreachable!(),
+                };
+                Line::from(Span::styled(ol.text.clone(), style))
+            }
         }
     }
 
@@ -2194,6 +2837,184 @@ mod tests {
         assert!(rendered.contains("INITIALISE A WORKSPACE"));
         assert!(rendered.contains("/init"));
         assert!(rendered.contains("duumbi init"));
+    }
+
+    #[test]
+    fn conversation_render_keeps_user_block_and_output() {
+        let (mut app, textarea) = make_app();
+        app.begin_user_block("/status");
+        app.push_output("Workspace: /tmp/example", OutputStyle::Normal);
+        let (rendered, _rows) = render_app_to_string(&app, &textarea, 120, 30);
+
+        assert!(rendered.contains("/status"));
+        assert!(!rendered.contains("copy"));
+        assert!(rendered.contains("Workspace: /tmp/example"));
+    }
+
+    #[test]
+    fn conversation_render_shows_elapsed_footer() {
+        let (mut app, textarea) = make_app();
+        app.begin_user_block("/describe");
+        app.push_output("function main() -> i64 {", OutputStyle::Normal);
+        app.finish_current_output_elapsed(std::time::Duration::from_millis(1250));
+        let (rendered, _rows) = render_app_to_string(&app, &textarea, 120, 30);
+
+        assert!(rendered.contains("completed in 1.25s"));
+    }
+
+    #[test]
+    fn conversation_page_up_down_scrolls_rendered_blocks() {
+        let (mut app, mut textarea) = make_app();
+        for i in 0..20 {
+            app.begin_user_block(&format!("/status {i}"));
+            app.push_output(format!("line {i}"), OutputStyle::Normal);
+        }
+
+        let page_up = KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE);
+        app.handle_key(page_up, &mut textarea);
+        assert!(app.output_scroll_offset > 0);
+
+        let page_down = KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE);
+        app.handle_key(page_down, &mut textarea);
+        assert_eq!(app.output_scroll_offset, 0);
+    }
+
+    #[test]
+    fn conversation_feedback_blocks_render_with_spacing() {
+        let (mut app, textarea) = make_app();
+        app.begin_user_block("/help");
+        app.push_output("Slash commands:", OutputStyle::Normal);
+        app.push_feedback("Copied message.", OutputStyle::Success);
+        app.push_feedback("Copied message.", OutputStyle::Success);
+
+        let (_rendered, rows) = render_app_to_string(&app, &textarea, 120, 30);
+        let help_row = rows
+            .iter()
+            .position(|line| line.contains("Slash commands:"))
+            .expect("help output row must render");
+        let copied_rows = rows
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, line)| line.contains("Copied message.").then_some(idx))
+            .collect::<Vec<_>>();
+
+        assert_eq!(copied_rows.len(), 2);
+        assert!(
+            rows[help_row + 1].trim().is_empty(),
+            "feedback should not touch previous command output"
+        );
+        assert!(
+            rows[copied_rows[0] + 1].trim().is_empty(),
+            "consecutive feedback blocks should be separated"
+        );
+    }
+
+    #[test]
+    fn conversation_click_selects_and_toggles_user_block() {
+        let (mut app, textarea) = make_app();
+        app.begin_user_block("/status");
+        let (_rendered, rows) = render_app_to_string(&app, &textarea, 120, 30);
+        let row = rows
+            .iter()
+            .position(|line| line.contains("/status"))
+            .expect("user block row must render") as u16;
+
+        app.handle_mouse(crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::Down(MouseButton::Left),
+            column: 2,
+            row,
+            modifiers: KeyModifiers::NONE,
+        });
+        assert_eq!(app.selected_conversation_block, Some(0));
+
+        app.handle_mouse(crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::Down(MouseButton::Left),
+            column: 2,
+            row,
+            modifiers: KeyModifiers::NONE,
+        });
+        assert_eq!(app.selected_conversation_block, None);
+    }
+
+    #[test]
+    fn conversation_keyboard_selection_opens_action_menu() {
+        let (mut app, mut textarea) = make_app();
+        app.begin_user_block("/status");
+        app.begin_user_block("/help");
+
+        app.handle_key(
+            KeyEvent::new(KeyCode::Up, KeyModifiers::CONTROL),
+            &mut textarea,
+        );
+        assert_eq!(app.selected_conversation_block, Some(1));
+
+        app.handle_key(
+            KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL),
+            &mut textarea,
+        );
+        assert!(app.conversation_action_menu.is_some());
+
+        let (rendered, _rows) = render_app_to_string(&app, &textarea, 120, 30);
+        assert!(rendered.contains("Copy message"));
+    }
+
+    #[test]
+    fn conversation_selected_block_shows_action_menu_trigger() {
+        let (mut app, textarea) = make_app();
+        app.begin_user_block("/status");
+        let (_rendered, rows) = render_app_to_string(&app, &textarea, 120, 30);
+        let row = rows
+            .iter()
+            .position(|line| line.contains("/status"))
+            .expect("user block row must render") as u16;
+
+        app.handle_mouse(crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::Down(MouseButton::Left),
+            column: 2,
+            row,
+            modifiers: KeyModifiers::NONE,
+        });
+        let (rendered, rows) = render_app_to_string(&app, &textarea, 120, 30);
+        assert!(rendered.contains("..."));
+
+        let menu_row = rows
+            .iter()
+            .position(|line| line.contains("..."))
+            .expect("selected block must expose menu trigger") as u16;
+        let menu_col = rows[menu_row as usize]
+            .find("...")
+            .expect("menu trigger must be findable") as u16;
+        app.handle_mouse(crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::Down(MouseButton::Left),
+            column: menu_col,
+            row: menu_row,
+            modifiers: KeyModifiers::NONE,
+        });
+
+        let (rendered, _rows) = render_app_to_string(&app, &textarea, 120, 30);
+        assert!(rendered.contains("Copy message"));
+    }
+
+    #[test]
+    fn conversation_menu_limits_revert_to_latest_revertable_block() {
+        let (mut app, _textarea) = make_app();
+        app.begin_user_block("first change");
+        app.conversation_blocks[0]
+            .actions
+            .push(ConversationAction::Revert);
+        app.begin_user_block("second change");
+        app.conversation_blocks[1]
+            .actions
+            .push(ConversationAction::Revert);
+
+        assert_eq!(
+            app.conversation_menu_actions(0),
+            vec![ConversationAction::Copy]
+        );
+        assert_eq!(
+            app.conversation_menu_actions(1),
+            vec![ConversationAction::Copy, ConversationAction::Revert]
+        );
     }
 
     #[test]

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -229,8 +229,44 @@ impl ReplApp {
         }
     }
 
-    /// Braille spinner frames for the working indicator.
+    /// Braille spinner frames for the working indicator (80 ms per frame).
     const SPINNER: &'static [char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+    /// Pulsing dot glyphs for the active mode indicator (2.6 s cycle).
+    const MODE_DOT_GLYPHS: &'static [&'static str] = &[" ", "\u{2219}", "\u{25CF}"];
+
+    /// Duration of one full pulse cycle for the mode dot, in milliseconds.
+    const MODE_DOT_CYCLE_MS: u128 = 2_600;
+
+    // -----------------------------------------------------------------------
+    // Animation
+    // -----------------------------------------------------------------------
+
+    /// Returns the current monotonic-ish time in milliseconds since the
+    /// Unix epoch. Used as the source of truth for spinner and pulse phase
+    /// so that all animated widgets stay in sync within a single frame.
+    fn animation_now_ms() -> u128 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+    }
+
+    /// Returns the current pulsing-dot glyph for the active mode label.
+    fn mode_dot_glyph() -> &'static str {
+        let phase = (Self::animation_now_ms() % Self::MODE_DOT_CYCLE_MS) as f32
+            / Self::MODE_DOT_CYCLE_MS as f32;
+        let idx = (phase * Self::MODE_DOT_GLYPHS.len() as f32) as usize;
+        Self::MODE_DOT_GLYPHS[idx.min(Self::MODE_DOT_GLYPHS.len() - 1)]
+    }
+
+    /// Returns `true` whenever the mode-dot animation should be redrawn.
+    /// Currently always animated; the wrapper exists so the event loop can
+    /// disable redraws for accessibility settings in the future.
+    #[must_use]
+    pub fn mode_dot_animated(&self) -> bool {
+        true
+    }
 
     // -----------------------------------------------------------------------
     // Key handling
@@ -1150,29 +1186,42 @@ impl ReplApp {
         }
     }
 
-    /// REPL-06 — mode strip with active mode label and focused intent slug.
+    /// REPL-06 — mode strip with pulsing dot, active mode label, intent slug.
     fn render_mode_strip(&self, frame: &mut Frame, area: Rect) {
-        let hint = Span::styled("Shift+Tab switch mode", theme::mode_hint());
-        let sep = Span::raw("  ");
+        let dot_glyph = Self::mode_dot_glyph();
         let mode_label = self.mode.label();
-        let mode_span = Span::styled(mode_label, theme::mode_label());
 
-        let right_text = if let Some(ref slug) = self.focused_intent {
-            format!("[{slug}]")
+        // Right-side intent indicator: "intent —" (empty) or "intent [slug]".
+        let intent_label = "intent ";
+        let intent_value: String = self
+            .focused_intent
+            .as_deref()
+            .map(|s| format!("[{s}]"))
+            .unwrap_or_else(|| "—".to_string());
+
+        let hint_text = "Shift+Tab swap";
+        // Layout (left → right):
+        //   ● mode_label   intent <value>                       hint
+        //   ^^ ^^^^^^^^^   ^^^^^^^^^^^^^^^                      ^^^^
+        //   2  N           7+m                                  N
+        let left_len = 2 + mode_label.len() + 3 + intent_label.len() + intent_value.chars().count();
+        let right_len = hint_text.len();
+        let padding = (area.width as usize).saturating_sub(left_len + right_len);
+
+        let mut spans = vec![
+            Span::styled(dot_glyph, theme::mode_dot()),
+            Span::raw(" "),
+            Span::styled(mode_label, theme::mode_label()),
+            Span::raw("   "),
+            Span::styled(intent_label, theme::label_caps()),
+        ];
+        if self.focused_intent.is_some() {
+            spans.push(Span::styled(intent_value, theme::intent_slug()));
         } else {
-            String::new()
-        };
-
-        let width = area.width as usize;
-        let left_len = "Shift+Tab switch mode".len() + 2 + mode_label.len();
-        let right_len = right_text.len();
-        let padding = width.saturating_sub(left_len + right_len);
-
-        let mut spans = vec![hint, sep, mode_span, Span::raw(" ".repeat(padding))];
-
-        if !right_text.is_empty() {
-            spans.push(Span::styled(right_text, theme::intent_slug()));
+            spans.push(Span::styled(intent_value, theme::out_dim()));
         }
+        spans.push(Span::raw(" ".repeat(padding)));
+        spans.push(Span::styled(hint_text, theme::mode_hint()));
 
         frame.render_widget(Paragraph::new(Line::from(spans)), area);
     }
@@ -1331,11 +1380,7 @@ impl ReplApp {
 
     /// Renders the rust-pill activity button shown in the ACTIVITY slot.
     fn render_activity_button(&self, frame: &mut Frame, area: Rect) {
-        let frame_idx = (std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis()
-            / 80) as usize;
+        let frame_idx = (Self::animation_now_ms() / 80) as usize;
         let glyph = Self::SPINNER[frame_idx % Self::SPINNER.len()];
         // Pad to fill the slot so the rust background covers the entire pill.
         let total = area.width as usize;
@@ -1722,6 +1767,35 @@ mod tests {
     fn new_starts_in_agent_mode() {
         let (app, _) = make_app();
         assert_eq!(app.mode, ReplMode::Agent);
+    }
+
+    #[test]
+    fn truncate_path_returns_input_when_short() {
+        assert_eq!(truncate_path("/a/b", 80), "/a/b");
+    }
+
+    #[test]
+    fn truncate_path_inserts_ellipsis() {
+        let p = "/Users/foo/space/hgahub/duumbi-cli-ux/target/debug/duumbi-binary";
+        let out = truncate_path(p, 30);
+        assert!(out.chars().count() <= 30);
+        assert!(out.contains('\u{2026}'));
+        // Tail should be preserved (it carries the most identifying suffix).
+        assert!(out.ends_with("ary"));
+    }
+
+    #[test]
+    fn truncate_path_handles_unicode() {
+        let p = "/föö/bär/baz/qüüx";
+        let out = truncate_path(p, 10);
+        assert!(out.chars().count() <= 10);
+        assert!(out.contains('\u{2026}'));
+    }
+
+    #[test]
+    fn mode_dot_glyph_returns_known_value() {
+        let g = ReplApp::mode_dot_glyph();
+        assert!(ReplApp::MODE_DOT_GLYPHS.contains(&g));
     }
 
     #[test]

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -1898,6 +1898,97 @@ mod tests {
         assert_eq!(ReplApp::mode_dot_glyph(), "\u{25CF}");
     }
 
+    /// Returns the full buffer content for a rendered frame as a single
+    /// string (cells joined row by row, no separator). Used by the status
+    /// dock render tests to assert what the user actually sees.
+    fn render_to_string(width: u16, height: u16) -> (String, Vec<String>) {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        let (mut app, textarea) = make_app();
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).expect("invariant: test terminal");
+        terminal
+            .draw(|frame| app.render(frame, &textarea))
+            .expect("invariant: draw");
+        let cells = terminal.backend().buffer().content();
+        let joined: String = cells.iter().map(|c| c.symbol()).collect();
+        // Split by width to also get per-row dump for debugging.
+        let rows: Vec<String> = (0..height as usize)
+            .map(|r| {
+                cells[r * width as usize..(r + 1) * width as usize]
+                    .iter()
+                    .map(|c| c.symbol())
+                    .collect()
+            })
+            .collect();
+        let _ = &mut app;
+        let _ = &textarea;
+        (joined, rows)
+    }
+
+    #[test]
+    fn full_render_draws_status_dock_labels_at_30_rows() {
+        let (_buf, rows) = render_to_string(120, 30);
+        let last_rows = rows.iter().rev().take(4).cloned().collect::<Vec<_>>();
+        let last_chunk = last_rows.join("\n");
+        assert!(
+            last_chunk.contains("time") && last_chunk.contains("workspace"),
+            "expected status-dock labels in the last rows; got:\n{last_chunk}"
+        );
+    }
+
+    #[test]
+    fn full_render_draws_status_dock_labels_at_small_heights() {
+        // The status dock must render even when the terminal is short,
+        // because the Min(0) conversation pane should collapse first.
+        for h in [20u16, 22, 24, 28] {
+            let (_buf, rows) = render_to_string(120, h);
+            let last_rows = rows.iter().rev().take(5).cloned().collect::<Vec<_>>();
+            let last_chunk = last_rows.join("\n");
+            assert!(
+                last_chunk.contains("time") && last_chunk.contains("workspace"),
+                "h={h}: status-dock missing from last rows:\n{last_chunk}"
+            );
+        }
+    }
+
+    #[test]
+    fn full_render_draws_status_dock_labels() {
+        // Render a full frame into an in-memory buffer and verify the
+        // lowercase status-dock labels actually reach the buffer. If this
+        // ever fails silently, the status row has fallen out of the layout
+        // (e.g. from a bad constraint total or an errant early return).
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let (mut app, mut textarea) = make_app();
+        let backend = TestBackend::new(120, 30);
+        let mut terminal = Terminal::new(backend).expect("invariant: test terminal");
+        terminal
+            .draw(|frame| app.render(frame, &textarea))
+            .expect("invariant: draw");
+
+        let buf_dump = terminal.backend().buffer().content();
+        let rendered: String = buf_dump.iter().map(|c| c.symbol()).collect();
+
+        assert!(
+            rendered.contains("time"),
+            "status dock should render 'time' label; buffer:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("workspace"),
+            "status dock should render 'workspace' label"
+        );
+        assert!(
+            rendered.contains("cwd"),
+            "status dock should render 'cwd' label"
+        );
+
+        // Unused to silence the mut warning in case the test harness evolves.
+        let _ = &mut textarea;
+        let _ = &mut app;
+    }
+
     #[test]
     fn backtab_toggles_mode() {
         let (mut app, mut textarea) = make_app();

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -937,12 +937,15 @@ impl ReplApp {
         let show_card = self.show_tip && !has_output;
         let outer = frame.area();
         let page = Self::page_area(outer);
+        let input_height = if page.width >= 60 { 3u16 } else { 1u16 };
+        // header(1) + spacer(1) + spacer-before-controls(1) + mode(1) + sep(1) + prompt + sep(1) + status(1)
+        let fixed_ui_rows: u16 = 8 + input_height;
         let card_height = if show_card {
-            if page.width >= 90 { 7u16 } else { 8u16 }
+            let desired = if page.width >= 90 { 7u16 } else { 8u16 };
+            desired.min(page.height.saturating_sub(fixed_ui_rows))
         } else {
             0
         };
-        let input_height = if page.width >= 60 { 3u16 } else { 1u16 };
 
         let chunks = Layout::vertical([
             Constraint::Length(1),            // header
@@ -1103,7 +1106,13 @@ impl ReplApp {
         let accent = cols[0];
         let card_area = cols[1];
 
-        frame.render_widget(Block::default().style(theme::panel_accent_bar()), accent);
+        // U+258F LEFT ONE EIGHTH BLOCK — narrow block char that fills the
+        // full cell height, so the bar stays continuous across rows even on
+        // terminals where the box-drawing │ leaves vertical gaps.
+        let bar_lines: Vec<Line<'_>> = (0..accent.height)
+            .map(|_| Line::from(Span::styled("\u{258F}", theme::panel_accent())))
+            .collect();
+        frame.render_widget(Paragraph::new(bar_lines), accent);
 
         // Only top + bottom borders — the rust pillar on the left already
         // visually anchors the card; a full border made the right edge feel

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -4,6 +4,7 @@
 //! using ratatui. Key handling delegates to `handle_key` which returns an
 //! [`Action`] that the event loop acts on.
 
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 use chrono::Local;
@@ -122,9 +123,10 @@ fn parse_provider_kind_by_index(idx: usize) -> Option<crate::config::ProviderKin
     }
 }
 
-use super::completion::SLASH_COMMANDS;
+use super::completion::{SLASH_COMMANDS, SLASH_GROUPS, SlashGroup};
 use super::mode::{
     Action, OutputLine, OutputStyle, PanelInputMode, PanelState, ReplMode, SlashMatch,
+    SlashMenuItem,
 };
 use super::theme::tui as theme;
 
@@ -174,6 +176,12 @@ pub struct ReplApp {
     pub output_scroll_offset: usize,
     /// All matching slash-command entries (untruncated).
     pub slash_matches: Vec<SlashMatch>,
+    /// Rows currently visible in the slash menu.
+    pub slash_rows: Vec<SlashMenuItem>,
+    /// Current slash-menu filter text.
+    pub slash_filter: String,
+    /// Expanded discovery groups for the current slash-menu session.
+    pub slash_expanded_groups: HashSet<SlashGroup>,
     /// Index of the highlighted entry in the slash menu.
     pub slash_selected: usize,
     /// Scroll offset for the slash menu (first visible row index).
@@ -191,8 +199,11 @@ pub struct ReplApp {
 }
 
 impl ReplApp {
+    /// Preferred minimum number of slash-menu rows when the terminal has room.
+    const SLASH_MENU_VISIBLE: usize = 7;
+
     /// Maximum number of slash-menu rows visible at once.
-    const SLASH_MENU_VISIBLE: usize = 5;
+    const SLASH_MENU_VISIBLE_MAX: usize = 12;
 
     /// Maximum number of lines kept in the output buffer.
     const OUTPUT_BUFFER_MAX: usize = 10_000;
@@ -220,6 +231,9 @@ impl ReplApp {
             output_lines: Vec::new(),
             output_scroll_offset: 0,
             slash_matches: Vec::new(),
+            slash_rows: Vec::new(),
+            slash_filter: String::new(),
+            slash_expanded_groups: HashSet::new(),
             slash_selected: 0,
             slash_scroll_offset: 0,
             show_tip,
@@ -288,26 +302,10 @@ impl ReplApp {
                 Action::Continue
             }
 
-            // Enter: if single slash match → execute directly; multi → accept into textarea; else submit
+            // Enter: execute selected slash command, expand discovery groups, or submit input.
             KeyCode::Enter => {
-                if self.slash_matches.len() == 1 {
-                    // Single match: execute it directly.
-                    let cmd = self.slash_matches[0].command.clone();
-                    textarea.move_cursor(CursorMove::Head);
-                    textarea.delete_line_by_end();
-                    self.slash_matches.clear();
-                    self.slash_selected = 0;
-                    return Action::Submit(cmd);
-                }
-                if !self.slash_matches.is_empty() {
-                    // Multiple matches: execute the highlighted command directly.
-                    let cmd = self.slash_matches[self.slash_selected].command.clone();
-                    textarea.move_cursor(CursorMove::Head);
-                    textarea.delete_line_by_end();
-                    self.slash_matches.clear();
-                    self.slash_selected = 0;
-                    self.slash_scroll_offset = 0;
-                    return Action::Submit(cmd);
+                if let Some(action) = self.activate_selected_slash_row(textarea) {
+                    return action;
                 }
 
                 let input: String = textarea.lines().join("\n");
@@ -324,7 +322,7 @@ impl ReplApp {
             }
 
             // Up: move slash menu selection up (scrolls window)
-            KeyCode::Up if !self.slash_matches.is_empty() => {
+            KeyCode::Up if !self.slash_rows.is_empty() => {
                 if self.slash_selected > 0 {
                     self.slash_selected -= 1;
                     if self.slash_selected < self.slash_scroll_offset {
@@ -335,8 +333,8 @@ impl ReplApp {
             }
 
             // Down: move slash menu selection down (scrolls window)
-            KeyCode::Down if !self.slash_matches.is_empty() => {
-                let max = self.slash_matches.len().saturating_sub(1);
+            KeyCode::Down if !self.slash_rows.is_empty() => {
+                let max = self.slash_rows.len().saturating_sub(1);
                 if self.slash_selected < max {
                     self.slash_selected += 1;
                     let visible = Self::SLASH_MENU_VISIBLE;
@@ -348,22 +346,33 @@ impl ReplApp {
             }
 
             // Tab: accept selected slash command without submitting
-            KeyCode::Tab if !self.slash_matches.is_empty() => {
-                let cmd = self.slash_matches[self.slash_selected].command.clone();
-                textarea.move_cursor(CursorMove::Head);
-                textarea.delete_line_by_end();
-                textarea.insert_str(&cmd);
-                self.slash_matches.clear();
-                self.slash_selected = 0;
-                self.slash_scroll_offset = 0;
+            KeyCode::Tab if !self.slash_rows.is_empty() => {
+                if let Some(cmd) = self.selected_slash_command() {
+                    textarea.move_cursor(CursorMove::Head);
+                    textarea.delete_line_by_end();
+                    textarea.insert_str(&cmd);
+                    self.clear_slash_menu();
+                } else {
+                    self.toggle_selected_slash_group();
+                }
+                Action::Continue
+            }
+
+            // Right: expand selected slash discovery group.
+            KeyCode::Right if !self.slash_rows.is_empty() => {
+                self.expand_selected_slash_group();
+                Action::Continue
+            }
+
+            // Left: collapse selected slash discovery group.
+            KeyCode::Left if !self.slash_rows.is_empty() => {
+                self.collapse_selected_slash_group();
                 Action::Continue
             }
 
             // Esc: dismiss slash menu
             KeyCode::Esc => {
-                self.slash_matches.clear();
-                self.slash_selected = 0;
-                self.slash_scroll_offset = 0;
+                self.clear_slash_menu();
                 Action::Continue
             }
 
@@ -879,20 +888,147 @@ impl ReplApp {
     /// populates `slash_matches` with all results. Clears matches when input
     /// does not start with `/`.
     pub fn update_slash_matches(&mut self, input: &str) {
-        if input.starts_with('/') {
+        if input.starts_with('/') && !input.contains('\n') {
+            let filter_changed = self.slash_filter != input;
+            let was_discovery = self.slash_filter == "/";
+            let is_discovery = input == "/";
+            if !was_discovery || !is_discovery {
+                self.slash_expanded_groups.clear();
+            }
+            self.slash_filter = input.to_string();
             self.slash_matches = SLASH_COMMANDS
                 .iter()
-                .filter(|(cmd, _)| cmd.starts_with(input) && *cmd != input)
-                .map(|(cmd, desc)| SlashMatch {
-                    command: (*cmd).to_string(),
-                    description: (*desc).to_string(),
+                .filter(|entry| entry.command.starts_with(input))
+                .map(|entry| SlashMatch {
+                    command: entry.command.to_string(),
+                    description: entry.description.to_string(),
+                    group: entry.group,
+                    matched_prefix_len: input.len().min(entry.command.len()),
                 })
                 .collect();
+            self.rebuild_slash_rows();
+            if filter_changed {
+                self.slash_selected = 0;
+                self.slash_scroll_offset = 0;
+            }
         } else {
-            self.slash_matches.clear();
+            self.clear_slash_menu();
         }
+        self.clamp_slash_selection();
+    }
+
+    fn clear_slash_menu(&mut self) {
+        self.slash_matches.clear();
+        self.slash_rows.clear();
+        self.slash_filter.clear();
+        self.slash_expanded_groups.clear();
         self.slash_selected = 0;
         self.slash_scroll_offset = 0;
+    }
+
+    fn rebuild_slash_rows(&mut self) {
+        if self.slash_filter == "/" {
+            let mut rows = Vec::new();
+            for group in SLASH_GROUPS {
+                let group_matches: Vec<SlashMatch> = self
+                    .slash_matches
+                    .iter()
+                    .filter(|sm| sm.group == *group)
+                    .cloned()
+                    .collect();
+                if group_matches.is_empty() {
+                    continue;
+                }
+                let expanded = self.slash_expanded_groups.contains(group);
+                rows.push(SlashMenuItem::Group {
+                    group: *group,
+                    count: group_matches.len(),
+                    expanded,
+                });
+                if expanded {
+                    rows.extend(group_matches.into_iter().map(SlashMenuItem::Command));
+                }
+            }
+            self.slash_rows = rows;
+        } else {
+            self.slash_rows = self
+                .slash_matches
+                .iter()
+                .cloned()
+                .map(SlashMenuItem::Command)
+                .collect();
+        }
+    }
+
+    fn clamp_slash_selection(&mut self) {
+        if self.slash_rows.is_empty() {
+            self.slash_selected = 0;
+            self.slash_scroll_offset = 0;
+            return;
+        }
+        self.slash_selected = self
+            .slash_selected
+            .min(self.slash_rows.len().saturating_sub(1));
+        if self.slash_scroll_offset > self.slash_selected {
+            self.slash_scroll_offset = self.slash_selected;
+        }
+        if self.slash_selected >= self.slash_scroll_offset + Self::SLASH_MENU_VISIBLE {
+            self.slash_scroll_offset = self.slash_selected + 1 - Self::SLASH_MENU_VISIBLE;
+        }
+    }
+
+    fn selected_slash_command(&self) -> Option<String> {
+        match self.slash_rows.get(self.slash_selected) {
+            Some(SlashMenuItem::Command(sm)) => Some(sm.command.clone()),
+            _ => None,
+        }
+    }
+
+    fn selected_slash_group(&self) -> Option<SlashGroup> {
+        match self.slash_rows.get(self.slash_selected) {
+            Some(SlashMenuItem::Group { group, .. }) => Some(*group),
+            _ => None,
+        }
+    }
+
+    fn activate_selected_slash_row(&mut self, textarea: &mut TextArea<'_>) -> Option<Action> {
+        if let Some(cmd) = self.selected_slash_command() {
+            textarea.move_cursor(CursorMove::Head);
+            textarea.delete_line_by_end();
+            self.clear_slash_menu();
+            return Some(Action::Submit(cmd));
+        }
+        if self.selected_slash_group().is_some() {
+            self.toggle_selected_slash_group();
+            return Some(Action::Continue);
+        }
+        None
+    }
+
+    fn toggle_selected_slash_group(&mut self) {
+        if let Some(group) = self.selected_slash_group() {
+            if !self.slash_expanded_groups.remove(&group) {
+                self.slash_expanded_groups.insert(group);
+            }
+            self.rebuild_slash_rows();
+            self.clamp_slash_selection();
+        }
+    }
+
+    fn expand_selected_slash_group(&mut self) {
+        if let Some(group) = self.selected_slash_group() {
+            self.slash_expanded_groups.insert(group);
+            self.rebuild_slash_rows();
+            self.clamp_slash_selection();
+        }
+    }
+
+    fn collapse_selected_slash_group(&mut self) {
+        if let Some(group) = self.selected_slash_group() {
+            self.slash_expanded_groups.remove(&group);
+            self.rebuild_slash_rows();
+            self.clamp_slash_selection();
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -938,8 +1074,8 @@ impl ReplApp {
         let outer = frame.area();
         let page = Self::page_area(outer);
         let input_height = if page.width >= 60 { 3u16 } else { 1u16 };
-        // header(1) + spacer(1) + spacer-before-controls(1) + mode(1) + sep(1) + prompt + sep(1) + status(1)
-        let fixed_ui_rows: u16 = 8 + input_height;
+        // header(1) + spacer(1) + spacer-before-controls(1) + mode(1) + prompt + status(1)
+        let fixed_ui_rows: u16 = 5 + input_height;
         let card_height = if show_card {
             let desired = if page.width >= 90 { 7u16 } else { 8u16 };
             desired.min(page.height.saturating_sub(fixed_ui_rows))
@@ -954,9 +1090,7 @@ impl ReplApp {
             Constraint::Min(0),               // conversation
             Constraint::Length(1),            // spacer before controls
             Constraint::Length(1),            // mode row
-            Constraint::Length(1),            // separator
             Constraint::Length(input_height), // prompt
-            Constraint::Length(1),            // separator
             Constraint::Length(1),            // status row
         ])
         .split(page);
@@ -967,24 +1101,24 @@ impl ReplApp {
         }
         self.render_conversation_pane(frame, chunks[3]);
         self.render_mode_strip(frame, chunks[5]);
-        self.render_hairline_with_dots(frame, chunks[6]);
-        self.render_prompt_well(frame, chunks[7], textarea);
-        self.render_hairline_with_dots(frame, chunks[8]);
-        self.render_status_dock(frame, chunks[9]);
+        self.render_prompt_well(frame, chunks[6], textarea);
+        self.render_status_dock(frame, chunks[7]);
 
-        if let Some(overlay_height) = self.overlay_height() {
-            let overlay_width = match &self.panel {
-                PanelState::None => page.width.saturating_sub(6).clamp(40, 96),
-                PanelState::ModelSelector { .. } => page.width.saturating_sub(4).clamp(52, 110),
-            };
-            let overlay_area = Self::overlay_rect(page, chunks[7], overlay_width, overlay_height);
-            match &self.panel {
-                PanelState::None => self.render_slash_menu(frame, overlay_area),
-                PanelState::ModelSelector {
-                    selected,
-                    input_mode,
-                    status_msg,
-                } => {
+        match &self.panel {
+            PanelState::None => {
+                if let Some(overlay_area) = self.slash_overlay_rect(page, chunks[6]) {
+                    self.render_slash_menu(frame, overlay_area);
+                }
+            }
+            PanelState::ModelSelector {
+                selected,
+                input_mode,
+                status_msg,
+            } => {
+                if let Some(overlay_height) = self.overlay_height() {
+                    let overlay_width = page.width.saturating_sub(4).clamp(52, 110);
+                    let overlay_area =
+                        Self::overlay_rect(page, chunks[6], overlay_width, overlay_height);
                     self.render_model_panel(frame, overlay_area, *selected, input_mode, status_msg)
                 }
             }
@@ -1009,7 +1143,7 @@ impl ReplApp {
     fn overlay_height(&self) -> Option<u16> {
         match &self.panel {
             PanelState::None => {
-                let total = self.slash_matches.len();
+                let total = self.slash_rows.len();
                 if total == 0 {
                     None
                 } else {
@@ -1057,6 +1191,28 @@ impl ReplApp {
         }
     }
 
+    /// Returns a prompt-aligned slash menu rectangle directly above the prompt.
+    fn slash_overlay_rect(&self, page: Rect, anchor: Rect) -> Option<Rect> {
+        let total = self.slash_rows.len();
+        if total == 0 {
+            return None;
+        }
+
+        let available_above = anchor.y.saturating_sub(page.y);
+        if available_above < 5 {
+            return None;
+        }
+
+        let max_visible = available_above
+            .saturating_sub(4)
+            .max(1)
+            .min(Self::SLASH_MENU_VISIBLE_MAX as u16) as usize;
+        let visible = total.min(max_visible);
+        let height = (visible as u16).saturating_add(4).min(available_above);
+        let y = anchor.y.saturating_sub(height);
+        Some(Rect::new(page.x, y, page.width, height))
+    }
+
     /// Returns an overlay rectangle anchored above the prompt well.
     fn overlay_rect(page: Rect, anchor: Rect, width: u16, height: u16) -> Rect {
         let width = width.min(page.width).max(1);
@@ -1096,7 +1252,7 @@ impl ReplApp {
 
     /// REPL-02 — inset empty-state card with examples and stronger onboarding.
     fn render_empty_state_card(&self, frame: &mut Frame, area: Rect) {
-        use ratatui::widgets::{Block, Borders, Padding};
+        use ratatui::widgets::{Block, Padding};
 
         if area.width < 12 || area.height < 5 {
             return;
@@ -1112,20 +1268,18 @@ impl ReplApp {
         let bar_lines: Vec<Line<'_>> = (0..accent.height)
             .map(|_| Line::from(Span::styled("\u{258F}", theme::panel_accent())))
             .collect();
-        frame.render_widget(Paragraph::new(bar_lines), accent);
+        frame.render_widget(
+            Paragraph::new(bar_lines).style(theme::panel_surface()),
+            accent,
+        );
 
-        // Only top + bottom borders — the rust pillar on the left already
-        // visually anchors the card; a full border made the right edge feel
-        // too heavy in the rendered output.
         let block = Block::default()
-            .borders(Borders::TOP | Borders::BOTTOM)
-            .border_style(theme::panel_border())
-            .padding(Padding::new(2, 2, 0, 0))
+            .padding(Padding::new(2, 2, 1, 1))
             .style(theme::panel_surface());
         let inner = block.inner(card_area);
         frame.render_widget(block, card_area);
 
-        let (badge_text, heading, left_lines, right_lines) = if !self.has_workspace {
+        let (badge_text, heading, example_lines) = if !self.has_workspace {
             (
                 " no workspace ",
                 "INITIALISE A WORKSPACE",
@@ -1139,10 +1293,6 @@ impl ReplApp {
                         theme::out_dim(),
                     )]),
                 ],
-                vec![Line::from(vec![Span::styled(
-                    "Once initialised, natural language requests work directly in the prompt.",
-                    theme::out_dim(),
-                )])],
             )
         } else {
             (
@@ -1164,56 +1314,27 @@ impl ReplApp {
                             "\"Add a function that adds two numbers\"",
                             theme::dock_value(),
                         ),
-                        Span::styled("  natural language works too", theme::out_dim()),
+                        Span::styled(" - natural language works too", theme::out_dim()),
                     ]),
                 ],
-                vec![Line::from(vec![Span::styled(
-                    "Use the prompt below for direct requests, or switch to intent mode when you want focused planning.",
-                    theme::out_dim(),
-                )])],
             )
         };
 
-        if inner.width >= 70 {
-            let rows = Layout::vertical([
-                Constraint::Length(1),
-                Constraint::Length(1),
-                Constraint::Length(1),
-                Constraint::Min(1),
-            ])
-            .split(inner);
-            let header = Line::from(vec![
+        let mut body = vec![
+            Line::from(vec![
                 Span::styled(badge_text, theme::pill_outline()),
                 Span::raw("  "),
                 Span::styled(heading, theme::label_caps()),
-            ]);
-            frame.render_widget(Paragraph::new(header), rows[0]);
-
-            let cols = Layout::horizontal([Constraint::Percentage(48), Constraint::Percentage(52)])
-                .split(rows[2]);
-            frame.render_widget(
-                Paragraph::new(left_lines).wrap(Wrap { trim: false }),
-                cols[0],
-            );
-            frame.render_widget(
-                Paragraph::new(right_lines).wrap(Wrap { trim: false }),
-                cols[1],
-            );
-        } else {
-            let body = vec![
-                Line::from(vec![
-                    Span::styled(badge_text, theme::pill_outline()),
-                    Span::raw("  "),
-                    Span::styled(heading, theme::label_caps()),
-                ]),
-                Line::from(""),
-                left_lines[0].clone(),
-                left_lines.get(1).cloned().unwrap_or_else(|| Line::from("")),
-                Line::from(""),
-                right_lines[0].clone(),
-            ];
-            frame.render_widget(Paragraph::new(body).wrap(Wrap { trim: false }), inner);
-        }
+            ]),
+            Line::from(""),
+        ];
+        body.extend(example_lines);
+        frame.render_widget(
+            Paragraph::new(body)
+                .style(theme::panel_surface())
+                .wrap(Wrap { trim: false }),
+            inner,
+        );
     }
 
     /// REPL-03 — scrollable conversation pane, bottom-aligned.
@@ -1301,7 +1422,7 @@ impl ReplApp {
 
         let mut spans = vec![
             Span::styled(" Shift ", theme::keycap()),
-            Span::raw(" "),
+            Span::styled(" + ", theme::hairline()),
             Span::styled(" Tab ", theme::keycap()),
             Span::styled(" switch mode  ", theme::mode_hint()),
             Span::styled(format!(" {dot_glyph} {mode_label} "), theme::mode_pill()),
@@ -1316,29 +1437,6 @@ impl ReplApp {
         }
 
         frame.render_widget(Paragraph::new(Line::from(spans)), area);
-    }
-
-    /// REPL-07 / REPL-09 — hairline separator with rust dots at both edges.
-    ///
-    /// On terminals narrower than 4 columns, falls back to a plain dim line.
-    fn render_hairline_with_dots(&self, frame: &mut Frame, area: Rect) {
-        let width = area.width as usize;
-        if width < 4 {
-            let line_str = "─".repeat(width);
-            frame.render_widget(
-                Paragraph::new(Span::styled(line_str, theme::hairline_dim())),
-                area,
-            );
-            return;
-        }
-        // Body: dim hairline between the two rust dots.
-        let body = "─".repeat(width.saturating_sub(2));
-        let line = Line::from(vec![
-            Span::styled("\u{2022}", theme::chevron()),
-            Span::styled(body, theme::hairline_dim()),
-            Span::styled("\u{2022}", theme::chevron()),
-        ]);
-        frame.render_widget(Paragraph::new(line), area);
     }
 
     /// REPL-08 — prompt input well with rust focus ring and placeholder.
@@ -1486,15 +1584,10 @@ impl ReplApp {
     }
 
     /// Renders the inline slash-command completion menu as an overlay.
-    ///
-    /// The selected entry is highlighted with a cyan foreground; all others
-    /// use the default terminal style. When the total number of matches
-    /// exceeds [`Self::SLASH_MENU_VISIBLE`], a scroll indicator (e.g.
-    /// `3/12`) is shown at the bottom.
     fn render_slash_menu(&self, frame: &mut Frame, area: Rect) {
         use ratatui::widgets::{Block, Borders, Padding};
 
-        if self.slash_matches.is_empty() {
+        if self.slash_rows.is_empty() {
             return;
         }
 
@@ -1502,24 +1595,56 @@ impl ReplApp {
         let block = Block::default()
             .borders(Borders::ALL)
             .border_style(theme::panel_border())
-            .padding(Padding::new(1, 1, 1, 1))
+            .padding(Padding::new(1, 1, 0, 0))
             .style(theme::panel_surface());
         let inner = block.inner(area);
         frame.render_widget(block, area);
 
-        let total = self.slash_matches.len();
-        let visible = total.min(Self::SLASH_MENU_VISIBLE);
-        let has_indicator = total > Self::SLASH_MENU_VISIBLE;
-        let row_count = if has_indicator { visible + 1 } else { visible };
+        if inner.height < 3 {
+            return;
+        }
 
-        let row_areas = Layout::vertical(
-            std::iter::repeat_n(Constraint::Length(1), row_count).collect::<Vec<_>>(),
+        let header = if self.slash_filter == "/" {
+            Line::from(vec![
+                Span::styled("DISCOVER", theme::slash_group()),
+                Span::styled(
+                    format!(
+                        "  {} commands across {} groups",
+                        SLASH_COMMANDS.len(),
+                        SLASH_GROUPS.len()
+                    ),
+                    theme::dock_value(),
+                ),
+            ])
+        } else {
+            Line::from(vec![
+                Span::styled("FILTER", theme::slash_group()),
+                Span::styled("  matching ", theme::dock_value()),
+                Span::styled(self.slash_filter.as_str(), theme::keycap()),
+                Span::styled(
+                    format!("  {} matches", self.slash_matches.len()),
+                    theme::out_dim(),
+                ),
+            ])
+        };
+
+        let body_capacity = inner.height.saturating_sub(2) as usize;
+        let total = self.slash_rows.len();
+        let visible = total.min(body_capacity);
+        if visible == 0 {
+            return;
+        }
+        let offset = self.slash_scroll_offset.min(total.saturating_sub(1));
+
+        let rows = Layout::vertical(
+            std::iter::repeat_n(Constraint::Length(1), visible + 2).collect::<Vec<_>>(),
         )
         .split(inner);
 
-        let offset = self.slash_scroll_offset;
-        for (i, sm) in self
-            .slash_matches
+        frame.render_widget(Paragraph::new(header), rows[0]);
+
+        for (i, item) in self
+            .slash_rows
             .iter()
             .skip(offset)
             .take(visible)
@@ -1527,34 +1652,111 @@ impl ReplApp {
         {
             let abs_index = offset + i;
             let is_selected = abs_index == self.slash_selected;
-            let prefix = if is_selected { "> " } else { "  " };
-            let text = format!("{prefix}{:<20}  {}", sm.command, sm.description);
-
-            let style = if is_selected {
-                theme::slash_selected()
-            } else {
-                theme::out_dim()
-            };
-
-            frame.render_widget(Paragraph::new(Span::styled(text, style)), row_areas[i]);
+            let row = rows[i + 1];
+            if is_selected {
+                frame.render_widget(Block::default().style(theme::slash_selected_row()), row);
+            }
+            match item {
+                SlashMenuItem::Group {
+                    group,
+                    count,
+                    expanded,
+                } => self.render_slash_group_row(frame, row, *group, *count, *expanded),
+                SlashMenuItem::Command(sm) => {
+                    self.render_slash_command_row(frame, row, sm, is_selected);
+                }
+            }
         }
 
-        // Scroll indicator: "  3/12 ↑↓"
-        if has_indicator {
-            let pos = self.slash_selected + 1;
-            let arrows = match (offset > 0, offset + visible < total) {
-                (true, true) => " \u{2191}\u{2193}",
-                (true, false) => " \u{2191}",
-                (false, true) => " \u{2193}",
-                (false, false) => "",
-            };
-            let indicator = format!("  {pos}/{total}{arrows}");
-            let style = theme::out_dim();
-            frame.render_widget(
-                Paragraph::new(Span::styled(indicator, style)),
-                row_areas[visible],
-            );
-        }
+        let pos = self.slash_selected.saturating_add(1).min(total);
+        let arrows = match (offset > 0, offset + visible < total) {
+            (true, true) => " \u{2191}\u{2193}",
+            (true, false) => " \u{2191}",
+            (false, true) => " \u{2193}",
+            (false, false) => "",
+        };
+        let footer = if self.slash_filter == "/" {
+            format!(
+                " \u{2191}\u{2193} navigate   \u{2192}/Enter expand   Tab complete   Esc close   {pos}/{total}{arrows}"
+            )
+        } else {
+            format!(
+                " \u{2191}\u{2193} navigate   Tab complete   Enter run   Esc close   {pos}/{total}{arrows}"
+            )
+        };
+        frame.render_widget(
+            Paragraph::new(Span::styled(footer, theme::out_dim())),
+            rows[visible + 1],
+        );
+    }
+
+    fn render_slash_group_row(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        group: SlashGroup,
+        count: usize,
+        expanded: bool,
+    ) {
+        let marker = if expanded { "\u{25be}" } else { "\u{203a}" };
+        let count_text = count.to_string();
+        let label = group.label();
+        let pad = area
+            .width
+            .saturating_sub((label.len() + count_text.len() + 5) as u16) as usize;
+        let line = Line::from(vec![
+            Span::styled(format!(" {marker} "), theme::slash_selected()),
+            Span::styled(label, theme::slash_group()),
+            Span::raw(" ".repeat(pad)),
+            Span::styled(count_text, theme::out_dim()),
+        ]);
+        frame.render_widget(Paragraph::new(line), area);
+    }
+
+    fn render_slash_command_row(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        sm: &SlashMatch,
+        selected: bool,
+    ) {
+        let command_width = area.width.saturating_sub(28).clamp(18, 34);
+        let cols = Layout::horizontal([
+            Constraint::Length(3),
+            Constraint::Length(command_width),
+            Constraint::Min(1),
+        ])
+        .split(area);
+        let marker = if selected { "\u{25cf}" } else { "\u{00b7}" };
+        frame.render_widget(
+            Paragraph::new(Span::styled(format!(" {marker} "), theme::slash_selected())),
+            cols[0],
+        );
+        frame.render_widget(Paragraph::new(self.slash_command_line(sm)), cols[1]);
+        frame.render_widget(
+            Paragraph::new(Span::styled(
+                sm.description.as_str(),
+                theme::dock_value_muted(),
+            )),
+            cols[2],
+        );
+    }
+
+    fn slash_command_line<'a>(&self, sm: &'a SlashMatch) -> Line<'a> {
+        let split_at = sm
+            .matched_prefix_len
+            .min(sm.command.len())
+            .min(sm.command.chars().count());
+        let byte_split = sm
+            .command
+            .char_indices()
+            .nth(split_at)
+            .map_or(sm.command.len(), |(idx, _)| idx);
+        let (matched, rest) = sm.command.split_at(byte_split);
+        Line::from(vec![
+            Span::styled(matched, theme::slash_match()),
+            Span::styled(rest, theme::slash_command()),
+        ])
     }
 
     /// Renders the interactive model/provider selector panel.
@@ -1872,6 +2074,28 @@ mod tests {
         (app, textarea)
     }
 
+    fn make_app_with_workspace_state(
+        has_workspace: bool,
+        show_tip: bool,
+    ) -> (ReplApp, TextArea<'static>) {
+        let tmp = tempfile::TempDir::new().expect("invariant: tempdir");
+        let session_mgr = if has_workspace {
+            Some(SessionManager::load_or_create(tmp.path()).expect("invariant: session manager"))
+        } else {
+            None
+        };
+        let app = ReplApp::new(
+            DuumbiConfig::default(),
+            tmp.path().to_path_buf(),
+            None,
+            session_mgr,
+            has_workspace,
+            show_tip,
+        );
+        let textarea = TextArea::default();
+        (app, textarea)
+    }
+
     #[test]
     fn new_starts_in_agent_mode() {
         let (app, _) = make_app();
@@ -1910,14 +2134,18 @@ mod tests {
     /// Returns the full buffer content for a rendered frame as a single
     /// string (cells joined row by row, no separator). Used by the status
     /// dock render tests to assert what the user actually sees.
-    fn render_to_string(width: u16, height: u16) -> (String, Vec<String>) {
+    fn render_app_to_string(
+        app: &ReplApp,
+        textarea: &TextArea<'_>,
+        width: u16,
+        height: u16,
+    ) -> (String, Vec<String>) {
         use ratatui::Terminal;
         use ratatui::backend::TestBackend;
-        let (mut app, textarea) = make_app();
         let backend = TestBackend::new(width, height);
         let mut terminal = Terminal::new(backend).expect("invariant: test terminal");
         terminal
-            .draw(|frame| app.render(frame, &textarea))
+            .draw(|frame| app.render(frame, textarea))
             .expect("invariant: draw");
         let cells = terminal.backend().buffer().content();
         let joined: String = cells.iter().map(|c| c.symbol()).collect();
@@ -1930,9 +2158,86 @@ mod tests {
                     .collect()
             })
             .collect();
-        let _ = &mut app;
-        let _ = &textarea;
         (joined, rows)
+    }
+
+    fn render_to_string(width: u16, height: u16) -> (String, Vec<String>) {
+        let (app, textarea) = make_app();
+        render_app_to_string(&app, &textarea, width, height)
+    }
+
+    #[test]
+    fn empty_workspace_tip_uses_single_column_copy() {
+        let (app, textarea) = make_app_with_workspace_state(true, true);
+        let (rendered, rows) = render_app_to_string(&app, &textarea, 120, 30);
+
+        assert!(rendered.contains(" empty workspace "));
+        assert!(rendered.contains("TRY ONE OF THESE"));
+        assert!(rendered.contains("/intent create"));
+        assert!(rendered.contains("\"Build a calculator with add and multiply\""));
+        assert!(!rendered.contains("Use the prompt"));
+
+        let card_rows = rows.iter().skip(2).take(9).cloned().collect::<Vec<_>>();
+        let card_chunk = card_rows.join("\n");
+        assert!(
+            !card_chunk.contains('\u{2500}'),
+            "empty-state card should not render top/bottom borders:\n{card_chunk}"
+        );
+    }
+
+    #[test]
+    fn no_workspace_tip_uses_single_column_copy() {
+        let (app, textarea) = make_app_with_workspace_state(false, true);
+        let (rendered, _rows) = render_app_to_string(&app, &textarea, 120, 30);
+
+        assert!(rendered.contains(" no workspace "));
+        assert!(rendered.contains("INITIALISE A WORKSPACE"));
+        assert!(rendered.contains("/init"));
+        assert!(rendered.contains("duumbi init"));
+    }
+
+    #[test]
+    fn slash_menu_discovery_render_shows_collapsed_groups() {
+        let (mut app, textarea) = make_app();
+        app.update_slash_matches("/");
+        let (rendered, _rows) = render_app_to_string(&app, &textarea, 120, 30);
+
+        assert!(rendered.contains("DISCOVER"));
+        assert!(rendered.contains("BUILD & RUN"));
+        assert!(rendered.contains("INTENT"));
+        assert!(rendered.contains("SYSTEM"));
+        assert!(!rendered.contains("/build"));
+    }
+
+    #[test]
+    fn slash_menu_filter_render_shows_prefix_matches() {
+        let (mut app, textarea) = make_app();
+        app.update_slash_matches("/in");
+        let (rendered, _rows) = render_app_to_string(&app, &textarea, 120, 30);
+
+        assert!(rendered.contains("FILTER"));
+        assert!(rendered.contains("/intent"));
+        assert!(rendered.contains("/intent create"));
+        assert!(rendered.contains("/init"));
+    }
+
+    #[test]
+    fn slash_menu_enter_expands_group_then_runs_command() {
+        let (mut app, mut textarea) = make_app();
+        app.update_slash_matches("/");
+
+        let enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+        let action = app.handle_key(enter, &mut textarea);
+        assert!(matches!(action, Action::Continue));
+        assert!(
+            app.slash_rows
+                .iter()
+                .any(|row| matches!(row, SlashMenuItem::Command(sm) if sm.command == "/build"))
+        );
+
+        app.slash_selected = 1;
+        let action = app.handle_key(enter, &mut textarea);
+        assert!(matches!(action, Action::Submit(cmd) if cmd == "/build"));
     }
 
     #[test]
@@ -2040,6 +2345,7 @@ mod tests {
         let (mut app, _) = make_app();
         app.update_slash_matches("/bui");
         assert!(!app.slash_matches.is_empty());
+        assert!(!app.slash_rows.is_empty());
         assert!(app.slash_matches.iter().any(|m| m.command == "/build"));
     }
 
@@ -2050,6 +2356,7 @@ mod tests {
         assert!(!app.slash_matches.is_empty());
         app.update_slash_matches("hello");
         assert!(app.slash_matches.is_empty());
+        assert!(app.slash_rows.is_empty());
     }
 
     #[test]
@@ -2059,13 +2366,33 @@ mod tests {
         app.update_slash_matches("/");
         // There are more than 5 total slash commands
         assert!(app.slash_matches.len() > 5);
+        assert!(app.slash_rows.iter().all(|row| matches!(
+            row,
+            SlashMenuItem::Group {
+                expanded: false,
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn slash_menu_filter_rows_include_exact_match_while_typing() {
+        let (mut app, _) = make_app();
+        app.update_slash_matches("/build");
+
+        assert!(app.slash_matches.iter().any(|m| m.command == "/build"));
+        assert!(
+            app.slash_rows
+                .iter()
+                .any(|row| matches!(row, SlashMenuItem::Command(sm) if sm.command == "/build"))
+        );
     }
 
     #[test]
     fn slash_menu_scroll_offset_adjusts_on_down() {
         let (mut app, mut textarea) = make_app();
-        app.update_slash_matches("/");
-        let total = app.slash_matches.len();
+        app.update_slash_matches("/de");
+        let total = app.slash_rows.len();
         assert!(total > ReplApp::SLASH_MENU_VISIBLE);
 
         let down = KeyEvent::new(KeyCode::Down, KeyModifiers::NONE);
@@ -2082,7 +2409,7 @@ mod tests {
     #[test]
     fn slash_menu_scroll_offset_adjusts_on_up() {
         let (mut app, mut textarea) = make_app();
-        app.update_slash_matches("/");
+        app.update_slash_matches("/de");
 
         let down = KeyEvent::new(KeyCode::Down, KeyModifiers::NONE);
         let up = KeyEvent::new(KeyCode::Up, KeyModifiers::NONE);
@@ -2110,6 +2437,7 @@ mod tests {
         let key = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
         app.handle_key(key, &mut textarea);
         assert!(app.slash_matches.is_empty());
+        assert!(app.slash_rows.is_empty());
     }
 
     #[test]

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -468,22 +468,23 @@ impl ReplApp {
 
     /// Handles mouse events when the terminal delivers them.
     ///
-    /// The REPL does not enable global mouse capture by default, so terminals
-    /// can keep native drag-selection available.
-    #[allow(dead_code)]
-    pub fn handle_mouse(&mut self, mouse: crossterm::event::MouseEvent) {
+    /// The REPL enables only basic mouse reporting, avoiding drag-motion
+    /// capture so terminals can keep native text selection available.
+    pub fn handle_mouse(&mut self, mouse: crossterm::event::MouseEvent) -> bool {
         use crossterm::event::MouseEventKind;
         match mouse.kind {
             MouseEventKind::ScrollUp => {
                 self.scroll_conversation_up(3, 1, 80);
+                true
             }
             MouseEventKind::ScrollDown => {
                 self.scroll_conversation_down(3);
+                true
             }
             MouseEventKind::Down(MouseButton::Left) => {
-                self.handle_conversation_click(mouse.column, mouse.row);
+                self.handle_conversation_click(mouse.column, mouse.row)
             }
-            _ => {}
+            _ => false,
         }
     }
 
@@ -1398,9 +1399,9 @@ impl ReplApp {
         idx
     }
 
-    fn handle_conversation_click(&mut self, column: u16, row: u16) {
+    fn handle_conversation_click(&mut self, column: u16, row: u16) -> bool {
         let Some(area) = self.last_conversation_area.get() else {
-            return;
+            return false;
         };
 
         if let Some((menu_area, actions)) = self.conversation_action_menu_rect(area)
@@ -1412,24 +1413,25 @@ impl ReplApp {
             {
                 self.execute_conversation_action(menu.block_index, action);
             }
-            return;
+            return true;
         }
 
         if self.conversation_action_menu.is_some() {
             self.conversation_action_menu = None;
+            return true;
         }
 
         if !self.rect_contains(area, column, row) {
-            return;
+            return false;
         }
 
         let layout = self.visible_conversation_layout(area);
         let relative_y = row.saturating_sub(area.y) as usize;
         if relative_y < layout.padding {
-            return;
+            return false;
         }
         let Some(visual_row) = layout.rows.get(relative_y - layout.padding) else {
-            return;
+            return false;
         };
 
         if let (Some(block_index), Some((start, end))) =
@@ -1439,18 +1441,18 @@ impl ReplApp {
             && self.selected_conversation_block == Some(block_index)
         {
             self.conversation_action_menu = Some(ConversationActionMenu { block_index });
-            return;
+            return true;
         }
 
         let Some(block_index) = visual_row.block_index else {
-            return;
+            return false;
         };
         if self
             .conversation_blocks
             .get(block_index)
             .is_none_or(|block| block.kind != ConversationBlockKind::User)
         {
-            return;
+            return false;
         }
 
         if self.selected_conversation_block == Some(block_index) {
@@ -1460,6 +1462,7 @@ impl ReplApp {
             self.selected_conversation_block = Some(block_index);
             self.conversation_action_menu = None;
         }
+        true
     }
 
     fn rect_contains(&self, rect: Rect, column: u16, row: u16) -> bool {

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use chrono::Local;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::prelude::*;
-use ratatui::widgets::{Paragraph, Wrap};
+use ratatui::widgets::{Clear, Paragraph, Wrap};
 use ratatui_textarea::{CursorMove, TextArea};
 
 use crate::agents::LlmClient;
@@ -927,58 +927,113 @@ impl ReplApp {
 
     /// Renders the full terminal UI into `frame`.
     ///
-    /// Layout (top to bottom):
-    /// 1. Header bar (1 line)
-    /// 2. Output area (fills remaining space)
-    /// 3. Mode line (1 line)
-    /// 4. Top separator (1 line)
-    /// 5. Input line (1 line)
-    /// 6. Bottom separator (1 line)
-    /// 7. Status bar (1 line)
-    /// 8. Slash menu or interactive panel (0–N lines)
+    /// The screen uses an inset page layout: content fills the upper portion,
+    /// while a stable footer stack keeps mode, prompt, and status information
+    /// anchored near the bottom. Transient menus render as overlays so the
+    /// footer does not jump when assistance panels open.
     pub fn render(&self, frame: &mut Frame, textarea: &TextArea<'_>) {
-        let bottom_height = match &self.panel {
-            PanelState::None => {
-                let total = self.slash_matches.len();
-                let visible = total.min(Self::SLASH_MENU_VISIBLE) as u16;
-                // Extra line for the "N/M" indicator when there are more matches
-                if total > Self::SLASH_MENU_VISIBLE {
-                    visible + 1
-                } else {
-                    visible
+        let has_output = !self.output_lines.is_empty();
+        let show_card = self.show_tip && !has_output;
+        let outer = frame.area();
+        let page = Self::page_area(outer);
+        let card_height = if show_card {
+            if page.width >= 90 { 7u16 } else { 8u16 }
+        } else {
+            0
+        };
+        let input_height = if page.width >= 60 { 3u16 } else { 1u16 };
+
+        let chunks = Layout::vertical([
+            Constraint::Length(1),            // header
+            Constraint::Length(1),            // spacer
+            Constraint::Length(card_height),  // empty-state
+            Constraint::Min(0),               // conversation
+            Constraint::Length(1),            // spacer before controls
+            Constraint::Length(1),            // mode row
+            Constraint::Length(1),            // separator
+            Constraint::Length(input_height), // prompt
+            Constraint::Length(1),            // separator
+            Constraint::Length(1),            // status row
+        ])
+        .split(page);
+
+        self.render_brand_header(frame, chunks[0]);
+        if card_height > 0 {
+            self.render_empty_state_card(frame, chunks[2]);
+        }
+        self.render_conversation_pane(frame, chunks[3]);
+        self.render_mode_strip(frame, chunks[5]);
+        self.render_hairline_with_dots(frame, chunks[6]);
+        self.render_prompt_well(frame, chunks[7], textarea);
+        self.render_hairline_with_dots(frame, chunks[8]);
+        self.render_status_dock(frame, chunks[9]);
+
+        if let Some(overlay_height) = self.overlay_height() {
+            let overlay_width = match &self.panel {
+                PanelState::None => page.width.saturating_sub(6).clamp(40, 96),
+                PanelState::ModelSelector { .. } => page.width.saturating_sub(4).clamp(52, 110),
+            };
+            let overlay_area = Self::overlay_rect(page, chunks[7], overlay_width, overlay_height);
+            match &self.panel {
+                PanelState::None => self.render_slash_menu(frame, overlay_area),
+                PanelState::ModelSelector {
+                    selected,
+                    input_mode,
+                    status_msg,
+                } => {
+                    self.render_model_panel(frame, overlay_area, *selected, input_mode, status_msg)
                 }
             }
-            PanelState::ModelSelector { input_mode, .. } => match input_mode {
-                Some(PanelInputMode::AddStep1Provider { .. }) => {
-                    // header + empty + N items
-                    (PROVIDER_KINDS.len() as u16) + 2
+        }
+    }
+
+    /// Returns the inset content page used for the main layout.
+    fn page_area(area: Rect) -> Rect {
+        let horizontal = match area.width {
+            0..=79 => 1,
+            80..=139 => 2,
+            _ => 3,
+        };
+        let vertical = if area.height >= 26 { 1 } else { 0 };
+        area.inner(Margin {
+            vertical,
+            horizontal,
+        })
+    }
+
+    /// Computes the height of the currently open overlay panel, if any.
+    fn overlay_height(&self) -> Option<u16> {
+        match &self.panel {
+            PanelState::None => {
+                let total = self.slash_matches.len();
+                if total == 0 {
+                    None
+                } else {
+                    let visible = total.min(Self::SLASH_MENU_VISIBLE) as u16;
+                    Some(if total > Self::SLASH_MENU_VISIBLE {
+                        visible + 3
+                    } else {
+                        visible + 2
+                    })
                 }
+            }
+            PanelState::ModelSelector { input_mode, .. } => Some(match input_mode {
+                Some(PanelInputMode::AddStep1Provider { .. }) => (PROVIDER_KINDS.len() as u16) + 4,
                 Some(PanelInputMode::AddStep2Model {
                     provider,
                     manual_input,
                     ..
                 }) => {
                     if manual_input.is_some() {
-                        // header + empty + input line
-                        3
+                        5
                     } else {
                         let models = recommended_models(provider);
-                        // header + empty + N items + empty + [M] hint
-                        (models.len() as u16) + 4
+                        (models.len() as u16) + 6
                     }
                 }
-                Some(PanelInputMode::AddStepAuthType { .. }) => {
-                    // header + empty + 2 options + empty + hint
-                    6
-                }
-                Some(PanelInputMode::AddStep3Key { .. }) => {
-                    // header + empty + model + env + empty + input + empty + hint
-                    8
-                }
-                Some(PanelInputMode::AddStep3Confirm { .. }) => {
-                    // title + empty + options
-                    3
-                }
+                Some(PanelInputMode::AddStepAuthType { .. }) => 8,
+                Some(PanelInputMode::AddStep3Key { .. }) => 10,
+                Some(PanelInputMode::AddStep3Confirm { .. }) => 5,
                 _ => {
                     let provider_count = self.config.effective_providers().len().max(1);
                     let input_line = if input_mode.is_some() { 1 } else { 0 };
@@ -992,55 +1047,21 @@ impl ReplApp {
                         ) => 2,
                         _ => 0,
                     };
-                    // header + empty + providers + empty + status? + footer
-                    (provider_count as u16) + 4 + input_line + status_line
+                    (provider_count as u16) + 6 + input_line + status_line
                 }
-            },
-        };
-        let has_output = !self.output_lines.is_empty();
-        let show_card = self.show_tip && !has_output;
-        let card_height = if show_card { 5u16 } else { 0 };
-        let area_width = frame.area().width;
-        // Focus ring needs 3 rows (top + content + bottom border); narrow
-        // terminals collapse to a single-row prompt without a border.
-        let input_height = if area_width >= 60 { 3u16 } else { 1u16 };
-
-        // REPL-01..REPL-10 region order, top to bottom.
-        let chunks = Layout::vertical([
-            Constraint::Length(1),             // 0 REPL-01 brand header (always visible)
-            Constraint::Length(card_height),   // 1 REPL-02 empty-state card
-            Constraint::Min(0),                // 2 REPL-03 conversation pane (expanding)
-            Constraint::Length(1),             // 3 REPL-06 mode strip
-            Constraint::Length(1),             // 4 REPL-07 top hairline separator
-            Constraint::Length(input_height),  // 5 REPL-08 prompt well (with focus ring)
-            Constraint::Length(1),             // 6 REPL-09 bottom hairline separator
-            Constraint::Length(2),             // 7 REPL-10 status dock (label row + value row)
-            Constraint::Length(bottom_height), // 8 slash menu / model panel
-        ])
-        .split(frame.area());
-
-        self.render_brand_header(frame, chunks[0]);
-        if card_height > 0 {
-            self.render_empty_state_card(frame, chunks[1]);
+            }),
         }
-        self.render_conversation_pane(frame, chunks[2]);
-        self.render_mode_strip(frame, chunks[3]);
-        self.render_hairline_with_dots(frame, chunks[4]);
-        self.render_prompt_well(frame, chunks[5], textarea);
-        self.render_hairline_with_dots(frame, chunks[6]);
-        self.render_status_dock(frame, chunks[7]);
-        if bottom_height > 0 {
-            match &self.panel {
-                PanelState::None => self.render_slash_menu(frame, chunks[8]),
-                PanelState::ModelSelector {
-                    selected,
-                    input_mode,
-                    status_msg,
-                } => {
-                    self.render_model_panel(frame, chunks[8], *selected, input_mode, status_msg);
-                }
-            }
-        }
+    }
+
+    /// Returns an overlay rectangle anchored above the prompt well.
+    fn overlay_rect(page: Rect, anchor: Rect, width: u16, height: u16) -> Rect {
+        let width = width.min(page.width).max(1);
+        let height = height.min(page.height).max(1);
+        let x = page.x + page.width.saturating_sub(width) / 2;
+        let min_y = page.y.saturating_add(1);
+        let preferred_y = anchor.y.saturating_sub(height.saturating_add(1));
+        let y = preferred_y.max(min_y);
+        Rect::new(x, y, width, height)
     }
 
     // -----------------------------------------------------------------------
@@ -1056,70 +1077,131 @@ impl ReplApp {
             Span::raw(" "),
             Span::styled(format!("v{version}"), theme::version_badge()),
             Span::styled("  ·  ", theme::hairline()),
-            Span::styled("type /help", theme::helper()),
+            Span::styled("Type a request or ", theme::dock_value()),
+            Span::styled("/help", theme::helper()),
+            Span::styled(" for commands. ", theme::dock_value()),
             Span::raw("   "),
-            Span::styled(" Ctrl+D ", theme::keycap()),
+            Span::styled(" Ctrl ", theme::keycap()),
+            Span::styled(" + ", theme::hairline()),
+            Span::styled(" D ", theme::keycap()),
+            Span::styled(" to exit.", theme::dock_value()),
         ]);
 
         frame.render_widget(Paragraph::new(line), area);
     }
 
-    /// REPL-02 — empty-state card with a rust ▌ left pillar.
-    ///
-    /// The card spans 5 rows: padding, badge, primary tip, secondary tip,
-    /// padding. The leftmost cell of every row is painted rust as a
-    /// vertical pillar; the rest of the row carries the content.
+    /// REPL-02 — inset empty-state card with examples and stronger onboarding.
     fn render_empty_state_card(&self, frame: &mut Frame, area: Rect) {
-        // Pillar | content split.
-        let cols = Layout::horizontal([Constraint::Length(2), Constraint::Min(1)]).split(area);
-        let pillar = cols[0];
-        let content = cols[1];
+        use ratatui::widgets::{Block, Borders, Padding};
 
-        // Paint a `▌` pillar in every row of the card.
-        for row in 0..pillar.height {
-            let cell = Rect::new(pillar.x, pillar.y + row, pillar.width, 1);
+        if area.width < 12 || area.height < 5 {
+            return;
+        }
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(theme::panel_border())
+            .padding(Padding::new(2, 2, 1, 1))
+            .style(theme::panel_surface());
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        for row in area.y..area.bottom() {
             frame.render_widget(
-                Paragraph::new(Span::styled("\u{258C}", theme::chevron())),
-                cell,
+                Paragraph::new(Span::styled("│", theme::panel_accent())),
+                Rect::new(area.x, row, 1, 1),
             );
         }
 
-        // Card body — 5 lines mapping to rows 0..4 of `content`.
-        let (badge_text, primary, secondary) = if !self.has_workspace {
+        let (badge_text, heading, left_lines, right_lines) = if !self.has_workspace {
             (
-                " NO WORKSPACE ",
-                Line::from(vec![
-                    Span::styled("\u{203A} ", theme::chevron()),
-                    Span::styled("/init", theme::brand_word()),
-                    Span::styled("  initialise a new workspace here", theme::out_dim()),
-                ]),
-                Line::from(Span::styled(
-                    "  or run `duumbi --help` to see all commands",
+                " no workspace ",
+                "INITIALISE A WORKSPACE",
+                vec![
+                    Line::from(vec![
+                        Span::styled("/init", theme::brand_word()),
+                        Span::styled("  create a new DUUMBI workspace here", theme::dock_value()),
+                    ]),
+                    Line::from(vec![Span::styled(
+                        "or just run `duumbi init` in this folder",
+                        theme::out_dim(),
+                    )]),
+                ],
+                vec![Line::from(vec![Span::styled(
+                    "Once initialised, natural language requests work directly in the prompt.",
                     theme::out_dim(),
-                )),
+                )])],
             )
         } else {
             (
-                " EMPTY WORKSPACE ",
-                Line::from(vec![
-                    Span::styled("\u{203A} ", theme::chevron()),
-                    Span::styled("/intent create \"build a calculator\"", theme::brand_word()),
-                ]),
-                Line::from(Span::styled(
-                    "  or just describe what you want and press Enter",
+                " empty workspace ",
+                "TRY ONE OF THESE",
+                vec![
+                    Line::from(vec![
+                        Span::styled("/intent create", theme::brand_word()),
+                        Span::raw("  "),
+                        Span::styled(
+                            "\"Build a calculator with add and multiply\"",
+                            theme::dock_value(),
+                        ),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("or just type", theme::out_dim()),
+                        Span::raw("  "),
+                        Span::styled(
+                            "\"Add a function that adds two numbers\"",
+                            theme::dock_value(),
+                        ),
+                        Span::styled("  natural language works too", theme::out_dim()),
+                    ]),
+                ],
+                vec![Line::from(vec![Span::styled(
+                    "Use the prompt below for direct requests, or switch to intent mode when you want focused planning.",
                     theme::out_dim(),
-                )),
+                )])],
             )
         };
 
-        let body = vec![
-            Line::from(""),
-            Line::from(vec![Span::styled(badge_text, theme::pill_rust())]),
-            Line::from(""),
-            primary,
-            secondary,
-        ];
-        frame.render_widget(Paragraph::new(body).wrap(Wrap { trim: false }), content);
+        if inner.width >= 70 {
+            let rows = Layout::vertical([
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Min(1),
+            ])
+            .split(inner);
+            let header = Line::from(vec![
+                Span::styled(badge_text, theme::pill_outline()),
+                Span::raw("  "),
+                Span::styled(heading, theme::label_caps()),
+            ]);
+            frame.render_widget(Paragraph::new(header), rows[0]);
+
+            let cols = Layout::horizontal([Constraint::Percentage(48), Constraint::Percentage(52)])
+                .split(rows[2]);
+            frame.render_widget(
+                Paragraph::new(left_lines).wrap(Wrap { trim: false }),
+                cols[0],
+            );
+            frame.render_widget(
+                Paragraph::new(right_lines).wrap(Wrap { trim: false }),
+                cols[1],
+            );
+        } else {
+            let body = vec![
+                Line::from(vec![
+                    Span::styled(badge_text, theme::pill_outline()),
+                    Span::raw("  "),
+                    Span::styled(heading, theme::label_caps()),
+                ]),
+                Line::from(""),
+                left_lines[0].clone(),
+                left_lines.get(1).cloned().unwrap_or_else(|| Line::from("")),
+                Line::from(""),
+                right_lines[0].clone(),
+            ];
+            frame.render_widget(Paragraph::new(body).wrap(Wrap { trim: false }), inner);
+        }
     }
 
     /// REPL-03 — scrollable conversation pane, bottom-aligned.
@@ -1186,7 +1268,7 @@ impl ReplApp {
         }
     }
 
-    /// REPL-06 — mode strip with pulsing dot, active mode label, intent slug.
+    /// REPL-06 — mode strip with shortcut hint, active mode pill, and intent label.
     fn render_mode_strip(&self, frame: &mut Frame, area: Rect) {
         let dot_glyph = Self::mode_dot_glyph();
         let mode_label = self.mode.label();
@@ -1199,29 +1281,27 @@ impl ReplApp {
             .map(|s| format!("[{s}]"))
             .unwrap_or_else(|| "—".to_string());
 
-        let hint_text = "Shift+Tab swap";
-        // Layout (left → right):
-        //   ● mode_label   intent <value>                       hint
-        //   ^^ ^^^^^^^^^   ^^^^^^^^^^^^^^^                      ^^^^
-        //   2  N           7+m                                  N
-        let left_len = 2 + mode_label.len() + 3 + intent_label.len() + intent_value.chars().count();
-        let right_len = hint_text.len();
+        let hint_prefix = 14usize;
+        let mode_len = 4 + mode_label.len();
+        let right_len = intent_label.len() + intent_value.chars().count();
+        let left_len = hint_prefix + mode_len;
         let padding = (area.width as usize).saturating_sub(left_len + right_len);
 
         let mut spans = vec![
-            Span::styled(dot_glyph, theme::mode_dot()),
+            Span::styled(" Shift ", theme::keycap()),
             Span::raw(" "),
-            Span::styled(mode_label, theme::mode_label()),
-            Span::raw("   "),
-            Span::styled(intent_label, theme::label_caps()),
+            Span::styled(" Tab ", theme::keycap()),
+            Span::styled(" switch mode  ", theme::mode_hint()),
+            Span::styled(format!(" {dot_glyph} {mode_label} "), theme::mode_pill()),
+            Span::raw("  "),
         ];
+        spans.push(Span::raw(" ".repeat(padding)));
+        spans.push(Span::styled(intent_label, theme::label_caps_inline()));
         if self.focused_intent.is_some() {
             spans.push(Span::styled(intent_value, theme::intent_slug()));
         } else {
             spans.push(Span::styled(intent_value, theme::out_dim()));
         }
-        spans.push(Span::raw(" ".repeat(padding)));
-        spans.push(Span::styled(hint_text, theme::mode_hint()));
 
         frame.render_widget(Paragraph::new(Line::from(spans)), area);
     }
@@ -1249,19 +1329,25 @@ impl ReplApp {
         frame.render_widget(Paragraph::new(line), area);
     }
 
-    /// REPL-08 — prompt input well with rust focus ring around the textarea.
+    /// REPL-08 — prompt input well with rust focus ring and placeholder.
     ///
     /// On terminals < 60 cols, the focus border is dropped and the prompt
     /// renders as a single line with a `› ` prefix.
     fn render_prompt_well(&self, frame: &mut Frame, area: Rect, textarea: &TextArea<'_>) {
         use ratatui::widgets::{Block, BorderType, Borders};
 
+        let is_empty = textarea.lines().iter().all(|line| line.is_empty());
+        let placeholder = match self.mode {
+            ReplMode::Agent => "e.g. \"create a module that parses CSV\" or /help",
+            ReplMode::Intent => "e.g. \"plan a calculator module\" or /intent create",
+        };
+
         if area.height >= 3 {
-            // Boxed input with rust focus ring (REPL-08 default).
             let block = Block::default()
                 .borders(Borders::ALL)
                 .border_type(BorderType::Plain)
-                .border_style(theme::focus_border());
+                .border_style(theme::focus_border())
+                .style(theme::panel_surface());
             let inner = block.inner(area);
             frame.render_widget(block, area);
 
@@ -1272,8 +1358,13 @@ impl ReplApp {
                 chunks[0],
             );
             frame.render_widget(textarea, chunks[1]);
+            if is_empty {
+                frame.render_widget(
+                    Paragraph::new(Span::styled(placeholder, theme::placeholder())),
+                    chunks[1],
+                );
+            }
         } else {
-            // Compact single-row fallback for narrow terminals.
             let chunks =
                 Layout::horizontal([Constraint::Length(2), Constraint::Min(1)]).split(area);
             frame.render_widget(
@@ -1281,48 +1372,21 @@ impl ReplApp {
                 chunks[0],
             );
             frame.render_widget(textarea, chunks[1]);
+            if is_empty {
+                frame.render_widget(
+                    Paragraph::new(Span::styled(placeholder, theme::placeholder())),
+                    chunks[1],
+                );
+            }
         }
     }
 
-    /// REPL-10 — two-row status dock (uppercase labels above values).
-    ///
-    /// Slots: TIME · WORKSPACE · CWD · ACTIVITY. The ACTIVITY slot is
-    /// blank when idle and shows the activity button when `working` is true
-    /// (rendered by [`Self::render_activity_button`]).
+    /// REPL-10 — compact single-row status dock.
     fn render_status_dock(&self, frame: &mut Frame, area: Rect) {
-        // Narrow-terminal fallback: single-row compact dock.
-        if area.height < 2 || area.width < 40 {
+        if area.width < 40 {
             self.render_compact_status(frame, area);
             return;
         }
-
-        let rows = Layout::vertical([Constraint::Length(1), Constraint::Length(1)]).split(area);
-
-        // Four equal slots — labels and values share the same horizontal split.
-        let cols = Layout::horizontal([
-            Constraint::Ratio(1, 4),
-            Constraint::Ratio(1, 4),
-            Constraint::Ratio(1, 4),
-            Constraint::Ratio(1, 4),
-        ])
-        .split(rows[0]);
-        let value_cols = Layout::horizontal([
-            Constraint::Ratio(1, 4),
-            Constraint::Ratio(1, 4),
-            Constraint::Ratio(1, 4),
-            Constraint::Ratio(1, 4),
-        ])
-        .split(rows[1]);
-
-        // Label row.
-        for (i, label) in ["TIME", "WORKSPACE", "CWD", "ACTIVITY"].iter().enumerate() {
-            frame.render_widget(
-                Paragraph::new(Span::styled(*label, theme::label_caps())),
-                cols[i],
-            );
-        }
-
-        // Value row.
         let time_str = Local::now().format("%H:%M").to_string();
         let workspace_name = self
             .config
@@ -1336,27 +1400,33 @@ impl ReplApp {
             .unwrap_or_else(|_| self.workspace_root.clone())
             .display()
             .to_string();
-        let cwd_truncated = truncate_path(&cwd, value_cols[2].width.saturating_sub(1) as usize);
+        let prefix_len = 5 + time_str.len() + 3 + 10 + workspace_name.len() + 3 + 4;
+        let activity_len = if self.working { 13 } else { 0 };
+        let cwd_budget = area
+            .width
+            .saturating_sub((prefix_len + activity_len) as u16)
+            .max(12) as usize;
+        let cwd_truncated = truncate_path(&cwd, cwd_budget);
 
-        frame.render_widget(
-            Paragraph::new(Span::styled(time_str, theme::dock_value())),
-            value_cols[0],
-        );
-        frame.render_widget(
-            Paragraph::new(Span::styled(
-                workspace_name.to_string(),
-                theme::workspace_value(),
-            )),
-            value_cols[1],
-        );
-        frame.render_widget(
-            Paragraph::new(Span::styled(cwd_truncated, theme::dock_value())),
-            value_cols[2],
-        );
-
+        let mut spans = vec![
+            Span::styled("TIME ", theme::label_caps_inline()),
+            Span::styled(time_str, theme::dock_value()),
+            Span::raw("   "),
+            Span::styled("WORKSPACE ", theme::label_caps_inline()),
+            Span::styled(workspace_name.to_string(), theme::workspace_value()),
+            Span::raw("   "),
+            Span::styled("CWD ", theme::label_caps_inline()),
+            Span::styled(cwd_truncated, theme::dock_value()),
+        ];
         if self.working {
-            self.render_activity_button(frame, value_cols[3]);
+            let frame_idx = (Self::animation_now_ms() / 80) as usize;
+            let glyph = Self::SPINNER[frame_idx % Self::SPINNER.len()];
+            spans.push(Span::raw("   "));
+            spans.push(Span::styled("ACTIVITY ", theme::label_caps_inline()));
+            spans.push(Span::styled(format!("{glyph} working"), theme::chevron()));
         }
+
+        frame.render_widget(Paragraph::new(Line::from(spans)), area);
     }
 
     /// Compact single-row status fallback for narrow terminals.
@@ -1368,48 +1438,39 @@ impl ReplApp {
             .as_ref()
             .map(|w| w.name.as_str())
             .unwrap_or("unnamed");
-        let activity = if self.working { " ⠹ working" } else { "" };
+        let activity = if self.working { "  working" } else { "" };
         let line = Line::from(vec![
+            Span::styled("TIME ", theme::label_caps_inline()),
             Span::styled(time_str, theme::dock_value()),
             Span::raw("  "),
+            Span::styled("WORKSPACE ", theme::label_caps_inline()),
             Span::styled(workspace_name.to_string(), theme::workspace_value()),
-            Span::styled(activity.to_string(), theme::chevron()),
+            Span::styled(activity.to_string(), theme::out_dim()),
         ]);
         frame.render_widget(Paragraph::new(line), area);
     }
 
-    /// Renders the rust-pill activity button shown in the ACTIVITY slot.
-    fn render_activity_button(&self, frame: &mut Frame, area: Rect) {
-        let frame_idx = (Self::animation_now_ms() / 80) as usize;
-        let glyph = Self::SPINNER[frame_idx % Self::SPINNER.len()];
-        // Pad to fill the slot so the rust background covers the entire pill.
-        let total = area.width as usize;
-        let label = format!(" {glyph} INTERRUPT \u{25A0} ");
-        let padded = if label.chars().count() < total {
-            format!(
-                "{label}{:width$}",
-                "",
-                width = total - label.chars().count()
-            )
-        } else {
-            label
-        };
-        frame.render_widget(
-            Paragraph::new(Span::styled(padded, theme::pill_rust())),
-            area,
-        );
-    }
-
-    /// Renders the inline slash-command completion menu with scrolling.
+    /// Renders the inline slash-command completion menu as an overlay.
     ///
     /// The selected entry is highlighted with a cyan foreground; all others
     /// use the default terminal style. When the total number of matches
     /// exceeds [`Self::SLASH_MENU_VISIBLE`], a scroll indicator (e.g.
     /// `3/12`) is shown at the bottom.
     fn render_slash_menu(&self, frame: &mut Frame, area: Rect) {
+        use ratatui::widgets::{Block, Borders, Padding};
+
         if self.slash_matches.is_empty() {
             return;
         }
+
+        frame.render_widget(Clear, area);
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(theme::panel_border())
+            .padding(Padding::new(1, 1, 1, 1))
+            .style(theme::panel_surface());
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
 
         let total = self.slash_matches.len();
         let visible = total.min(Self::SLASH_MENU_VISIBLE);
@@ -1419,7 +1480,7 @@ impl ReplApp {
         let row_areas = Layout::vertical(
             std::iter::repeat_n(Constraint::Length(1), row_count).collect::<Vec<_>>(),
         )
-        .split(area);
+        .split(inner);
 
         let offset = self.slash_scroll_offset;
         for (i, sm) in self
@@ -1470,13 +1531,26 @@ impl ReplApp {
         input_mode: &Option<PanelInputMode>,
         status_msg: &Option<(String, OutputStyle)>,
     ) {
+        use ratatui::widgets::{Block, Borders, Padding};
+
+        frame.render_widget(Clear, area);
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(theme::panel_border())
+            .padding(Padding::new(1, 1, 1, 1))
+            .style(theme::panel_surface());
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
         let providers = self.config.effective_providers();
         let mut lines: Vec<Line<'_>> = Vec::new();
+
+        let inner_width = inner.width as usize;
 
         // Header
         lines.push(Line::from(vec![
             Span::styled("  Select Model", theme::brand_word()),
-            Span::raw(" ".repeat(area.width.saturating_sub(40) as usize)),
+            Span::raw(" ".repeat(inner_width.saturating_sub(40))),
             Span::styled("(Esc to close)", theme::out_dim()),
         ]));
 
@@ -1544,7 +1618,7 @@ impl ReplApp {
                 lines.clear();
                 lines.push(Line::from(vec![
                     Span::styled("  Add Provider", theme::brand_word()),
-                    Span::raw(" ".repeat(area.width.saturating_sub(45) as usize)),
+                    Span::raw(" ".repeat(inner_width.saturating_sub(45))),
                     Span::styled("(Esc to cancel)", theme::out_dim()),
                 ]));
                 lines.push(Line::from(""));
@@ -1571,7 +1645,7 @@ impl ReplApp {
                         format!("  Select Model for {provider}"),
                         theme::brand_word(),
                     ),
-                    Span::raw(" ".repeat(area.width.saturating_sub(55) as usize)),
+                    Span::raw(" ".repeat(inner_width.saturating_sub(55))),
                     Span::styled("(Esc to go back)", theme::out_dim()),
                 ]));
                 lines.push(Line::from(""));
@@ -1611,7 +1685,7 @@ impl ReplApp {
                         format!("  Authentication for {provider} ({model})"),
                         theme::brand_word(),
                     ),
-                    Span::raw(" ".repeat(area.width.saturating_sub(60) as usize)),
+                    Span::raw(" ".repeat(inner_width.saturating_sub(60))),
                     Span::styled("(Esc to go back)", theme::out_dim()),
                 ]));
                 lines.push(Line::from(""));
@@ -1655,7 +1729,7 @@ impl ReplApp {
                 lines.clear();
                 lines.push(Line::from(vec![
                     Span::styled(format!("  {label} for {provider}"), theme::brand_word()),
-                    Span::raw(" ".repeat(area.width.saturating_sub(50) as usize)),
+                    Span::raw(" ".repeat(inner_width.saturating_sub(50))),
                     Span::styled("(Esc to go back)", theme::out_dim()),
                 ]));
                 lines.push(Line::from(""));
@@ -1734,7 +1808,7 @@ impl ReplApp {
             }
         }
 
-        frame.render_widget(Paragraph::new(lines), area);
+        frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
     }
 }
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -218,6 +218,16 @@ pub(crate) fn describe(input: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Returns a human-readable pseudocode description of the graph.
+pub(crate) fn describe_to_string(input: &Path) -> Result<String> {
+    if let Some(workspace_root) = workspace_root_for_graph_input(input) {
+        return describe_workspace_program_to_string(&workspace_root, input);
+    }
+
+    let semantic_graph = parse_and_validate(input)?;
+    Ok(crate::cli::describe::describe_to_string(&semantic_graph))
+}
+
 /// If `input` is `<workspace>/.duumbi/graph/*.jsonld`, returns `<workspace>`.
 fn workspace_root_for_graph_input(input: &Path) -> Option<std::path::PathBuf> {
     let parent = input.parent()?;
@@ -279,6 +289,39 @@ fn describe_workspace_program(workspace_root: &Path, input: &Path) -> Result<()>
 
     crate::cli::describe::describe(module_graph);
     Ok(())
+}
+
+fn describe_workspace_program_to_string(workspace_root: &Path, input: &Path) -> Result<String> {
+    let source = fs::read_to_string(input)
+        .with_context(|| format!("Failed to read input file '{}'", input.display()))?;
+
+    let module_ast = parser::parse_jsonld(&source).map_err(|e| {
+        let diag = match &e {
+            parser::ParseError::Json { code, .. } => Diagnostic::error(code, e.to_string()),
+            parser::ParseError::MissingField { code, node_id, .. } => {
+                Diagnostic::error(code, e.to_string()).with_node(&types::NodeId(node_id.clone()))
+            }
+            parser::ParseError::UnknownOp { code, node_id, .. } => {
+                Diagnostic::error(code, e.to_string()).with_node(&types::NodeId(node_id.clone()))
+            }
+            parser::ParseError::SchemaInvalid { code, .. } => {
+                Diagnostic::error(code, e.to_string())
+            }
+        };
+        emit_diagnostic(&diag);
+        anyhow::anyhow!("Parse failed")
+    })?;
+
+    let program = deps::load_program_with_deps(workspace_root).map_err(|e| {
+        emit_program_error_diagnostics(&e);
+        anyhow::anyhow!("Graph construction failed: {e}")
+    })?;
+
+    let module_graph = program.modules.get(&module_ast.name).ok_or_else(|| {
+        anyhow::anyhow!("Module '{}' not found in loaded program", module_ast.name.0)
+    })?;
+
+    Ok(crate::cli::describe::describe_to_string(module_graph))
 }
 
 fn emit_program_error_diagnostics(err: &deps::DepsError) {

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -8,49 +8,265 @@
 // Static slash command list
 // ---------------------------------------------------------------------------
 
+/// Slash command groups shown by the discovery menu.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SlashGroup {
+    /// Build, run, and inspect the current graph.
+    BuildRun,
+    /// Intent-driven development commands.
+    Intent,
+    /// Persistent agent knowledge commands.
+    Knowledge,
+    /// Dependency, registry, and publishing commands.
+    DependenciesRegistry,
+    /// Session and history commands.
+    Session,
+    /// Workspace setup and configuration commands.
+    WorkspaceConfig,
+    /// Help and process control commands.
+    System,
+}
+
+impl SlashGroup {
+    /// User-facing group label.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::BuildRun => "BUILD & RUN",
+            Self::Intent => "INTENT",
+            Self::Knowledge => "KNOWLEDGE",
+            Self::DependenciesRegistry => "DEPENDENCIES & REGISTRY",
+            Self::Session => "SESSION",
+            Self::WorkspaceConfig => "WORKSPACE & CONFIG",
+            Self::System => "SYSTEM",
+        }
+    }
+}
+
+/// Display order for slash-command groups.
+pub const SLASH_GROUPS: &[SlashGroup] = &[
+    SlashGroup::BuildRun,
+    SlashGroup::Intent,
+    SlashGroup::Knowledge,
+    SlashGroup::DependenciesRegistry,
+    SlashGroup::Session,
+    SlashGroup::WorkspaceConfig,
+    SlashGroup::System,
+];
+
+/// A slash command definition.
+#[derive(Debug, Clone, Copy)]
+pub struct SlashCommand {
+    /// Full command string.
+    pub command: &'static str,
+    /// One-line description.
+    pub description: &'static str,
+    /// Discovery-menu group.
+    pub group: SlashGroup,
+}
+
 /// All known slash commands with descriptions (used for completion and help).
-pub const SLASH_COMMANDS: &[(&str, &str)] = &[
-    ("/build", "Compile the current graph to a native binary"),
-    ("/run", "Run the compiled binary"),
-    ("/check", "Validate the graph without compiling"),
-    ("/describe", "Print human-readable pseudocode"),
-    ("/undo", "Restore the previous graph snapshot"),
-    ("/status", "Show workspace and session info"),
-    ("/history", "Show session conversation history"),
-    ("/model", "Manage LLM providers and models"),
-    ("/intent", "Manage intent specs"),
-    ("/intent create", "Generate a new intent spec"),
-    ("/intent review", "Show intent details"),
-    ("/intent execute", "Execute an intent end-to-end"),
-    ("/intent status", "Show intent status"),
-    ("/intent focus", "Focus an intent by slug"),
-    ("/intent unfocus", "Clear the focused intent"),
-    ("/knowledge", "Show knowledge statistics"),
-    ("/knowledge list", "List all knowledge nodes"),
-    ("/knowledge stats", "Show learning statistics"),
-    ("/knowledge show", "Show details of a knowledge node"),
-    ("/knowledge prune", "Remove old knowledge nodes"),
-    ("/resume", "List or resume archived sessions"),
-    ("/search", "Search registries for modules"),
-    ("/publish", "Package and publish current module"),
-    ("/registry list", "List configured registries"),
-    ("/deps", "Manage dependencies"),
-    ("/deps list", "List declared dependencies"),
-    ("/deps add", "Add a dependency"),
-    ("/deps remove", "Remove a dependency"),
-    ("/deps audit", "Verify dependency integrity"),
-    ("/deps tree", "Show the dependency tree"),
-    ("/deps update", "Update dependencies"),
-    ("/deps vendor", "Vendor cached dependencies"),
-    ("/deps install", "Download and resolve all dependencies"),
-    ("/clear", "Clear chat history and screen"),
-    ("/clear chat", "Clear chat history and screen"),
-    ("/clear session", "Clear and archive current session"),
-    ("/clear all", "Clear history and archive session"),
-    ("/init", "Initialise a new workspace"),
-    ("/help", "Show available commands"),
-    ("/exit", "Exit the REPL"),
-    ("/quit", "Exit the REPL"),
+pub const SLASH_COMMANDS: &[SlashCommand] = &[
+    SlashCommand {
+        command: "/build",
+        description: "Compile the current graph to a native binary",
+        group: SlashGroup::BuildRun,
+    },
+    SlashCommand {
+        command: "/run",
+        description: "Run the compiled binary",
+        group: SlashGroup::BuildRun,
+    },
+    SlashCommand {
+        command: "/check",
+        description: "Validate the graph without compiling",
+        group: SlashGroup::BuildRun,
+    },
+    SlashCommand {
+        command: "/describe",
+        description: "Print human-readable pseudocode",
+        group: SlashGroup::BuildRun,
+    },
+    SlashCommand {
+        command: "/intent",
+        description: "Manage intent specs",
+        group: SlashGroup::Intent,
+    },
+    SlashCommand {
+        command: "/intent create",
+        description: "Generate a new intent spec",
+        group: SlashGroup::Intent,
+    },
+    SlashCommand {
+        command: "/intent review",
+        description: "Show intent details",
+        group: SlashGroup::Intent,
+    },
+    SlashCommand {
+        command: "/intent execute",
+        description: "Execute an intent end-to-end",
+        group: SlashGroup::Intent,
+    },
+    SlashCommand {
+        command: "/intent status",
+        description: "Show intent status",
+        group: SlashGroup::Intent,
+    },
+    SlashCommand {
+        command: "/intent focus",
+        description: "Focus an intent by slug",
+        group: SlashGroup::Intent,
+    },
+    SlashCommand {
+        command: "/intent unfocus",
+        description: "Clear the focused intent",
+        group: SlashGroup::Intent,
+    },
+    SlashCommand {
+        command: "/knowledge",
+        description: "Show knowledge statistics",
+        group: SlashGroup::Knowledge,
+    },
+    SlashCommand {
+        command: "/knowledge list",
+        description: "List all knowledge nodes",
+        group: SlashGroup::Knowledge,
+    },
+    SlashCommand {
+        command: "/knowledge stats",
+        description: "Show learning statistics",
+        group: SlashGroup::Knowledge,
+    },
+    SlashCommand {
+        command: "/knowledge show",
+        description: "Show details of a knowledge node",
+        group: SlashGroup::Knowledge,
+    },
+    SlashCommand {
+        command: "/knowledge prune",
+        description: "Remove old knowledge nodes",
+        group: SlashGroup::Knowledge,
+    },
+    SlashCommand {
+        command: "/search",
+        description: "Search registries for modules",
+        group: SlashGroup::DependenciesRegistry,
+    },
+    SlashCommand {
+        command: "/publish",
+        description: "Package and publish current module",
+        group: SlashGroup::DependenciesRegistry,
+    },
+    SlashCommand {
+        command: "/registry list",
+        description: "List configured registries",
+        group: SlashGroup::DependenciesRegistry,
+    },
+    SlashCommand {
+        command: "/deps",
+        description: "Manage dependencies",
+        group: SlashGroup::DependenciesRegistry,
+    },
+    SlashCommand {
+        command: "/deps list",
+        description: "List declared dependencies",
+        group: SlashGroup::DependenciesRegistry,
+    },
+    SlashCommand {
+        command: "/deps add",
+        description: "Add a dependency",
+        group: SlashGroup::DependenciesRegistry,
+    },
+    SlashCommand {
+        command: "/deps remove",
+        description: "Remove a dependency",
+        group: SlashGroup::DependenciesRegistry,
+    },
+    SlashCommand {
+        command: "/deps audit",
+        description: "Verify dependency integrity",
+        group: SlashGroup::DependenciesRegistry,
+    },
+    SlashCommand {
+        command: "/deps tree",
+        description: "Show the dependency tree",
+        group: SlashGroup::DependenciesRegistry,
+    },
+    SlashCommand {
+        command: "/deps update",
+        description: "Update dependencies",
+        group: SlashGroup::DependenciesRegistry,
+    },
+    SlashCommand {
+        command: "/deps vendor",
+        description: "Vendor cached dependencies",
+        group: SlashGroup::DependenciesRegistry,
+    },
+    SlashCommand {
+        command: "/deps install",
+        description: "Download and resolve all dependencies",
+        group: SlashGroup::DependenciesRegistry,
+    },
+    SlashCommand {
+        command: "/status",
+        description: "Show workspace and session info",
+        group: SlashGroup::Session,
+    },
+    SlashCommand {
+        command: "/history",
+        description: "Show session conversation history",
+        group: SlashGroup::Session,
+    },
+    SlashCommand {
+        command: "/resume",
+        description: "List or resume archived sessions",
+        group: SlashGroup::Session,
+    },
+    SlashCommand {
+        command: "/clear",
+        description: "Clear chat history and screen",
+        group: SlashGroup::Session,
+    },
+    SlashCommand {
+        command: "/clear chat",
+        description: "Clear chat history and screen",
+        group: SlashGroup::Session,
+    },
+    SlashCommand {
+        command: "/clear session",
+        description: "Clear and archive current session",
+        group: SlashGroup::Session,
+    },
+    SlashCommand {
+        command: "/clear all",
+        description: "Clear history and archive session",
+        group: SlashGroup::Session,
+    },
+    SlashCommand {
+        command: "/init",
+        description: "Initialise a new workspace",
+        group: SlashGroup::WorkspaceConfig,
+    },
+    SlashCommand {
+        command: "/model",
+        description: "Manage LLM providers and models",
+        group: SlashGroup::WorkspaceConfig,
+    },
+    SlashCommand {
+        command: "/help",
+        description: "Show available commands",
+        group: SlashGroup::System,
+    },
+    SlashCommand {
+        command: "/exit",
+        description: "Exit the REPL",
+        group: SlashGroup::System,
+    },
+    SlashCommand {
+        command: "/quit",
+        description: "Exit the REPL",
+        group: SlashGroup::System,
+    },
 ];
 
 /// Returns the top `limit` slash commands whose name starts with `prefix`.
@@ -61,9 +277,9 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
 pub fn match_commands(prefix: &str, limit: usize) -> Vec<(&'static str, &'static str)> {
     SLASH_COMMANDS
         .iter()
-        .filter(|(cmd, _)| cmd.starts_with(prefix) && *cmd != prefix)
+        .filter(|entry| entry.command.starts_with(prefix) && entry.command != prefix)
         .take(limit)
-        .copied()
+        .map(|entry| (entry.command, entry.description))
         .collect()
 }
 
@@ -110,12 +326,12 @@ mod tests {
         assert!(
             SLASH_COMMANDS
                 .iter()
-                .any(|(cmd, _)| *cmd == "/intent focus")
+                .any(|entry| entry.command == "/intent focus")
         );
         assert!(
             SLASH_COMMANDS
                 .iter()
-                .any(|(cmd, _)| *cmd == "/intent unfocus")
+                .any(|entry| entry.command == "/intent unfocus")
         );
     }
 }

--- a/src/cli/describe.rs
+++ b/src/cli/describe.rs
@@ -41,6 +41,36 @@ pub fn describe(graph: &SemanticGraph) {
     }
 }
 
+/// Returns a plain-text human-readable pseudo-code description of the semantic graph.
+#[must_use]
+pub fn describe_to_string(graph: &SemanticGraph) -> String {
+    let mut lines = Vec::new();
+    for func in &graph.functions {
+        let params: Vec<String> = func
+            .params
+            .iter()
+            .map(|p| format!("{}: {}", p.name, p.param_type))
+            .collect();
+        lines.push(format!(
+            "function {}({}) -> {} {{",
+            func.name,
+            params.join(", "),
+            func.return_type
+        ));
+
+        for block in &func.blocks {
+            lines.push(format!("  {}:", block.label));
+            for &node_idx in &block.nodes {
+                let node = &graph.graph[node_idx];
+                let desc = describe_op_plain(graph, node_idx, &node.op);
+                lines.push(format!("    %{} = {}", node.id, desc));
+            }
+        }
+        lines.push("}".to_string());
+    }
+    lines.join("\n")
+}
+
 /// Produces a string description of a single operation.
 fn describe_op(
     graph: &SemanticGraph,
@@ -161,6 +191,101 @@ fn describe_op(
         }
         // Phase 9a+ ops — use Display impl with magenta op name
         other => format!("{}", other.to_string().magenta()),
+    }
+}
+
+fn describe_op_plain(
+    graph: &SemanticGraph,
+    node_idx: petgraph::stable_graph::NodeIndex,
+    op: &Op,
+) -> String {
+    use petgraph::Direction;
+
+    let incoming: Vec<_> = graph
+        .graph
+        .edges_directed(node_idx, Direction::Incoming)
+        .collect();
+
+    fn ref_plain(id: &crate::types::NodeId) -> String {
+        format!("%{}", id.0)
+    }
+
+    match op {
+        Op::Const(v) => format!("Const({v})"),
+        Op::ConstF64(v) => format!("ConstF64({v})"),
+        Op::ConstBool(v) => format!("ConstBool({v})"),
+        Op::ConstString(s) => format!("ConstString(\"{s}\")"),
+        Op::Add | Op::Sub | Op::Mul | Op::Div => {
+            let mut left = String::from("?");
+            let mut right = String::from("?");
+            for e in &incoming {
+                let src = &graph.graph[e.source()];
+                match e.weight() {
+                    GraphEdge::Left => left = ref_plain(&src.id),
+                    GraphEdge::Right => right = ref_plain(&src.id),
+                    _ => {}
+                }
+            }
+            format!("{op}({left}, {right})")
+        }
+        Op::Compare(cmp_op) => {
+            let mut left = String::from("?");
+            let mut right = String::from("?");
+            for e in &incoming {
+                let src = &graph.graph[e.source()];
+                match e.weight() {
+                    GraphEdge::Left => left = ref_plain(&src.id),
+                    GraphEdge::Right => right = ref_plain(&src.id),
+                    _ => {}
+                }
+            }
+            format!("Compare({left}, {right}, {cmp_op})")
+        }
+        Op::Branch => {
+            let mut cond = String::from("?");
+            if let Some((true_lbl, false_lbl)) = graph.branch_targets.get(&graph.graph[node_idx].id)
+            {
+                for e in &incoming {
+                    if matches!(e.weight(), GraphEdge::Condition) {
+                        cond = ref_plain(&graph.graph[e.source()].id);
+                    }
+                }
+                format!("Branch({cond}, {true_lbl}, {false_lbl})")
+            } else {
+                format!("Branch({cond}, ?, ?)")
+            }
+        }
+        Op::Call { function } => {
+            let mut args: Vec<(usize, String)> = Vec::new();
+            for e in &incoming {
+                if let GraphEdge::Arg(i) = e.weight() {
+                    args.push((*i, ref_plain(&graph.graph[e.source()].id)));
+                }
+            }
+            args.sort_by_key(|(i, _)| *i);
+            let arg_strs: Vec<String> = args.into_iter().map(|(_, s)| s).collect();
+            format!("Call({function}, [{}])", arg_strs.join(", "))
+        }
+        Op::Load { variable } => format!("Load({variable})"),
+        Op::Store { variable } => {
+            let mut val = String::from("?");
+            for e in &incoming {
+                if matches!(e.weight(), GraphEdge::Operand) {
+                    val = ref_plain(&graph.graph[e.source()].id);
+                }
+            }
+            format!("Store({variable}, {val})")
+        }
+        Op::Return => {
+            let mut val = String::from("?");
+            for e in &incoming {
+                if matches!(e.weight(), GraphEdge::Operand) {
+                    val = ref_plain(&graph.graph[e.source()].id);
+                }
+            }
+            format!("Return({val})")
+        }
+        other => other.to_string(),
     }
 }
 
@@ -360,5 +485,18 @@ mod tests {
         let graph = const_graph();
         // describe() calls println!, so just ensure it completes without panic.
         describe(&graph);
+    }
+
+    #[test]
+    fn describe_to_string_returns_plain_text() {
+        let graph = const_graph();
+        let out = describe_to_string(&graph);
+        assert!(out.contains("function main() -> i64 {"));
+        assert!(out.contains("Const(42)"));
+        assert!(out.contains("Return("));
+        assert!(
+            !out.contains('\u{1b}'),
+            "plain output must not contain ANSI escapes"
+        );
     }
 }

--- a/src/cli/mode.rs
+++ b/src/cli/mode.rs
@@ -4,6 +4,8 @@
 //! - **Agent** — free-form AI mutation (default)
 //! - **Intent** — intent-focused planning and modification
 
+use std::path::PathBuf;
+
 /// The two REPL interaction modes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ReplMode {
@@ -58,6 +60,69 @@ impl OutputLine {
         Self {
             text: text.into(),
             style,
+        }
+    }
+}
+
+/// Kind of a conversation-pane block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConversationBlockKind {
+    /// User-submitted prompt or selected slash command.
+    User,
+    /// Assistant or command output.
+    Output,
+}
+
+/// Action shown in a conversation block header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConversationAction {
+    /// Copy the block text to the clipboard.
+    Copy,
+    /// Revert graph changes associated with this turn.
+    Revert,
+}
+
+/// One scrollable conversation-pane block.
+#[derive(Debug, Clone)]
+pub struct ConversationBlock {
+    /// Block type.
+    pub kind: ConversationBlockKind,
+    /// Lines rendered inside the block.
+    pub lines: Vec<OutputLine>,
+    /// Time the user submitted the block, formatted for display.
+    pub submitted_at: Option<String>,
+    /// Runtime footer text, if applicable.
+    pub elapsed: Option<String>,
+    /// Header actions shown for the block.
+    pub actions: Vec<ConversationAction>,
+    /// Snapshot file associated with this user turn, if it changed the graph.
+    pub revert_snapshot: Option<PathBuf>,
+}
+
+impl ConversationBlock {
+    /// Creates a user block.
+    #[must_use]
+    pub fn user(input: impl Into<String>, submitted_at: impl Into<String>) -> Self {
+        Self {
+            kind: ConversationBlockKind::User,
+            lines: vec![OutputLine::new(input, OutputStyle::Normal)],
+            submitted_at: Some(submitted_at.into()),
+            elapsed: None,
+            actions: vec![ConversationAction::Copy],
+            revert_snapshot: None,
+        }
+    }
+
+    /// Creates an empty output block.
+    #[must_use]
+    pub fn output() -> Self {
+        Self {
+            kind: ConversationBlockKind::Output,
+            lines: Vec::new(),
+            submitted_at: None,
+            elapsed: None,
+            actions: Vec::new(),
+            revert_snapshot: None,
         }
     }
 }

--- a/src/cli/mode.rs
+++ b/src/cli/mode.rs
@@ -69,6 +69,26 @@ pub struct SlashMatch {
     pub command: String,
     /// Description text.
     pub description: String,
+    /// Discovery-menu group.
+    pub group: crate::cli::completion::SlashGroup,
+    /// Number of leading command characters matched by the current input.
+    pub matched_prefix_len: usize,
+}
+
+/// A visible row in the slash-command menu.
+#[derive(Debug, Clone)]
+pub enum SlashMenuItem {
+    /// Collapsible discovery group header.
+    Group {
+        /// Group identity.
+        group: crate::cli::completion::SlashGroup,
+        /// Number of commands in the group.
+        count: usize,
+        /// Whether commands under this group are currently visible.
+        expanded: bool,
+    },
+    /// Executable slash command row.
+    Command(SlashMatch),
 }
 
 /// Action returned by key handling to control the event loop.

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -429,8 +429,8 @@ async fn handle_slash(
             // "Did you mean?" suggestion using Levenshtein distance.
             let known_cmds: Vec<&str> = super::completion::SLASH_COMMANDS
                 .iter()
-                .filter(|(c, _)| !c.contains(' '))
-                .map(|(c, _)| *c)
+                .filter(|entry| !entry.command.contains(' '))
+                .map(|entry| entry.command)
                 .collect();
             if let Some(suggestion) = find_closest_command(cmd, &known_cmds) {
                 app.push_output(

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -96,15 +96,27 @@ pub async fn run(workspace_root: PathBuf, config: DuumbiConfig) -> Result<()> {
 // ---------------------------------------------------------------------------
 
 /// Drives the ratatui event loop until the user exits or an I/O error occurs.
+///
+/// Polls events on a 40 ms tick (a clean divisor of the 80 ms spinner
+/// frame). Redraws fire on three triggers: a real terminal event, an
+/// active animation (working spinner or pulsing mode dot), or the first
+/// iteration of the loop. When idle and no animation is running the
+/// terminal is left untouched, keeping CPU usage near zero.
 async fn event_loop(
     terminal: &mut ratatui::DefaultTerminal,
     app: &mut ReplApp,
     textarea: &mut TextArea<'_>,
 ) -> Result<()> {
-    loop {
-        terminal.draw(|frame| app.render(frame, textarea))?;
+    use std::time::{Duration, Instant};
 
-        if event::poll(std::time::Duration::from_millis(50))? {
+    const TICK: Duration = Duration::from_millis(40);
+    // Initial paint so the user sees the UI immediately.
+    terminal.draw(|frame| app.render(frame, textarea))?;
+    let mut last_draw = Instant::now();
+
+    loop {
+        let event_ready = event::poll(TICK)?;
+        if event_ready {
             match event::read()? {
                 Event::Key(key) => match app.handle_key(key, textarea) {
                     super::mode::Action::Continue => {}
@@ -113,13 +125,13 @@ async fn event_loop(
                             mgr.archive().ok();
                         }
                         app.push_output("Goodbye!", OutputStyle::Dim);
-                        // Draw one last frame so the farewell message is visible.
                         terminal.draw(|frame| app.render(frame, textarea))?;
                         break;
                     }
                     super::mode::Action::Submit(input) => {
                         app.working = true;
                         terminal.draw(|frame| app.render(frame, textarea))?;
+                        last_draw = Instant::now();
 
                         if process_input(terminal, app, textarea, &input).await {
                             if let Some(ref mut mgr) = app.session_mgr {
@@ -135,6 +147,12 @@ async fn event_loop(
                 }
                 _ => {}
             }
+        }
+
+        let needs_anim = app.working || app.mode_dot_animated();
+        if event_ready || (needs_anim && last_draw.elapsed() >= TICK) {
+            terminal.draw(|frame| app.render(frame, textarea))?;
+            last_draw = Instant::now();
         }
     }
     Ok(())

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -25,7 +25,7 @@ use super::app::{ReplApp, Turn};
 use super::commands;
 use super::mode::{OutputStyle, ReplMode};
 
-const ENABLE_BALANCED_MOUSE_REPORTING: &str = "\x1b[?1000h\x1b[?1006h";
+const ENABLE_BALANCED_MOUSE_REPORTING: &str = "\x1b[?1000h\x1b[?1002h\x1b[?1006h";
 const DISABLE_ALL_MOUSE_REPORTING: &str = "\x1b[?1006l\x1b[?1015l\x1b[?1003l\x1b[?1002l\x1b[?1000l";
 
 // ---------------------------------------------------------------------------
@@ -1730,10 +1730,10 @@ mod tests {
     }
 
     #[test]
-    fn balanced_mouse_reporting_avoids_drag_modes() {
+    fn balanced_mouse_reporting_enables_app_drag_without_all_motion() {
         assert!(ENABLE_BALANCED_MOUSE_REPORTING.contains("?1000h"));
+        assert!(ENABLE_BALANCED_MOUSE_REPORTING.contains("?1002h"));
         assert!(ENABLE_BALANCED_MOUSE_REPORTING.contains("?1006h"));
-        assert!(!ENABLE_BALANCED_MOUSE_REPORTING.contains("?1002h"));
         assert!(!ENABLE_BALANCED_MOUSE_REPORTING.contains("?1003h"));
         assert!(!ENABLE_BALANCED_MOUSE_REPORTING.contains("?1015h"));
 

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -6,6 +6,7 @@
 //! the async command dispatch.
 
 use std::fs;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process;
 
@@ -23,6 +24,9 @@ use crate::snapshot;
 use super::app::{ReplApp, Turn};
 use super::commands;
 use super::mode::{OutputStyle, ReplMode};
+
+const ENABLE_BALANCED_MOUSE_REPORTING: &str = "\x1b[?1000h\x1b[?1006h";
+const DISABLE_ALL_MOUSE_REPORTING: &str = "\x1b[?1006l\x1b[?1015l\x1b[?1003l\x1b[?1002l\x1b[?1000l";
 
 // ---------------------------------------------------------------------------
 // Public entry point
@@ -77,6 +81,7 @@ pub async fn run(workspace_root: PathBuf, config: DuumbiConfig) -> Result<()> {
     // Initialise ratatui (enters alternate screen, enables raw mode).
     let mut terminal = ratatui::init();
     execute!(std::io::stdout(), EnableBracketedPaste)?;
+    enable_balanced_mouse_reporting()?;
 
     // Single-line textarea — we intercept Enter ourselves.
     let mut textarea = TextArea::default();
@@ -85,6 +90,7 @@ pub async fn run(workspace_root: PathBuf, config: DuumbiConfig) -> Result<()> {
     let result = event_loop(&mut terminal, &mut app, &mut textarea).await;
 
     // Always restore the terminal, even on error.
+    disable_balanced_mouse_reporting().ok();
     execute!(std::io::stdout(), DisableBracketedPaste).ok();
     ratatui::restore();
 
@@ -116,10 +122,13 @@ async fn event_loop(
 
     loop {
         let event_ready = event::poll(TICK)?;
+        let mut should_redraw = false;
         if event_ready {
             match event::read()? {
                 Event::Key(key) => match app.handle_key(key, textarea) {
-                    super::mode::Action::Continue => {}
+                    super::mode::Action::Continue => {
+                        should_redraw = true;
+                    }
                     super::mode::Action::Exit => {
                         if let Some(ref mut mgr) = app.session_mgr {
                             mgr.archive().ok();
@@ -140,20 +149,24 @@ async fn event_loop(
                             break;
                         }
                         app.working = false;
+                        should_redraw = true;
                     }
                 },
                 Event::Paste(text) => {
                     textarea.insert_str(&text);
+                    should_redraw = true;
                 }
                 Event::Mouse(mouse) => {
-                    app.handle_mouse(mouse);
+                    should_redraw = app.handle_mouse(mouse);
                 }
-                _ => {}
+                _ => {
+                    should_redraw = true;
+                }
             }
         }
 
         let needs_anim = app.working || app.mode_dot_animated();
-        if event_ready || (needs_anim && last_draw.elapsed() >= TICK) {
+        if should_redraw || (needs_anim && last_draw.elapsed() >= TICK) {
             terminal.draw(|frame| app.render(frame, textarea))?;
             last_draw = Instant::now();
         }
@@ -405,13 +418,10 @@ async fn handle_slash(
             if app.has_workspace {
                 app.push_output("Workspace already initialised.", OutputStyle::Dim);
             } else {
-                run_with_terminal_restore(terminal, app, textarea, || {
-                    // run_init writes messages to stderr — visible outside alternate screen.
+                let workspace_root = app.workspace_root.clone();
+                let init_result = run_with_terminal_restore(terminal, app, textarea, || {
+                    super::init::run_init(&workspace_root)
                 });
-                ratatui::restore();
-                let init_result = super::init::run_init(&app.workspace_root);
-                *terminal = ratatui::init();
-                let _ = terminal.draw(|frame| app.render(frame, textarea));
                 match init_result {
                     Ok(()) => {
                         app.has_workspace = true;
@@ -475,18 +485,20 @@ async fn handle_slash(
 /// This is necessary for commands like `/build`, `/run`, `/check`, and
 /// `/describe` that write diagnostics directly to stderr — output that would
 /// be hidden inside the alternate screen.
-fn run_with_terminal_restore<F>(
+fn run_with_terminal_restore<F, R>(
     terminal: &mut ratatui::DefaultTerminal,
     app: &mut ReplApp,
     textarea: &mut TextArea<'_>,
     f: F,
-) where
-    F: FnOnce(),
+) -> R
+where
+    F: FnOnce() -> R,
 {
     // Leave alternate screen so the command's stderr output is visible.
+    disable_balanced_mouse_reporting().ok();
     ratatui::restore();
 
-    f();
+    let result = f();
 
     // Prompt the user to return to the TUI.
     eprintln!("\n[Press Enter to return to the REPL]");
@@ -494,8 +506,25 @@ fn run_with_terminal_restore<F>(
 
     // Re-enter alternate screen.
     *terminal = ratatui::init();
+    enable_balanced_mouse_reporting().ok();
     // Redraw immediately so the TUI is not blank.
     let _ = terminal.draw(|frame| app.render(frame, textarea));
+    result
+}
+
+fn enable_balanced_mouse_reporting() -> io::Result<()> {
+    write_terminal_sequence(DISABLE_ALL_MOUSE_REPORTING)?;
+    write_terminal_sequence(ENABLE_BALANCED_MOUSE_REPORTING)
+}
+
+fn disable_balanced_mouse_reporting() -> io::Result<()> {
+    write_terminal_sequence(DISABLE_ALL_MOUSE_REPORTING)
+}
+
+fn write_terminal_sequence(sequence: &str) -> io::Result<()> {
+    let mut stdout = io::stdout();
+    stdout.write_all(sequence.as_bytes())?;
+    stdout.flush()
 }
 
 // ---------------------------------------------------------------------------
@@ -1698,6 +1727,21 @@ mod tests {
         assert!(!should_show_elapsed("/status"));
         assert!(should_show_elapsed("/describe"));
         assert!(should_show_elapsed("create a calculator"));
+    }
+
+    #[test]
+    fn balanced_mouse_reporting_avoids_drag_modes() {
+        assert!(ENABLE_BALANCED_MOUSE_REPORTING.contains("?1000h"));
+        assert!(ENABLE_BALANCED_MOUSE_REPORTING.contains("?1006h"));
+        assert!(!ENABLE_BALANCED_MOUSE_REPORTING.contains("?1002h"));
+        assert!(!ENABLE_BALANCED_MOUSE_REPORTING.contains("?1003h"));
+        assert!(!ENABLE_BALANCED_MOUSE_REPORTING.contains("?1015h"));
+
+        assert!(DISABLE_ALL_MOUSE_REPORTING.contains("?1006l"));
+        assert!(DISABLE_ALL_MOUSE_REPORTING.contains("?1015l"));
+        assert!(DISABLE_ALL_MOUSE_REPORTING.contains("?1003l"));
+        assert!(DISABLE_ALL_MOUSE_REPORTING.contains("?1002l"));
+        assert!(DISABLE_ALL_MOUSE_REPORTING.contains("?1000l"));
     }
 
     #[test]

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -145,6 +145,9 @@ async fn event_loop(
                 Event::Paste(text) => {
                     textarea.insert_str(&text);
                 }
+                Event::Mouse(mouse) => {
+                    app.handle_mouse(mouse);
+                }
                 _ => {}
             }
         }
@@ -171,25 +174,47 @@ async fn process_input(
     textarea: &mut TextArea<'_>,
     input: &str,
 ) -> bool {
-    if input.starts_with('/') {
-        handle_slash(terminal, app, textarea, input).await
-    } else {
-        // Visual separator before user-submitted input output.
-        if !app.output_lines.is_empty() {
-            app.push_output("", OutputStyle::Normal);
-        }
-        app.push_output(format!("\u{25cf} {input}"), OutputStyle::Dim);
+    let trimmed = input.trim();
+    if matches!(trimmed, "/exit" | "/quit") {
+        return handle_slash(terminal, app, textarea, input).await;
+    }
 
+    app.begin_user_block(input);
+    let started = std::time::Instant::now();
+    let show_elapsed = should_show_elapsed(input);
+
+    if input.starts_with('/') {
+        let should_exit = handle_slash(terminal, app, textarea, input).await;
+        if show_elapsed && !should_exit {
+            app.finish_current_output_elapsed(started.elapsed());
+        }
+        should_exit
+    } else {
         match app.mode {
             ReplMode::Agent => {
                 handle_ai_request(terminal, app, textarea, input).await;
+                if show_elapsed {
+                    app.finish_current_output_elapsed(started.elapsed());
+                }
                 false
             }
             ReplMode::Intent => {
                 handle_intent_input(app, input).await;
+                if show_elapsed {
+                    app.finish_current_output_elapsed(started.elapsed());
+                }
                 false
             }
         }
+    }
+}
+
+fn should_show_elapsed(input: &str) -> bool {
+    let mut parts = input.splitn(2, ' ');
+    match parts.next().unwrap_or("") {
+        "/help" | "/status" => false,
+        cmd if cmd.starts_with('/') => true,
+        _ => true,
     }
 }
 
@@ -212,14 +237,6 @@ async fn handle_slash(
 
     let graph_path = app.workspace_root.join(".duumbi/graph/main.jsonld");
     let output_path = app.workspace_root.join(".duumbi/build/output");
-
-    // Visual separator: empty line + bullet header before each command's output.
-    if !matches!(cmd, "/exit" | "/quit") {
-        if !app.output_lines.is_empty() {
-            app.push_output("", OutputStyle::Normal);
-        }
-        app.push_output(format!("\u{25cf} {input}"), OutputStyle::Normal);
-    }
 
     match cmd {
         "/build" => {
@@ -259,13 +276,14 @@ async fn handle_slash(
             });
         }
 
-        "/describe" => {
-            run_with_terminal_restore(terminal, app, textarea, || {
-                commands::describe(&graph_path).unwrap_or_else(|e| {
-                    eprintln!("Describe failed: {e:#}");
-                });
-            });
-        }
+        "/describe" => match commands::describe_to_string(&graph_path) {
+            Ok(description) => {
+                app.push_output(description, OutputStyle::Normal);
+            }
+            Err(e) => {
+                app.push_output(format!("Describe failed: {e:#}"), OutputStyle::Error);
+            }
+        },
 
         "/undo" => match snapshot::restore_latest(&app.workspace_root) {
             Ok(true) => {
@@ -605,7 +623,11 @@ async fn handle_ai_request(
     let result = match outcome {
         Ok(orchestrator::MutationOutcome::Success(r)) => r,
         Ok(orchestrator::MutationOutcome::NeedsClarification(question)) => {
-            app.push_output(format!("? {question}"), OutputStyle::Ai);
+            app.push_output(format!("Question: {question}"), OutputStyle::Ai);
+            app.push_output(
+                "Reply in the prompt to continue this turn.",
+                OutputStyle::Dim,
+            );
             app.history.push(Turn {
                 request: request.to_string(),
                 summary: format!("Clarification needed: {question}"),
@@ -631,11 +653,14 @@ async fn handle_ai_request(
     );
 
     // Save snapshot and write the updated graph.
-    if let Err(e) = snapshot::save_snapshot(&workspace, &source_str) {
-        app.push_output(
-            format!("Warning: snapshot save failed: {e:#}"),
-            OutputStyle::Error,
-        );
+    match snapshot::save_snapshot(&workspace, &source_str) {
+        Ok(snapshot_path) => app.mark_latest_user_block_revertable(snapshot_path),
+        Err(e) => {
+            app.push_output(
+                format!("Warning: snapshot save failed: {e:#}"),
+                OutputStyle::Error,
+            );
+        }
     }
     let patched_str = match serde_json::to_string_pretty(&result.patched) {
         Ok(s) => s,
@@ -1499,74 +1524,18 @@ fn print_status_to_buffer(app: &mut ReplApp) {
 
 /// Pushes the available slash commands into the output buffer.
 fn print_help_to_buffer(app: &mut ReplApp) {
-    let entries: &[(&str, &str)] = &[
-        ("Slash commands:", ""),
-        ("  /build", "Compile the current graph to a native binary"),
-        ("  /run [args]", "Run the compiled binary"),
-        ("  /check", "Validate the graph without compiling"),
-        (
-            "  /describe",
-            "Print human-readable pseudocode of the graph",
-        ),
-        ("  /undo", "Restore the previous graph snapshot"),
-        (
-            "  /status",
-            "Show workspace, model, and session information",
-        ),
-        ("  /history", "Show session conversation history"),
-        ("  /model", "Show the current LLM model"),
-        (
-            "  /clear [chat|session|all]",
-            "Clear chat history and screen",
-        ),
-        ("", ""),
-        ("Intent commands:", ""),
-        ("  /intent", "List all active intents"),
-        (
-            "  /intent create <desc>",
-            "Generate and save a new intent spec",
-        ),
-        ("  /intent review [name]", "Show intent details"),
-        ("  /intent execute <name>", "Execute an intent end-to-end"),
-        ("  /intent status [name]", "Show intent execution status"),
-        ("  /intent focus <slug>", "Focus an intent (Intent mode)"),
-        ("  /intent unfocus", "Clear focused intent"),
-        ("", ""),
-        ("Knowledge commands:", ""),
-        ("  /knowledge", "Show knowledge statistics"),
-        ("  /knowledge list", "List all knowledge nodes"),
-        ("  /knowledge show <id>", "Show knowledge node details"),
-        ("  /knowledge prune [days]", "Prune old knowledge nodes"),
-        ("", ""),
-        ("Session commands:", ""),
-        ("  /resume", "List archived sessions"),
-        (
-            "  /resume <N>",
-            "Load session N's history into current context",
-        ),
-        ("", ""),
-        ("Registry & dependency commands:", ""),
-        ("  /search <query>", "Search registries for modules"),
-        ("  /publish", "Package and publish the current module"),
-        ("  /registry list", "List configured registries"),
-        ("  /deps list", "List declared dependencies"),
-        ("  /deps add <name> [path]", "Add a dependency"),
-        ("  /deps remove <name>", "Remove a dependency"),
-        ("  /deps audit", "Verify dependency integrity"),
-        ("  /deps tree", "Show the dependency tree"),
-        ("  /deps update [name]", "Update dependencies"),
-        ("  /deps vendor", "Vendor cached dependencies"),
-        ("", ""),
-        ("  /help", "Show this help text"),
-        ("  /exit", "Exit the REPL"),
-    ];
-    for (cmd, desc) in entries {
-        if cmd.is_empty() {
-            app.push_output("", OutputStyle::Normal);
-        } else if desc.is_empty() {
-            app.push_output(*cmd, OutputStyle::Normal);
-        } else {
-            app.push_output(format!("{cmd:<35} {desc}"), OutputStyle::Help);
+    app.push_output("Slash commands:", OutputStyle::Normal);
+    for group in super::completion::SLASH_GROUPS {
+        app.push_output("", OutputStyle::Normal);
+        app.push_output(group.label(), OutputStyle::Normal);
+        for entry in super::completion::SLASH_COMMANDS
+            .iter()
+            .filter(|entry| entry.group == *group)
+        {
+            app.push_output(
+                format!("  {:<32} {}", entry.command, entry.description),
+                OutputStyle::Help,
+            );
         }
     }
 }
@@ -1721,5 +1690,39 @@ mod tests {
         assert!(prompt.contains("Context from this session"));
         assert!(prompt.contains("add add function"));
         assert!(prompt.ends_with("add multiply"));
+    }
+
+    #[test]
+    fn elapsed_policy_skips_internal_commands() {
+        assert!(!should_show_elapsed("/help"));
+        assert!(!should_show_elapsed("/status"));
+        assert!(should_show_elapsed("/describe"));
+        assert!(should_show_elapsed("create a calculator"));
+    }
+
+    #[test]
+    fn help_uses_slash_group_order() {
+        let mut app = ReplApp::new(
+            crate::config::DuumbiConfig::default(),
+            std::path::PathBuf::from("."),
+            None,
+            None,
+            true,
+            false,
+        );
+
+        print_help_to_buffer(&mut app);
+        let rendered = app
+            .output_lines
+            .iter()
+            .map(|line| line.text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let build = rendered.find("BUILD & RUN").expect("build group");
+        let intent = rendered.find("INTENT").expect("intent group");
+        let system = rendered.find("SYSTEM").expect("system group");
+        assert!(build < intent);
+        assert!(intent < system);
     }
 }

--- a/src/cli/theme.rs
+++ b/src/cli/theme.rs
@@ -105,6 +105,8 @@ pub mod tui {
 
     /// Primary text colour (warm off-white).
     pub const PARCHMENT: Color = Color::Rgb(0xf5, 0xf2, 0xea);
+    /// Global canvas background for the whole TUI.
+    pub const CANVAS_BG: Color = Color::Rgb(0x0f, 0x1f, 0x27);
     /// Primary action / accent colour (rust).
     pub const RUST: Color = Color::Rgb(0xd0, 0x7a, 0x47);
     /// Softer rust used for badges and helper text.
@@ -216,6 +218,12 @@ pub mod tui {
         Style::default().fg(col(PARCHMENT)).bg(col(HAIRLINE_DIM))
     }
 
+    /// Base canvas style used across the whole TUI.
+    #[must_use]
+    pub fn canvas() -> Style {
+        Style::default().bg(col(CANVAS_BG))
+    }
+
     /// Mode pill background (parchment text on blue-ink).
     #[must_use]
     #[allow(dead_code)] // used in Phase B mode strip
@@ -275,8 +283,15 @@ pub mod tui {
 
     /// Rust accent used for the left edge of the empty-state card.
     #[must_use]
+    #[allow(dead_code)] // kept for future glyph-style accents (currently using panel_accent_bar)
     pub fn panel_accent() -> Style {
         Style::default().fg(col(RUST)).add_modifier(Modifier::BOLD)
+    }
+
+    /// Solid accent strip for the empty-state card.
+    #[must_use]
+    pub fn panel_accent_bar() -> Style {
+        Style::default().bg(col(RUST))
     }
 
     /// Outline pill used for mode badges and empty-state tags.
@@ -299,7 +314,9 @@ pub mod tui {
     /// Inline uppercase labels for the single-row footer.
     #[must_use]
     pub fn label_caps_inline() -> Style {
-        Style::default().fg(col(HAIRLINE))
+        Style::default()
+            .fg(col(HAIRLINE))
+            .add_modifier(Modifier::DIM)
     }
 
     /// Bold rust for status-dock workspace name.
@@ -312,6 +329,12 @@ pub mod tui {
     #[must_use]
     pub fn dock_value() -> Style {
         Style::default().fg(col(PARCHMENT))
+    }
+
+    /// Muted value style for dense footer rows.
+    #[must_use]
+    pub fn dock_value_muted() -> Style {
+        Style::default().fg(col(Color::Rgb(0xd9, 0xd4, 0xc8)))
     }
 
     /// Bold blue-mid for the focused intent slug.
@@ -460,6 +483,7 @@ mod tests {
         let _ = tui::version_badge();
         let _ = tui::helper();
         let _ = tui::keycap();
+        let _ = tui::canvas();
         let _ = tui::pill_blue();
         let _ = tui::pill_rust();
         let _ = tui::chevron();
@@ -469,11 +493,13 @@ mod tests {
         let _ = tui::panel_surface();
         let _ = tui::panel_border();
         let _ = tui::panel_accent();
+        let _ = tui::panel_accent_bar();
         let _ = tui::pill_outline();
         let _ = tui::label_caps();
         let _ = tui::label_caps_inline();
         let _ = tui::workspace_value();
         let _ = tui::dock_value();
+        let _ = tui::dock_value_muted();
         let _ = tui::intent_slug();
         let _ = tui::placeholder();
         let _ = tui::out_normal();

--- a/src/cli/theme.rs
+++ b/src/cli/theme.rs
@@ -109,6 +109,8 @@ pub mod tui {
     /// `--ink` canvas). Deliberately lightened slightly from pure black so
     /// the brand tone is perceptible on every modern terminal.
     pub const CANVAS_BG: Color = Color::Rgb(0x1a, 0x1a, 0x18);
+    /// Slightly lifted surface used for inset cards.
+    pub const PANEL_BG: Color = Color::Rgb(0x21, 0x21, 0x1e);
     /// Primary action / accent colour (rust).
     pub const RUST: Color = Color::Rgb(0xd0, 0x7a, 0x47);
     /// Softer rust used for badges and helper text.
@@ -265,20 +267,10 @@ pub mod tui {
         Style::default().fg(col(HAIRLINE))
     }
 
-    /// Dim hairline (used for the line body between rust dots).
-    #[must_use]
-    pub fn hairline_dim() -> Style {
-        Style::default().fg(col(HAIRLINE_DIM))
-    }
-
     /// Subtle panel surface used for inset cards and overlays.
-    ///
-    /// Matches the canvas bg exactly so a card embedded in the main view
-    /// has no visible "stripe" where its background ends — only the rust
-    /// pillar and top/bottom hairline borders mark the card boundary.
     #[must_use]
     pub fn panel_surface() -> Style {
-        Style::default().bg(col(CANVAS_BG))
+        Style::default().bg(col(PANEL_BG))
     }
 
     /// Border colour for inset panels and cards.
@@ -290,7 +282,10 @@ pub mod tui {
     /// Rust accent used for the left edge of the empty-state card.
     #[must_use]
     pub fn panel_accent() -> Style {
-        Style::default().fg(col(RUST)).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(col(RUST))
+            .bg(col(PANEL_BG))
+            .add_modifier(Modifier::BOLD)
     }
 
     /// Outline pill used for mode badges and empty-state tags.
@@ -407,6 +402,35 @@ pub mod tui {
         Style::default().fg(col(RUST)).add_modifier(Modifier::BOLD)
     }
 
+    /// Background for the highlighted slash-menu row.
+    #[must_use]
+    pub fn slash_selected_row() -> Style {
+        Style::default().bg(col(Color::Rgb(0x2d, 0x25, 0x1f)))
+    }
+
+    /// Highlight for the matched slash-command prefix.
+    #[must_use]
+    pub fn slash_match() -> Style {
+        Style::default()
+            .fg(col(PARCHMENT))
+            .bg(col(Color::Rgb(0x5a, 0x34, 0x24)))
+            .add_modifier(Modifier::BOLD)
+    }
+
+    /// Slash command text.
+    #[must_use]
+    pub fn slash_command() -> Style {
+        Style::default()
+            .fg(col(PARCHMENT))
+            .add_modifier(Modifier::BOLD)
+    }
+
+    /// Slash-menu group label.
+    #[must_use]
+    pub fn slash_group() -> Style {
+        Style::default().fg(col(RUST)).add_modifier(Modifier::BOLD)
+    }
+
     /// Unselected slash-menu row.
     #[must_use]
     #[allow(dead_code)] // currently uses out_dim() — kept for future per-row styling
@@ -489,7 +513,6 @@ mod tests {
         let _ = tui::chevron();
         let _ = tui::focus_border();
         let _ = tui::hairline();
-        let _ = tui::hairline_dim();
         let _ = tui::panel_surface();
         let _ = tui::panel_border();
         let _ = tui::panel_accent();
@@ -509,6 +532,10 @@ mod tests {
         let _ = tui::out_help_cmd();
         let _ = tui::out_help_desc();
         let _ = tui::slash_selected();
+        let _ = tui::slash_selected_row();
+        let _ = tui::slash_match();
+        let _ = tui::slash_command();
+        let _ = tui::slash_group();
         let _ = tui::slash_normal();
         let _ = tui::mode_pill();
         let _ = tui::mode_pill();

--- a/src/cli/theme.rs
+++ b/src/cli/theme.rs
@@ -1,9 +1,14 @@
 //! Centralized terminal color palette.
 //!
-//! All CLI color usage goes through these helper functions so that:
-//! - Colors are consistent across the entire CLI
-//! - `NO_COLOR` / `CLICOLOR` are respected via `owo-colors` + `anstream`
-//! - Non-TTY output is automatically stripped of ANSI codes
+//! Two coexisting APIs:
+//!
+//! - The top-level `owo-colors` helpers (`error`, `success`, `dim`, …) return
+//!   colored `String` values for non-TUI command output.
+//! - The [`tui`] submodule returns `ratatui::Style` values for the full-screen
+//!   REPL, using the brand-aligned dark palette (rust + parchment + blue ink).
+//!
+//! Both honour `NO_COLOR`/`CLICOLOR` for graceful degradation on terminals
+//! that do not support truecolor.
 
 use owo_colors::OwoColorize;
 
@@ -79,6 +84,301 @@ pub fn cross_mark() -> String {
 }
 
 // ---------------------------------------------------------------------------
+// TUI palette — ratatui::Style helpers for the full-screen REPL
+// ---------------------------------------------------------------------------
+
+/// Brand-aligned dark theme palette and semantic style helpers for the REPL.
+///
+/// The constants mirror the CSS variables used in the design mockup
+/// (`duumbi-cli-brand-dark.html`). Every style helper returns a
+/// [`ratatui::style::Style`] suitable for [`ratatui::text::Span::styled`].
+///
+/// Truecolor (24-bit) is preferred but the module gracefully falls back to
+/// the 16 ANSI named colors when `NO_COLOR=1` is set or the terminal does
+/// not advertise truecolor support via `COLORTERM`.
+pub mod tui {
+    use std::sync::OnceLock;
+
+    use ratatui::style::{Color, Modifier, Style};
+
+    // ---- Raw RGB palette (mirrors the mockup CSS vars) ---------------------
+
+    /// Primary text colour (warm off-white).
+    pub const PARCHMENT: Color = Color::Rgb(0xf5, 0xf2, 0xea);
+    /// Primary action / accent colour (rust).
+    pub const RUST: Color = Color::Rgb(0xd0, 0x7a, 0x47);
+    /// Softer rust used for badges and helper text.
+    pub const RUST_SOFT: Color = Color::Rgb(0xc9, 0x6a, 0x3e);
+    /// Emphasis blue used for the version badge and pulsing dot.
+    pub const BLUE_INK: Color = Color::Rgb(0x7b, 0xa8, 0xe0);
+    /// Slightly cooler blue used for the focused intent slug.
+    pub const BLUE_MID: Color = Color::Rgb(0x6b, 0x9e, 0xd9);
+    /// Dim hairline colour (parchment at ~7% alpha against the canvas).
+    pub const HAIRLINE_DIM: Color = Color::Rgb(0x3a, 0x39, 0x35);
+    /// Brighter hairline colour (parchment at ~22% alpha).
+    pub const HAIRLINE: Color = Color::Rgb(0x6e, 0x6c, 0x65);
+    /// Reserved for future JSON-LD key highlighting.
+    pub const TOKEN_KEY: Color = Color::Rgb(0x7d, 0xcf, 0xff);
+    /// Reserved for future JSON-LD string highlighting.
+    pub const TOKEN_STRING: Color = Color::Rgb(0x9e, 0xce, 0x6a);
+    /// Reserved for future JSON-LD URL highlighting.
+    pub const TOKEN_URL: Color = Color::Rgb(0xe0, 0xaf, 0x68);
+    /// Reserved for future JSON-LD type highlighting.
+    pub const TOKEN_TYPE: Color = Color::Rgb(0xbb, 0x9a, 0xf7);
+
+    /// Snapshot of the palette decision made once at startup.
+    #[derive(Clone, Copy)]
+    struct Palette {
+        truecolor: bool,
+    }
+
+    static PALETTE: OnceLock<Palette> = OnceLock::new();
+
+    fn palette() -> Palette {
+        *PALETTE.get_or_init(|| Palette {
+            truecolor: detect_truecolor(),
+        })
+    }
+
+    fn detect_truecolor() -> bool {
+        if std::env::var_os("NO_COLOR").is_some() {
+            return false;
+        }
+        match std::env::var("COLORTERM") {
+            Ok(v) => {
+                let lower = v.to_lowercase();
+                lower.contains("truecolor") || lower.contains("24bit")
+            }
+            Err(_) => {
+                // Common modern terminals (kitty, wezterm, alacritty, vscode)
+                // export `TERM_PROGRAM` even without COLORTERM.
+                std::env::var("TERM_PROGRAM").is_ok()
+            }
+        }
+    }
+
+    /// Returns `true` when truecolor (24-bit) styling is enabled.
+    #[must_use]
+    pub fn truecolor_supported() -> bool {
+        palette().truecolor
+    }
+
+    /// Maps a truecolor palette value to its closest 16-color fallback.
+    pub(super) fn fallback(c: Color) -> Color {
+        match c {
+            RUST | RUST_SOFT => Color::Red,
+            BLUE_INK | BLUE_MID | TOKEN_KEY => Color::Cyan,
+            PARCHMENT => Color::White,
+            HAIRLINE | HAIRLINE_DIM => Color::Gray,
+            TOKEN_STRING => Color::Green,
+            TOKEN_URL => Color::Yellow,
+            TOKEN_TYPE => Color::Magenta,
+            other => other,
+        }
+    }
+
+    /// Returns the colour as-is when truecolor is supported, otherwise the
+    /// 16-colour fallback.
+    #[must_use]
+    pub fn col(c: Color) -> Color {
+        if truecolor_supported() {
+            c
+        } else {
+            fallback(c)
+        }
+    }
+
+    // ---- Semantic style helpers --------------------------------------------
+
+    /// Bold parchment for the brand word ("duumbi").
+    #[must_use]
+    pub fn brand_word() -> Style {
+        Style::default()
+            .fg(col(PARCHMENT))
+            .add_modifier(Modifier::BOLD)
+    }
+
+    /// Blue-ink badge for the version number.
+    #[must_use]
+    pub fn version_badge() -> Style {
+        Style::default().fg(col(BLUE_INK))
+    }
+
+    /// Soft rust used for short helper text (e.g. "type /help").
+    #[must_use]
+    pub fn helper() -> Style {
+        Style::default().fg(col(RUST_SOFT))
+    }
+
+    /// Inset keycap (parchment foreground on a hairline-dim background).
+    #[must_use]
+    pub fn keycap() -> Style {
+        Style::default().fg(col(PARCHMENT)).bg(col(HAIRLINE_DIM))
+    }
+
+    /// Mode pill background (parchment text on blue-ink).
+    #[must_use]
+    #[allow(dead_code)] // used in Phase B mode strip
+    pub fn pill_blue() -> Style {
+        Style::default()
+            .fg(col(PARCHMENT))
+            .bg(col(BLUE_INK))
+            .add_modifier(Modifier::BOLD)
+    }
+
+    /// Activity / empty-state pill background (parchment text on rust).
+    #[must_use]
+    #[allow(dead_code)] // used in Phase C activity button + empty-state card
+    pub fn pill_rust() -> Style {
+        Style::default()
+            .fg(col(PARCHMENT))
+            .bg(col(RUST))
+            .add_modifier(Modifier::BOLD)
+    }
+
+    /// Bold rust chevron (`›`) used as the prompt prefix.
+    #[must_use]
+    pub fn chevron() -> Style {
+        Style::default().fg(col(RUST)).add_modifier(Modifier::BOLD)
+    }
+
+    /// Rust focus border around the prompt input well.
+    #[must_use]
+    #[allow(dead_code)] // used in Phase D focus ring
+    pub fn focus_border() -> Style {
+        Style::default().fg(col(RUST))
+    }
+
+    /// Hairline separator colour (mid-tone).
+    #[must_use]
+    pub fn hairline() -> Style {
+        Style::default().fg(col(HAIRLINE))
+    }
+
+    /// Dim hairline (used for the line body between rust dots).
+    #[must_use]
+    pub fn hairline_dim() -> Style {
+        Style::default().fg(col(HAIRLINE_DIM))
+    }
+
+    /// Uppercase status-dock labels ("TIME", "WORKSPACE", …).
+    #[must_use]
+    pub fn label_caps() -> Style {
+        Style::default()
+            .fg(col(HAIRLINE))
+            .add_modifier(Modifier::DIM)
+    }
+
+    /// Bold rust for status-dock workspace name.
+    #[must_use]
+    pub fn workspace_value() -> Style {
+        Style::default().fg(col(RUST)).add_modifier(Modifier::BOLD)
+    }
+
+    /// Parchment for status-dock value rows.
+    #[must_use]
+    pub fn dock_value() -> Style {
+        Style::default().fg(col(PARCHMENT))
+    }
+
+    /// Bold blue-mid for the focused intent slug.
+    #[must_use]
+    pub fn intent_slug() -> Style {
+        Style::default()
+            .fg(col(BLUE_MID))
+            .add_modifier(Modifier::BOLD)
+    }
+
+    // ---- Output buffer styles (replaces the inline OutputStyle match) -----
+
+    /// Style for normal output lines.
+    #[must_use]
+    pub fn out_normal() -> Style {
+        Style::default().fg(col(PARCHMENT))
+    }
+
+    /// Style for error output lines.
+    #[must_use]
+    pub fn out_error() -> Style {
+        Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
+    }
+
+    /// Style for success output lines.
+    #[must_use]
+    pub fn out_success() -> Style {
+        Style::default()
+            .fg(Color::Green)
+            .add_modifier(Modifier::BOLD)
+    }
+
+    /// Style for dim/secondary output lines.
+    #[must_use]
+    pub fn out_dim() -> Style {
+        Style::default().fg(col(HAIRLINE))
+    }
+
+    /// Style for AI streaming / assistant output.
+    #[must_use]
+    pub fn out_ai() -> Style {
+        Style::default().fg(col(BLUE_INK))
+    }
+
+    /// Style for the command column of `/help` output.
+    #[must_use]
+    pub fn out_help_cmd() -> Style {
+        Style::default().fg(col(RUST)).add_modifier(Modifier::BOLD)
+    }
+
+    /// Style for the description column of `/help` output.
+    #[must_use]
+    pub fn out_help_desc() -> Style {
+        Style::default().fg(col(PARCHMENT))
+    }
+
+    // ---- Slash-menu styles -------------------------------------------------
+
+    /// Highlighted slash-menu row.
+    #[must_use]
+    pub fn slash_selected() -> Style {
+        Style::default().fg(col(RUST)).add_modifier(Modifier::BOLD)
+    }
+
+    /// Unselected slash-menu row.
+    #[must_use]
+    #[allow(dead_code)] // currently uses out_dim() — kept for future per-row styling
+    pub fn slash_normal() -> Style {
+        Style::default()
+            .fg(col(HAIRLINE))
+            .add_modifier(Modifier::DIM)
+    }
+
+    // ---- Mode strip --------------------------------------------------------
+
+    /// Bold parchment for the active mode label.
+    #[must_use]
+    pub fn mode_label() -> Style {
+        Style::default()
+            .fg(col(PARCHMENT))
+            .add_modifier(Modifier::BOLD)
+    }
+
+    /// Dim helper text on the mode strip ("Shift+Tab swap").
+    #[must_use]
+    pub fn mode_hint() -> Style {
+        Style::default()
+            .fg(col(HAIRLINE))
+            .add_modifier(Modifier::DIM)
+    }
+
+    /// Pulsing dot beside the active mode label.
+    #[must_use]
+    #[allow(dead_code)] // used in Phase D pulsing animation
+    pub fn mode_dot() -> Style {
+        Style::default().fg(col(BLUE_INK))
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -109,5 +409,59 @@ mod tests {
         // On non-TTY the ANSI codes might be stripped, but the char itself is present
         assert!(cm.contains('\u{2713}') || cm.contains("✓"));
         assert!(xm.contains('\u{2717}') || xm.contains("✗"));
+    }
+
+    #[test]
+    fn tui_helpers_compile_and_return_styles() {
+        // Smoke test: every public helper returns a usable Style.
+        let _ = tui::brand_word();
+        let _ = tui::version_badge();
+        let _ = tui::helper();
+        let _ = tui::keycap();
+        let _ = tui::pill_blue();
+        let _ = tui::pill_rust();
+        let _ = tui::chevron();
+        let _ = tui::focus_border();
+        let _ = tui::hairline();
+        let _ = tui::hairline_dim();
+        let _ = tui::label_caps();
+        let _ = tui::workspace_value();
+        let _ = tui::dock_value();
+        let _ = tui::intent_slug();
+        let _ = tui::out_normal();
+        let _ = tui::out_error();
+        let _ = tui::out_success();
+        let _ = tui::out_dim();
+        let _ = tui::out_ai();
+        let _ = tui::out_help_cmd();
+        let _ = tui::out_help_desc();
+        let _ = tui::slash_selected();
+        let _ = tui::slash_normal();
+        let _ = tui::mode_label();
+        let _ = tui::mode_hint();
+        let _ = tui::mode_dot();
+    }
+
+    #[test]
+    fn fallback_maps_palette_to_named_colors() {
+        use ratatui::style::Color;
+        // These conversions are deterministic regardless of env state.
+        assert_eq!(tui::fallback(tui::RUST), Color::Red);
+        assert_eq!(tui::fallback(tui::RUST_SOFT), Color::Red);
+        assert_eq!(tui::fallback(tui::BLUE_INK), Color::Cyan);
+        assert_eq!(tui::fallback(tui::BLUE_MID), Color::Cyan);
+        assert_eq!(tui::fallback(tui::PARCHMENT), Color::White);
+        assert_eq!(tui::fallback(tui::HAIRLINE), Color::Gray);
+        assert_eq!(tui::fallback(tui::HAIRLINE_DIM), Color::Gray);
+        assert_eq!(tui::fallback(tui::TOKEN_STRING), Color::Green);
+        assert_eq!(tui::fallback(tui::TOKEN_URL), Color::Yellow);
+    }
+
+    #[test]
+    fn col_returns_palette_color_when_truecolor() {
+        // We can't easily mock the OnceLock, but we can at least exercise
+        // the function and verify it returns *some* colour without panicking.
+        let _ = tui::col(tui::RUST);
+        let _ = tui::col(tui::PARCHMENT);
     }
 }

--- a/src/cli/theme.rs
+++ b/src/cli/theme.rs
@@ -261,12 +261,45 @@ pub mod tui {
         Style::default().fg(col(HAIRLINE_DIM))
     }
 
+    /// Subtle panel surface used for inset cards and overlays.
+    #[must_use]
+    pub fn panel_surface() -> Style {
+        Style::default().bg(col(Color::Rgb(0x1a, 0x19, 0x17)))
+    }
+
+    /// Border colour for inset panels and cards.
+    #[must_use]
+    pub fn panel_border() -> Style {
+        Style::default().fg(col(HAIRLINE_DIM))
+    }
+
+    /// Rust accent used for the left edge of the empty-state card.
+    #[must_use]
+    pub fn panel_accent() -> Style {
+        Style::default().fg(col(RUST)).add_modifier(Modifier::BOLD)
+    }
+
+    /// Outline pill used for mode badges and empty-state tags.
+    #[must_use]
+    pub fn pill_outline() -> Style {
+        Style::default()
+            .fg(col(RUST))
+            .bg(col(Color::Rgb(0x22, 0x1d, 0x19)))
+            .add_modifier(Modifier::BOLD)
+    }
+
     /// Uppercase status-dock labels ("TIME", "WORKSPACE", …).
     #[must_use]
     pub fn label_caps() -> Style {
         Style::default()
             .fg(col(HAIRLINE))
             .add_modifier(Modifier::DIM)
+    }
+
+    /// Inline uppercase labels for the single-row footer.
+    #[must_use]
+    pub fn label_caps_inline() -> Style {
+        Style::default().fg(col(HAIRLINE))
     }
 
     /// Bold rust for status-dock workspace name.
@@ -287,6 +320,14 @@ pub mod tui {
         Style::default()
             .fg(col(BLUE_MID))
             .add_modifier(Modifier::BOLD)
+    }
+
+    /// Placeholder text inside the prompt well.
+    #[must_use]
+    pub fn placeholder() -> Style {
+        Style::default()
+            .fg(col(HAIRLINE))
+            .add_modifier(Modifier::DIM)
     }
 
     // ---- Output buffer styles (replaces the inline OutputStyle match) -----
@@ -354,11 +395,12 @@ pub mod tui {
 
     // ---- Mode strip --------------------------------------------------------
 
-    /// Bold parchment for the active mode label.
+    /// Outlined blue pill for the active mode indicator.
     #[must_use]
-    pub fn mode_label() -> Style {
+    pub fn mode_pill() -> Style {
         Style::default()
-            .fg(col(PARCHMENT))
+            .fg(col(BLUE_INK))
+            .bg(col(Color::Rgb(0x1d, 0x23, 0x2c)))
             .add_modifier(Modifier::BOLD)
     }
 
@@ -424,10 +466,16 @@ mod tests {
         let _ = tui::focus_border();
         let _ = tui::hairline();
         let _ = tui::hairline_dim();
+        let _ = tui::panel_surface();
+        let _ = tui::panel_border();
+        let _ = tui::panel_accent();
+        let _ = tui::pill_outline();
         let _ = tui::label_caps();
+        let _ = tui::label_caps_inline();
         let _ = tui::workspace_value();
         let _ = tui::dock_value();
         let _ = tui::intent_slug();
+        let _ = tui::placeholder();
         let _ = tui::out_normal();
         let _ = tui::out_error();
         let _ = tui::out_success();
@@ -437,7 +485,8 @@ mod tests {
         let _ = tui::out_help_desc();
         let _ = tui::slash_selected();
         let _ = tui::slash_normal();
-        let _ = tui::mode_label();
+        let _ = tui::mode_pill();
+        let _ = tui::mode_pill();
         let _ = tui::mode_hint();
         let _ = tui::mode_dot();
     }

--- a/src/cli/theme.rs
+++ b/src/cli/theme.rs
@@ -105,8 +105,10 @@ pub mod tui {
 
     /// Primary text colour (warm off-white).
     pub const PARCHMENT: Color = Color::Rgb(0xf5, 0xf2, 0xea);
-    /// Global canvas background for the whole TUI.
-    pub const CANVAS_BG: Color = Color::Rgb(0x0f, 0x1f, 0x27);
+    /// Global canvas background for the whole TUI (matches the mockup
+    /// `--ink` canvas). Deliberately lightened slightly from pure black so
+    /// the brand tone is perceptible on every modern terminal.
+    pub const CANVAS_BG: Color = Color::Rgb(0x1a, 0x1a, 0x18);
     /// Primary action / accent colour (rust).
     pub const RUST: Color = Color::Rgb(0xd0, 0x7a, 0x47);
     /// Softer rust used for badges and helper text.
@@ -270,9 +272,13 @@ pub mod tui {
     }
 
     /// Subtle panel surface used for inset cards and overlays.
+    ///
+    /// Matches the canvas bg exactly so a card embedded in the main view
+    /// has no visible "stripe" where its background ends — only the rust
+    /// pillar and top/bottom hairline borders mark the card boundary.
     #[must_use]
     pub fn panel_surface() -> Style {
-        Style::default().bg(col(Color::Rgb(0x1a, 0x19, 0x17)))
+        Style::default().bg(col(CANVAS_BG))
     }
 
     /// Border colour for inset panels and cards.

--- a/src/cli/theme.rs
+++ b/src/cli/theme.rs
@@ -505,6 +505,15 @@ pub mod tui {
         Style::default().fg(col(RUST))
     }
 
+    /// Highlight used for app-managed mouse text selection.
+    #[must_use]
+    pub fn conversation_text_selection() -> Style {
+        Style::default()
+            .fg(col(PARCHMENT))
+            .bg(col(Color::Rgb(0x36, 0x45, 0x58)))
+            .add_modifier(Modifier::BOLD)
+    }
+
     /// Unselected slash-menu row.
     #[must_use]
     #[allow(dead_code)] // currently uses out_dim() — kept for future per-row styling
@@ -612,6 +621,7 @@ mod tests {
         let _ = tui::slash_group();
         let _ = tui::conversation_user_text();
         let _ = tui::conversation_user_meta();
+        let _ = tui::conversation_text_selection();
         let _ = tui::slash_normal();
         let _ = tui::mode_pill();
         let _ = tui::mode_pill();

--- a/src/cli/theme.rs
+++ b/src/cli/theme.rs
@@ -320,9 +320,10 @@ pub mod tui {
     /// Inline uppercase labels for the single-row footer.
     #[must_use]
     pub fn label_caps_inline() -> Style {
-        Style::default()
-            .fg(col(HAIRLINE))
-            .add_modifier(Modifier::DIM)
+        // Use the brighter hairline without DIM so the labels remain
+        // perceptible against the warm canvas bg (DIM pushed the contrast
+        // ratio below WCAG AA on the #1a1a18 surface).
+        Style::default().fg(col(HAIRLINE))
     }
 
     /// Bold rust for status-dock workspace name.

--- a/src/cli/theme.rs
+++ b/src/cli/theme.rs
@@ -431,6 +431,80 @@ pub mod tui {
         Style::default().fg(col(RUST)).add_modifier(Modifier::BOLD)
     }
 
+    /// User-submitted text inside a conversation block.
+    #[must_use]
+    pub fn conversation_user_text() -> Style {
+        Style::default()
+            .fg(col(PARCHMENT))
+            .bg(col(PANEL_BG))
+            .add_modifier(Modifier::BOLD)
+    }
+
+    /// Timestamp and action text inside a conversation user block.
+    #[must_use]
+    pub fn conversation_user_meta() -> Style {
+        Style::default().fg(col(HAIRLINE)).bg(col(PANEL_BG))
+    }
+
+    /// User block surface while selected by mouse.
+    #[must_use]
+    pub fn conversation_user_selected_surface() -> Style {
+        Style::default().bg(col(Color::Rgb(0x2a, 0x28, 0x23)))
+    }
+
+    /// User text inside the selected conversation block.
+    #[must_use]
+    pub fn conversation_user_selected_text() -> Style {
+        conversation_user_selected_surface()
+            .fg(col(PARCHMENT))
+            .add_modifier(Modifier::BOLD)
+    }
+
+    /// Timestamp and muted controls inside the selected conversation block.
+    #[must_use]
+    pub fn conversation_user_selected_meta() -> Style {
+        conversation_user_selected_surface().fg(col(Color::Rgb(0xb0, 0xaa, 0x9d)))
+    }
+
+    /// Active action trigger inside the selected conversation block.
+    #[must_use]
+    pub fn conversation_user_action() -> Style {
+        conversation_user_selected_surface()
+            .fg(col(RUST))
+            .add_modifier(Modifier::BOLD)
+    }
+
+    /// Rust accent used for selected conversation blocks.
+    #[must_use]
+    pub fn conversation_user_selected_accent() -> Style {
+        conversation_user_selected_surface()
+            .fg(col(RUST))
+            .add_modifier(Modifier::BOLD)
+    }
+
+    /// Popup row used for conversation block actions.
+    #[must_use]
+    pub fn conversation_action_menu() -> Style {
+        Style::default()
+            .fg(col(PARCHMENT))
+            .bg(col(Color::Rgb(0x24, 0x23, 0x20)))
+    }
+
+    /// Selected popup row used for conversation block actions.
+    #[must_use]
+    pub fn conversation_action_menu_selected() -> Style {
+        Style::default()
+            .fg(col(PARCHMENT))
+            .bg(col(Color::Rgb(0x3a, 0x2b, 0x22)))
+            .add_modifier(Modifier::BOLD)
+    }
+
+    /// Popup border used for conversation block actions.
+    #[must_use]
+    pub fn conversation_action_menu_border() -> Style {
+        Style::default().fg(col(RUST))
+    }
+
     /// Unselected slash-menu row.
     #[must_use]
     #[allow(dead_code)] // currently uses out_dim() — kept for future per-row styling
@@ -536,6 +610,8 @@ mod tests {
         let _ = tui::slash_match();
         let _ = tui::slash_command();
         let _ = tui::slash_group();
+        let _ = tui::conversation_user_text();
+        let _ = tui::conversation_user_meta();
         let _ = tui::slash_normal();
         let _ = tui::mode_pill();
         let _ = tui::mode_pill();

--- a/src/cli/theme.rs
+++ b/src/cli/theme.rs
@@ -289,15 +289,8 @@ pub mod tui {
 
     /// Rust accent used for the left edge of the empty-state card.
     #[must_use]
-    #[allow(dead_code)] // kept for future glyph-style accents (currently using panel_accent_bar)
     pub fn panel_accent() -> Style {
         Style::default().fg(col(RUST)).add_modifier(Modifier::BOLD)
-    }
-
-    /// Solid accent strip for the empty-state card.
-    #[must_use]
-    pub fn panel_accent_bar() -> Style {
-        Style::default().bg(col(RUST))
     }
 
     /// Outline pill used for mode badges and empty-state tags.
@@ -500,7 +493,6 @@ mod tests {
         let _ = tui::panel_surface();
         let _ = tui::panel_border();
         let _ = tui::panel_accent();
-        let _ = tui::panel_accent_bar();
         let _ = tui::pill_outline();
         let _ = tui::label_caps();
         let _ = tui::label_caps_inline();

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -5,7 +5,7 @@
 //! before a mutation; `restore_latest` reverts to the most recent snapshot.
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 
@@ -13,7 +13,7 @@ use anyhow::{Context, Result};
 ///
 /// Files are named `{N:06}.jsonld` (zero-padded 6-digit sequence numbers).
 /// The next available sequence number is used automatically.
-pub fn save_snapshot(workspace_root: &Path, source: &str) -> Result<()> {
+pub fn save_snapshot(workspace_root: &Path, source: &str) -> Result<PathBuf> {
     let history_dir = workspace_root.join(".duumbi").join("history");
     fs::create_dir_all(&history_dir).context("Failed to create .duumbi/history/ directory")?;
 
@@ -24,7 +24,7 @@ pub fn save_snapshot(workspace_root: &Path, source: &str) -> Result<()> {
         .with_context(|| format!("Failed to write snapshot to '{}'", snapshot_path.display()))?;
 
     tracing::debug!("Snapshot saved: {}", snapshot_path.display());
-    Ok(())
+    Ok(snapshot_path)
 }
 
 /// Restores the most recent snapshot to `.duumbi/graph/main.jsonld`.


### PR DESCRIPTION
## Summary

Reimagines the `duumbi` interactive REPL to match the brand-aligned dark
mockup (`duumbi-cli-brand-dark.html`) with a new region-based layout,
rust + parchment + blue-ink palette, and animated polish.

### What's new

- **Brand header** (REPL-01) — `duumbi v0.x.x · type /help [Ctrl+D]`
  with parchment brand word, blue version badge, rust helper, keycap.
- **Empty-state card** (REPL-02) — rust ▌ left pillar with EMPTY/NO
  WORKSPACE pill, primary `/intent create` tip, secondary fallback hint.
  Auto-hides once any output is in the buffer.
- **Conversation pane** (REPL-03) — bottom-aligned scrollable buffer with
  parchment / rust / blue-ink output styles.
- **Mode strip** (REPL-06) — pulsing blue dot (2.6 s cycle), bold mode
  label, `intent —` / `intent [slug]` slot, right-aligned `Shift+Tab swap`.
- **Hairline separators** (REPL-07/09) — dim line with rust • dots at
  both edges.
- **Prompt well** (REPL-08) — rust focus ring (`Block::ALL` border) with
  `›` chevron prefix; collapses to single-row prompt below 60 cols.
- **Status dock** (REPL-10) — two-row layout with uppercase
  `TIME · WORKSPACE · CWD · ACTIVITY` labels above values; `truncate_path`
  helper keeps long CWDs readable.
- **Activity button** — rust pill in the ACTIVITY slot showing the
  braille spinner + `INTERRUPT` label + ■ stop square while working.
- **Animation loop** — 40 ms tick with `needs_anim` guard. Idle CPU
  drops to ~zero; spinner and pulsing dot share a single time source.

### Architecture

- New `theme::tui` submodule with 24+ semantic style helpers and a
  truecolor → 16-color fallback (honours `NO_COLOR`, `COLORTERM`).
- Hardcoded `Color::*` literals removed from `app.rs`.
- Layout topology rewritten in `app.rs::render`; render helpers renamed
  to match the REPL-XX zone naming.
- Event loop in `repl.rs` reduces redraws by gating on event/animation.

### Stats

- 838 tests passing (4 new for `truncate_path` + `mode_dot_glyph`).
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- 3 commits (Phase A theme · Phase B+C layout & components · Phase D animation).

## Test plan

- [ ] Open in a truecolor terminal (iTerm2 / WezTerm / kitty / VS Code) and
      verify the rust + parchment + blue-ink palette renders correctly.
- [ ] In an empty workspace: confirm the EMPTY/NO WORKSPACE card with rust
      pillar appears; after `/init` it disappears.
- [ ] Toggle modes with Shift+Tab; confirm pulsing blue dot is visible.
- [ ] Trigger an LLM call (Agent mode prompt); confirm the rust activity
      button appears in the ACTIVITY slot with the braille spinner.
- [ ] Resize terminal to 50 cols; confirm the prompt collapses to a single
      row and the status dock falls back to the compact form.
- [ ] Run `NO_COLOR=1 duumbi`; confirm no truecolor escapes are emitted
      (palette degrades to 16 ANSI named colours).

🤖 Generated with [Claude Code](https://claude.com/claude-code)