### PR TITLE
✨ feat(cli): add provider manager TUI

### DIFF
--- a/src/agents/factory.rs
+++ b/src/agents/factory.rs
@@ -32,6 +32,22 @@ pub fn create_provider(config: &ProviderConfig) -> Result<Box<dyn LlmProvider>, 
         (key, false)
     };
 
+    create_provider_with_api_key(config, api_key, use_auth_token)
+}
+
+/// Creates a single [`LlmProvider`] from explicit credential material.
+///
+/// This is used for connection probes before a key is persisted.
+///
+/// # Errors
+///
+/// Returns an error if provider construction fails.
+pub fn create_provider_with_api_key(
+    config: &ProviderConfig,
+    api_key: impl Into<String>,
+    use_auth_token: bool,
+) -> Result<Box<dyn LlmProvider>, AgentError> {
+    let api_key = api_key.into();
     let provider: Box<dyn LlmProvider> = match config.provider {
         ProviderKind::Anthropic => Box::new(
             super::anthropic::AnthropicClient::new(&config.model, &api_key)

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -681,7 +681,8 @@ impl ReplApp {
     /// When a popup input is active, pasted text belongs to that field instead
     /// of the underlying REPL prompt.
     pub fn handle_paste(&mut self, text: &str, textarea: &mut TextArea<'_>) {
-        if self.insert_text_into_active_panel_field(text) {
+        if matches!(self.panel, PanelState::ProviderManager { .. }) {
+            let _ = self.insert_text_into_active_panel_field(text);
             return;
         }
 
@@ -4411,6 +4412,26 @@ mod tests {
             assert!(!is_subscription);
         } else {
             panic!("panel should remain in API key input mode");
+        }
+    }
+
+    #[test]
+    fn provider_panel_main_list_paste_does_not_change_prompt() {
+        let (mut app, mut textarea) = make_app();
+        textarea.insert_str("/provider");
+        app.panel = PanelState::ProviderManager {
+            selected: 4,
+            input_mode: None,
+            status_msg: None,
+        };
+
+        app.handle_paste("API key megadásakor", &mut textarea);
+
+        assert_eq!(textarea.lines(), &["/provider"]);
+        if let PanelState::ProviderManager { input_mode, .. } = &app.panel {
+            assert!(input_mode.is_none());
+        } else {
+            panic!("panel should remain ProviderManager");
         }
     }
 

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -3073,7 +3073,7 @@ impl ReplApp {
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
             format!(
-                "     {:<3} {:<12} {:<34} {:<15} {:<10} {:<12}",
+                "    {:<3} {:<12} {:<34} {:<15} {:<10} {:<12}",
                 "#", "Provider ID", "Display name", "Connection", "Key source", "Required secret"
             ),
             theme::out_dim(),

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -344,9 +344,7 @@ pub(crate) async fn probe_provider_config_with_key(
         match url {
             "duumbi-test://ok" => return Ok(()),
             "duumbi-test://unauthorized" => {
-                return Err(
-                    "Provider connection test failed with status 401: Unauthorized".to_string(),
-                );
+                return Err("Invalid API key.".to_string());
             }
             _ => {}
         }
@@ -368,14 +366,7 @@ pub(crate) async fn probe_provider_config_with_key(
 
 fn format_provider_probe_error(error: &crate::agents::AgentError) -> String {
     match error {
-        crate::agents::AgentError::ApiError { status, body } => {
-            let summary = body.lines().next().unwrap_or("").trim();
-            if summary.is_empty() {
-                format!("Provider connection test failed with status {status}.")
-            } else {
-                format!("Provider connection test failed with status {status}: {summary}")
-            }
-        }
+        crate::agents::AgentError::ApiError { body, .. } => provider_api_error_message(body),
         crate::agents::AgentError::Http(e) => {
             format!("Provider connection test failed: {e}")
         }
@@ -384,6 +375,43 @@ fn format_provider_probe_error(error: &crate::agents::AgentError) -> String {
             "Provider connection test was rate limited.".to_string()
         }
         other => format!("Provider connection test failed: {other}"),
+    }
+}
+
+fn provider_api_error_message(body: &str) -> String {
+    if let Ok(json) = serde_json::from_str::<serde_json::Value>(body)
+        && let Some(message) = find_json_message(&json)
+    {
+        return message;
+    }
+
+    let summary = body.lines().next().unwrap_or("").trim();
+    if summary.is_empty() {
+        "Provider rejected the API key.".to_string()
+    } else {
+        summary.to_string()
+    }
+}
+
+fn find_json_message(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::Object(map) => {
+            if let Some(message) = map.get("message").and_then(|v| v.as_str()) {
+                let message = message.trim();
+                if !message.is_empty() {
+                    return Some(message.to_string());
+                }
+            }
+
+            for child in map.values() {
+                if let Some(message) = find_json_message(child) {
+                    return Some(message);
+                }
+            }
+            None
+        }
+        serde_json::Value::Array(items) => items.iter().find_map(find_json_message),
+        _ => None,
     }
 }
 
@@ -3334,11 +3362,6 @@ impl ReplApp {
                     };
                     lines.push(Line::from(Span::styled(format!("  {msg}"), s)));
                 }
-                lines.push(Line::from(""));
-                lines.push(Line::from(Span::styled(
-                    "  [Enter] Save  [Esc] Back",
-                    theme::out_dim(),
-                )));
             }
             None => {
                 if let Some((msg, style)) = status_msg {
@@ -4456,7 +4479,7 @@ mod tests {
             ));
             assert_eq!(
                 status_msg.as_ref().map(|(msg, _)| msg.as_str()),
-                Some("Provider connection test failed with status 401: Unauthorized")
+                Some("Invalid API key.")
             );
         } else {
             panic!("panel should remain ProviderManager");
@@ -4584,6 +4607,19 @@ mod tests {
         assert!(!rendered.contains("API key env"));
         assert!(!rendered.contains("chars"));
         assert!(!rendered.contains("MiniMax-M2.7"));
+        assert!(!rendered.contains("[Enter] Save"));
+        assert!(!rendered.contains("[Esc] Back"));
+    }
+
+    #[test]
+    fn provider_probe_error_prefers_json_message() {
+        let message = provider_api_error_message(
+            r#"{"error":{"message":"Incorrect API key provided.","type":"auth_error"}}"#,
+        );
+
+        assert_eq!(message, "Incorrect API key provided.");
+        assert!(!message.contains("auth_error"));
+        assert!(!message.contains("status"));
     }
 
     #[test]

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -223,14 +223,6 @@ fn configured_provider_index(
     config.providers.iter().position(|p| &p.provider == kind)
 }
 
-/// Returns the credential env var that is active for a provider config.
-fn active_credential_env(config: &crate::config::ProviderConfig) -> &str {
-    config
-        .auth_token_env
-        .as_deref()
-        .unwrap_or(&config.api_key_env)
-}
-
 use super::completion::{SLASH_COMMANDS, SLASH_GROUPS, SlashGroup};
 use super::mode::{
     Action, ConversationAction, ConversationBlock, ConversationBlockKind, OutputLine, OutputStyle,
@@ -922,11 +914,11 @@ impl ReplApp {
                             }
                             KeyCode::Enter if !manual.is_empty() => {
                                 let model = manual.clone();
-                                input_mode = Some(PanelInputMode::AddStep3Key {
+                                input_mode = Some(PanelInputMode::AddStepCredentialSource {
                                     provider: provider.clone(),
                                     model,
-                                    key_buf: String::new(),
                                     is_subscription: *is_subscription,
+                                    selected: 0,
                                 });
                             }
                             _ => {}
@@ -949,11 +941,11 @@ impl ReplApp {
                             }
                             KeyCode::Enter => {
                                 if let Some((model_name, _)) = models.get(*model_sel) {
-                                    input_mode = Some(PanelInputMode::AddStep3Key {
+                                    input_mode = Some(PanelInputMode::AddStepCredentialSource {
                                         provider: provider.clone(),
                                         model: (*model_name).to_string(),
-                                        key_buf: String::new(),
                                         is_subscription: *is_subscription,
+                                        selected: 0,
                                     });
                                 }
                             }
@@ -961,11 +953,11 @@ impl ReplApp {
                         }
                     }
                 }
-                PanelInputMode::AddStep3Key {
+                PanelInputMode::AddStepCredentialSource {
                     provider,
                     model,
-                    key_buf,
                     is_subscription,
+                    selected: source_sel,
                 } => match key_event.code {
                     KeyCode::Esc => {
                         input_mode = Some(PanelInputMode::AddStep2Model {
@@ -973,6 +965,49 @@ impl ReplApp {
                             is_subscription: *is_subscription,
                             selected: 0,
                             manual_input: None,
+                        });
+                    }
+                    KeyCode::Up if *source_sel > 0 => {
+                        *source_sel -= 1;
+                    }
+                    KeyCode::Down if *source_sel < 1 => {
+                        *source_sel += 1;
+                    }
+                    KeyCode::Enter if *source_sel == 0 => {
+                        self.save_provider_with_env_credential(
+                            provider.clone(),
+                            model.clone(),
+                            *is_subscription,
+                        );
+                        self.save_config_and_rebuild_client();
+                        new_status_msg = Some((
+                            "Provider connection saved.".to_string(),
+                            OutputStyle::Success,
+                        ));
+                        input_mode = None;
+                    }
+                    KeyCode::Enter => {
+                        input_mode = Some(PanelInputMode::AddStep3Key {
+                            provider: provider.clone(),
+                            model: model.clone(),
+                            key_buf: String::new(),
+                            is_subscription: *is_subscription,
+                        });
+                    }
+                    _ => {}
+                },
+                PanelInputMode::AddStep3Key {
+                    provider,
+                    model,
+                    key_buf,
+                    is_subscription,
+                } => match key_event.code {
+                    KeyCode::Esc => {
+                        input_mode = Some(PanelInputMode::AddStepCredentialSource {
+                            provider: provider.clone(),
+                            model: model.clone(),
+                            is_subscription: *is_subscription,
+                            selected: 0,
                         });
                     }
                     KeyCode::Backspace => {
@@ -1035,130 +1070,30 @@ impl ReplApp {
                         }
                     }
                     KeyCode::Enter if !key_buf.is_empty() => {
-                        // Transition to storage-choice confirmation step.
-                        input_mode = Some(PanelInputMode::AddStep3Confirm {
-                            provider: provider.clone(),
-                            model: model.clone(),
-                            key: key_buf.clone(),
-                            is_subscription: *is_subscription,
-                        });
-                    }
-                    KeyCode::Char(c) if !is_clipboard_shortcut(key_event.modifiers) => {
-                        key_buf.push(c);
-                    }
-                    _ => {}
-                },
-                PanelInputMode::AddStep3Confirm {
-                    provider,
-                    model,
-                    key: api_key_value,
-                    is_subscription,
-                } => match key_event.code {
-                    KeyCode::Char('k') | KeyCode::Char('K') => {
-                        let api_key_env = default_api_key_env(provider).to_string();
-                        let token_env = if *is_subscription {
-                            Some(default_auth_token_env(provider).to_string())
-                        } else {
-                            None
-                        };
-                        let store_env = token_env.as_deref().unwrap_or(&api_key_env);
-                        let prov_clone = provider.clone();
-                        let model_clone = model.clone();
-                        let key_clone = api_key_value.clone();
-                        match super::keystore::store_api_key(store_env, &key_clone) {
+                        match self.save_provider_with_file_credential(
+                            provider.clone(),
+                            model.clone(),
+                            key_buf.clone(),
+                            *is_subscription,
+                        ) {
                             Ok(()) => {
-                                // SAFETY: single-threaded CLI — no concurrent env access.
-                                unsafe {
-                                    std::env::set_var(store_env, &key_clone);
-                                }
-                                self.upsert_provider_connection(crate::config::ProviderConfig {
-                                    provider: prov_clone,
-                                    role: crate::config::ProviderRole::Primary,
-                                    model: model_clone,
-                                    api_key_env: api_key_env.clone(),
-                                    base_url: None,
-                                    timeout_secs: None,
-                                    key_storage: Some(crate::config::KeyStorage::File),
-                                    auth_token_env: token_env,
-                                });
-                                self.save_config_and_rebuild_client();
-                                let auth_msg = if *is_subscription {
-                                    "Provider connection saved (subscription/Bearer token in ~/.duumbi/credentials.toml)."
-                                } else {
-                                    "Provider connection saved (API key in ~/.duumbi/credentials.toml)."
-                                };
-                                new_status_msg = Some((auth_msg.to_string(), OutputStyle::Success));
-                            }
-                            Err(e) => {
-                                // File storage failed — fall back to session-only.
-                                // SAFETY: single-threaded CLI — no concurrent env access.
-                                unsafe {
-                                    std::env::set_var(store_env, &key_clone);
-                                }
-                                self.upsert_provider_connection(crate::config::ProviderConfig {
-                                    provider: prov_clone,
-                                    role: crate::config::ProviderRole::Primary,
-                                    model: model_clone,
-                                    api_key_env,
-                                    base_url: None,
-                                    timeout_secs: None,
-                                    key_storage: None,
-                                    auth_token_env: token_env,
-                                });
                                 self.save_config_and_rebuild_client();
                                 new_status_msg = Some((
-                                    format!("File storage error: {e}. Token set for session only."),
+                                    "Provider connection saved.".to_string(),
+                                    OutputStyle::Success,
+                                ));
+                                input_mode = None;
+                            }
+                            Err(e) => {
+                                new_status_msg = Some((
+                                    format!("Credential save failed: {e}"),
                                     OutputStyle::Error,
                                 ));
                             }
                         }
-                        input_mode = None; // back to list view
                     }
-                    KeyCode::Char('e') | KeyCode::Char('E') | KeyCode::Enter => {
-                        let api_key_env = default_api_key_env(provider).to_string();
-                        let token_env = if *is_subscription {
-                            Some(default_auth_token_env(provider).to_string())
-                        } else {
-                            None
-                        };
-                        let store_env_name =
-                            token_env.as_deref().unwrap_or(&api_key_env).to_string();
-                        let prov_clone = provider.clone();
-                        let model_clone = model.clone();
-                        let key_clone = api_key_value.clone();
-                        // SAFETY: single-threaded CLI — no concurrent env access.
-                        unsafe {
-                            std::env::set_var(&store_env_name, &key_clone);
-                        }
-                        self.upsert_provider_connection(crate::config::ProviderConfig {
-                            provider: prov_clone,
-                            role: crate::config::ProviderRole::Primary,
-                            model: model_clone,
-                            api_key_env: api_key_env.clone(),
-                            base_url: None,
-                            timeout_secs: None,
-                            key_storage: None,
-                            auth_token_env: token_env,
-                        });
-                        self.save_config_and_rebuild_client();
-                        let auth_msg = if *is_subscription {
-                            format!(
-                                "Provider connection saved (subscription/Bearer, {store_env_name}, session only)."
-                            )
-                        } else {
-                            format!("Provider connection saved ({api_key_env}, session only).")
-                        };
-                        new_status_msg = Some((auth_msg, OutputStyle::Success));
-                        input_mode = None; // back to list view
-                    }
-                    KeyCode::Esc => {
-                        // Back to key entry step with the key pre-filled.
-                        input_mode = Some(PanelInputMode::AddStep3Key {
-                            provider: provider.clone(),
-                            model: model.clone(),
-                            key_buf: api_key_value.clone(),
-                            is_subscription: *is_subscription,
-                        });
+                    KeyCode::Char(c) if !is_clipboard_shortcut(key_event.modifiers) => {
+                        key_buf.push(c);
                     }
                     _ => {}
                 },
@@ -1296,6 +1231,62 @@ impl ReplApp {
         Self::ensure_primary_provider(&mut self.user_config);
         self.refresh_effective_config();
         true
+    }
+
+    fn save_provider_with_env_credential(
+        &mut self,
+        provider: crate::config::ProviderKind,
+        model: String,
+        is_subscription: bool,
+    ) {
+        let api_key_env = default_api_key_env(&provider).to_string();
+        let token_env = if is_subscription {
+            Some(default_auth_token_env(&provider).to_string())
+        } else {
+            None
+        };
+        self.upsert_provider_connection(crate::config::ProviderConfig {
+            provider,
+            role: crate::config::ProviderRole::Primary,
+            model,
+            api_key_env,
+            base_url: None,
+            timeout_secs: None,
+            key_storage: None,
+            auth_token_env: token_env,
+        });
+    }
+
+    fn save_provider_with_file_credential(
+        &mut self,
+        provider: crate::config::ProviderKind,
+        model: String,
+        key: String,
+        is_subscription: bool,
+    ) -> Result<(), String> {
+        let api_key_env = default_api_key_env(&provider).to_string();
+        let token_env = if is_subscription {
+            Some(default_auth_token_env(&provider).to_string())
+        } else {
+            None
+        };
+        let store_env = token_env.as_deref().unwrap_or(&api_key_env);
+        super::keystore::store_api_key(store_env, &key)?;
+        // SAFETY: single-threaded CLI — no concurrent env access.
+        unsafe {
+            std::env::set_var(store_env, &key);
+        }
+        self.upsert_provider_connection(crate::config::ProviderConfig {
+            provider,
+            role: crate::config::ProviderRole::Primary,
+            model,
+            api_key_env,
+            base_url: None,
+            timeout_secs: None,
+            key_storage: Some(crate::config::KeyStorage::File),
+            auth_token_env: token_env,
+        });
+        Ok(())
     }
 
     /// Marks a configured provider as the first provider in the fallback chain.
@@ -2195,8 +2186,8 @@ impl ReplApp {
                 Some(PanelInputMode::AddStepAuthType { provider, .. }) => {
                     provider_auth_modes(provider).len() as u16 + 6
                 }
+                Some(PanelInputMode::AddStepCredentialSource { .. }) => 8,
                 Some(PanelInputMode::AddStep3Key { .. }) => 10,
-                Some(PanelInputMode::AddStep3Confirm { .. }) => 5,
                 _ => {
                     let provider_count = PROVIDER_KINDS.len().max(1);
                     let input_line = if input_mode.is_some() { 1 } else { 0 };
@@ -3123,26 +3114,15 @@ impl ReplApp {
                 } else {
                     "api key"
                 };
-                let credential_env = active_credential_env(provider);
-                let source = if std::env::var(credential_env).is_ok() {
-                    "env"
-                } else if self.keychain_cache.contains(credential_env) {
-                    "file"
-                } else {
-                    "missing"
-                };
-                let priority = if provider.role == crate::config::ProviderRole::Primary {
-                    "priority"
-                } else {
-                    "fallback"
-                };
                 let config_source = self.provider_config_source_label(&kind);
-                format!(
-                    "configured  {:<9} {:<12} {:<8} {:<8} default {}",
-                    config_source, auth, source, priority, provider.model
-                )
+                format!("{:<15} {:<10} {:<12}", "configured", config_source, auth)
             } else {
-                format!("not configured  missing  {}", provider_auth_summary(&kind))
+                format!(
+                    "{:<15} {:<10} {:<12}",
+                    "not configured",
+                    "missing",
+                    provider_auth_summary(&kind)
+                )
             };
             let text = format!("{prefix}{}. {:<11} {:<34} {}", i + 1, name, desc, status);
             let style = if is_sel {
@@ -3281,6 +3261,50 @@ impl ReplApp {
                     )));
                 }
             }
+            Some(PanelInputMode::AddStepCredentialSource {
+                provider,
+                model,
+                is_subscription,
+                selected: source_sel,
+            }) => {
+                let (env_name, label) = if *is_subscription {
+                    (default_auth_token_env(provider), "Subscription token")
+                } else {
+                    (default_api_key_env(provider), "API key")
+                };
+                lines.clear();
+                lines.push(Line::from(vec![
+                    Span::styled(
+                        format!("  {label} source for {provider}"),
+                        theme::brand_word(),
+                    ),
+                    Span::raw(" ".repeat(inner_width.saturating_sub(58))),
+                    Span::styled("(Esc to go back)", theme::out_dim()),
+                ]));
+                lines.push(Line::from(""));
+                lines.push(Line::from(Span::styled(
+                    format!("  Model: {model}"),
+                    theme::out_dim(),
+                )));
+                lines.push(Line::from(""));
+                let options = [
+                    format!("Use environment variable: {env_name}"),
+                    format!("Enter {label}"),
+                ];
+                for (i, option) in options.iter().enumerate() {
+                    let prefix = if i == *source_sel {
+                        "  \u{25cf} "
+                    } else {
+                        "    "
+                    };
+                    let style = if i == *source_sel {
+                        theme::slash_selected()
+                    } else {
+                        theme::out_dim()
+                    };
+                    lines.push(Line::from(Span::styled(format!("{prefix}{option}"), style)));
+                }
+            }
             Some(PanelInputMode::AddStep3Key {
                 provider,
                 model,
@@ -3336,29 +3360,7 @@ impl ReplApp {
                 ]));
                 lines.push(Line::from(""));
                 lines.push(Line::from(Span::styled(
-                    "  [Enter] Continue  [Esc] Back",
-                    theme::out_dim(),
-                )));
-            }
-            Some(PanelInputMode::AddStep3Confirm {
-                provider,
-                model,
-                is_subscription,
-                ..
-            }) => {
-                let label = if *is_subscription {
-                    "subscription token"
-                } else {
-                    "API key"
-                };
-                lines.clear();
-                lines.push(Line::from(Span::styled(
-                    format!("  Store {label} for {provider} ({model})?"),
-                    theme::brand_word(),
-                )));
-                lines.push(Line::from(""));
-                lines.push(Line::from(Span::styled(
-                    "  [K] Save to ~/.duumbi/credentials.toml  [E] Session only  [Esc] Back",
+                    "  [Enter] Save  [Esc] Back",
                     theme::out_dim(),
                 )));
             }
@@ -3391,6 +3393,36 @@ impl ReplApp {
 mod tests {
     use super::*;
     use crate::session::SessionManager;
+    use std::ffi::OsString;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct HomeEnvGuard(Option<OsString>);
+
+    impl HomeEnvGuard {
+        fn set(path: &std::path::Path) -> Self {
+            let previous = std::env::var_os("HOME");
+            // SAFETY: guarded test-only environment mutation.
+            unsafe {
+                std::env::set_var("HOME", path);
+            }
+            Self(previous)
+        }
+    }
+
+    impl Drop for HomeEnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: guarded test-only environment mutation.
+            unsafe {
+                if let Some(previous) = &self.0 {
+                    std::env::set_var("HOME", previous);
+                } else {
+                    std::env::remove_var("HOME");
+                }
+            }
+        }
+    }
 
     fn make_app() -> (ReplApp, TextArea<'static>) {
         let tmp = tempfile::TempDir::new().expect("invariant: tempdir");
@@ -4245,6 +4277,107 @@ mod tests {
             app.provider_config_source_label(&crate::config::ProviderKind::OpenAI),
             "workspace"
         );
+    }
+
+    #[test]
+    fn provider_panel_env_source_saves_config_without_key_input() {
+        let (mut app, _) = make_app();
+
+        app.save_provider_with_env_credential(
+            crate::config::ProviderKind::MiniMax,
+            "MiniMax-M2.7".to_string(),
+            false,
+        );
+
+        let provider = app
+            .config
+            .providers
+            .iter()
+            .find(|provider| provider.provider == crate::config::ProviderKind::MiniMax)
+            .expect("invariant: provider should be configured");
+        assert_eq!(provider.api_key_env, "MINIMAX_API_KEY");
+        assert!(provider.key_storage.is_none());
+        assert!(provider.auth_token_env.is_none());
+    }
+
+    #[test]
+    fn provider_panel_api_key_enter_saves_file_and_returns_to_list() {
+        let _guard = ENV_LOCK.lock().expect("invariant: env lock");
+        let home = tempfile::TempDir::new().expect("invariant: temp home");
+        let _home_guard = HomeEnvGuard::set(home.path());
+
+        let (mut app, mut textarea) = make_app();
+        app.has_workspace = false;
+        app.panel = PanelState::ProviderManager {
+            selected: 4,
+            input_mode: Some(PanelInputMode::AddStep3Key {
+                provider: crate::config::ProviderKind::MiniMax,
+                model: "MiniMax-M2.7".to_string(),
+                key_buf: "sk-test-key".to_string(),
+                is_subscription: false,
+            }),
+            status_msg: None,
+        };
+
+        let key = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+        app.handle_key(key, &mut textarea);
+
+        if let PanelState::ProviderManager {
+            input_mode,
+            status_msg,
+            ..
+        } = &app.panel
+        {
+            assert!(input_mode.is_none());
+            assert_eq!(
+                status_msg.as_ref().map(|(msg, _)| msg.as_str()),
+                Some("Provider connection saved.")
+            );
+        } else {
+            panic!("panel should remain ProviderManager");
+        }
+        let provider = app
+            .config
+            .providers
+            .iter()
+            .find(|provider| provider.provider == crate::config::ProviderKind::MiniMax)
+            .expect("invariant: provider should be configured");
+        assert_eq!(provider.key_storage, Some(crate::config::KeyStorage::File));
+        let credentials = std::fs::read_to_string(home.path().join(".duumbi/credentials.toml"))
+            .expect("invariant: credentials file should exist");
+        assert!(credentials.contains("MINIMAX_API_KEY"));
+        assert!(credentials.contains("sk-test-key"));
+    }
+
+    #[test]
+    fn provider_panel_configured_status_is_compact() {
+        let (mut app, textarea) = make_app();
+        app.user_config
+            .providers
+            .push(crate::config::ProviderConfig {
+                provider: crate::config::ProviderKind::MiniMax,
+                role: crate::config::ProviderRole::Primary,
+                model: "MiniMax-M2.7".to_string(),
+                api_key_env: "MINIMAX_API_KEY".to_string(),
+                base_url: None,
+                timeout_secs: None,
+                key_storage: Some(crate::config::KeyStorage::File),
+                auth_token_env: None,
+            });
+        app.refresh_effective_config();
+        app.panel = PanelState::ProviderManager {
+            selected: 4,
+            input_mode: None,
+            status_msg: None,
+        };
+
+        let (rendered, _) = render_app_to_string(&app, &textarea, 180, 40);
+
+        assert!(rendered.contains("configured      user       api key"));
+        assert!(rendered.contains("not configured  missing    api key"));
+        assert!(!rendered.contains("priority"));
+        assert!(!rendered.contains("fallback"));
+        assert!(!rendered.contains("default MiniMax-M2.7"));
     }
 
     #[test]

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -226,7 +226,17 @@ fn configured_provider_index(
     config: &DuumbiConfig,
     kind: &crate::config::ProviderKind,
 ) -> Option<usize> {
-    config.providers.iter().position(|p| &p.provider == kind)
+    let mut first_match = None;
+    for (index, provider) in config.providers.iter().enumerate() {
+        if &provider.provider != kind {
+            continue;
+        }
+        first_match.get_or_insert(index);
+        if matches!(provider.role, crate::config::ProviderRole::Primary) {
+            return Some(index);
+        }
+    }
+    first_match
 }
 
 use super::completion::{SLASH_COMMANDS, SLASH_GROUPS, SlashGroup};
@@ -283,6 +293,7 @@ struct ConversationTextSelection {
     dragged: bool,
 }
 
+#[cfg(target_os = "macos")]
 fn copy_text_to_clipboard(text: &str) -> Result<(), String> {
     let mut child = std::process::Command::new("pbcopy")
         .stdin(std::process::Stdio::piped())
@@ -303,6 +314,12 @@ fn copy_text_to_clipboard(text: &str) -> Result<(), String> {
     }
 }
 
+#[cfg(not(target_os = "macos"))]
+fn copy_text_to_clipboard(_text: &str) -> Result<(), String> {
+    Err("Clipboard shortcut integration is only available on macOS.".to_string())
+}
+
+#[cfg(target_os = "macos")]
 fn read_text_from_clipboard() -> Result<String, String> {
     let output = std::process::Command::new("pbpaste")
         .output()
@@ -311,6 +328,11 @@ fn read_text_from_clipboard() -> Result<String, String> {
         return Err(output.status.to_string());
     }
     String::from_utf8(output.stdout).map_err(|e| e.to_string())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn read_text_from_clipboard() -> Result<String, String> {
+    Err("Clipboard shortcut integration is only available on macOS.".to_string())
 }
 
 fn is_clipboard_shortcut(modifiers: KeyModifiers) -> bool {
@@ -434,6 +456,8 @@ pub struct ReplApp {
     pub workspace_root: PathBuf,
     /// Parsed workspace configuration.
     pub config: DuumbiConfig,
+    /// System-level configuration from `/etc/duumbi/config.toml`.
+    pub system_config: DuumbiConfig,
     /// User-level configuration from `~/.duumbi/config.toml`.
     pub user_config: DuumbiConfig,
     /// Workspace-level configuration from `<workspace>/.duumbi/config.toml`.
@@ -514,6 +538,7 @@ impl ReplApp {
         Self::new_with_config_layers(
             config.clone(),
             DuumbiConfig::default(),
+            DuumbiConfig::default(),
             config,
             ProviderConfigSource::Workspace,
             workspace_root,
@@ -529,6 +554,7 @@ impl ReplApp {
     #[allow(clippy::too_many_arguments)]
     pub fn new_with_config_layers(
         config: DuumbiConfig,
+        system_config: DuumbiConfig,
         user_config: DuumbiConfig,
         workspace_config: DuumbiConfig,
         provider_config_source: ProviderConfigSource,
@@ -544,6 +570,7 @@ impl ReplApp {
             focused_intent: None,
             workspace_root,
             config,
+            system_config,
             user_config,
             workspace_config,
             provider_config_source,
@@ -1134,15 +1161,28 @@ impl ReplApp {
                 Action::Continue
             }
             KeyCode::Char('d') | KeyCode::Char('D') => {
-                if parse_provider_kind_by_index(selected)
-                    .and_then(|kind| configured_provider_index(&self.config, &kind))
-                    .is_some()
-                {
-                    self.panel = PanelState::ProviderManager {
-                        selected,
-                        input_mode: Some(PanelInputMode::ConfirmDelete),
-                        status_msg: None,
-                    };
+                if let Some(kind) = parse_provider_kind_by_index(selected) {
+                    if configured_provider_index(&self.workspace_config, &kind).is_some()
+                        || configured_provider_index(&self.user_config, &kind).is_some()
+                    {
+                        self.panel = PanelState::ProviderManager {
+                            selected,
+                            input_mode: Some(PanelInputMode::ConfirmDelete),
+                            status_msg: None,
+                        };
+                    } else if configured_provider_index(&self.config, &kind).is_some() {
+                        self.panel = PanelState::ProviderManager {
+                            selected,
+                            input_mode: None,
+                            status_msg: Some((
+                                format!(
+                                    "{} connection is not stored in user or workspace config.",
+                                    provider_kind_label(&kind)
+                                ),
+                                OutputStyle::Dim,
+                            )),
+                        };
+                    }
                 }
                 Action::Continue
             }
@@ -1179,8 +1219,6 @@ impl ReplApp {
             Some(self.workspace_config.providers.remove(index))
         } else if let Some(index) = configured_provider_index(&self.user_config, kind) {
             Some(self.user_config.providers.remove(index))
-        } else if let Some(index) = configured_provider_index(&self.config, kind) {
-            Some(self.config.providers.remove(index))
         } else {
             None
         };
@@ -1213,9 +1251,15 @@ impl ReplApp {
             .chain(self.user_config.providers.iter())
             .chain(self.config.providers.iter())
             .find(|candidate| candidate.provider == provider);
-        let api_key_env = default_api_key_env(&provider).to_string();
+        let api_key_env = existing
+            .map(|provider| provider.api_key_env.clone())
+            .unwrap_or_else(|| default_api_key_env(&provider).to_string());
         let token_env = if is_subscription {
-            Some(default_auth_token_env(&provider).to_string())
+            Some(
+                existing
+                    .and_then(|provider| provider.auth_token_env.clone())
+                    .unwrap_or_else(|| default_auth_token_env(&provider).to_string()),
+            )
         } else {
             None
         };
@@ -1364,7 +1408,7 @@ impl ReplApp {
 
     fn refresh_effective_config(&mut self) {
         let effective = crate::config::merge_config_layers(
-            DuumbiConfig::default(),
+            self.system_config.clone(),
             self.user_config.clone(),
             self.workspace_config.clone(),
         );
@@ -3073,7 +3117,7 @@ impl ReplApp {
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
             format!(
-                "    {:<3} {:<12} {:<34} {:<15} {:<10} {:<12}",
+                "  {:<3} {:<12} {:<34} {:<15} {:<10} {:<12}",
                 "#", "Provider ID", "Display name", "Connection", "Key source", "Required secret"
             ),
             theme::out_dim(),
@@ -4172,6 +4216,37 @@ mod tests {
     }
 
     #[test]
+    fn configured_provider_index_prefers_primary_duplicate() {
+        let mut config = DuumbiConfig::default();
+        config.providers.push(crate::config::ProviderConfig {
+            provider: crate::config::ProviderKind::MiniMax,
+            role: crate::config::ProviderRole::Fallback,
+            model: "fallback-model".to_string(),
+            api_key_env: "MINIMAX_FALLBACK_API_KEY".to_string(),
+            base_url: None,
+            timeout_secs: None,
+            key_storage: None,
+            auth_token_env: None,
+        });
+        config.providers.push(crate::config::ProviderConfig {
+            provider: crate::config::ProviderKind::MiniMax,
+            role: crate::config::ProviderRole::Primary,
+            model: "primary-model".to_string(),
+            api_key_env: "MINIMAX_API_KEY".to_string(),
+            base_url: None,
+            timeout_secs: None,
+            key_storage: None,
+            auth_token_env: None,
+        });
+
+        let index = configured_provider_index(&config, &crate::config::ProviderKind::MiniMax)
+            .expect("provider should be found");
+
+        assert_eq!(index, 1);
+        assert_eq!(config.providers[index].model, "primary-model");
+    }
+
+    #[test]
     fn provider_panel_workspace_provider_overrides_user_provider() {
         let (mut app, _) = make_app();
         app.user_config
@@ -4207,6 +4282,28 @@ mod tests {
             app.provider_config_source_label(&crate::config::ProviderKind::OpenAI),
             "workspace"
         );
+    }
+
+    #[test]
+    fn provider_panel_system_provider_survives_effective_refresh() {
+        let (mut app, _) = make_app();
+        app.system_config
+            .providers
+            .push(crate::config::ProviderConfig {
+                provider: crate::config::ProviderKind::MiniMax,
+                role: crate::config::ProviderRole::Primary,
+                model: "system-model".to_string(),
+                api_key_env: "MINIMAX_SYSTEM_API_KEY".to_string(),
+                base_url: None,
+                timeout_secs: None,
+                key_storage: None,
+                auth_token_env: None,
+            });
+
+        app.refresh_effective_config();
+
+        assert_eq!(app.provider_config_source, ProviderConfigSource::System);
+        assert_eq!(app.config.providers[0].model, "system-model");
     }
 
     #[test]
@@ -4319,6 +4416,48 @@ mod tests {
         let credentials = std::fs::read_to_string(home.path().join(".duumbi/credentials.toml"))
             .expect("invariant: credentials file should exist");
         assert!(credentials.contains("MINIMAX_API_KEY"));
+        assert!(credentials.contains("sk-test-key"));
+    }
+
+    #[test]
+    fn provider_panel_file_credential_preserves_custom_api_key_env() {
+        let _guard = ENV_LOCK.lock().expect("invariant: env lock");
+        let home = tempfile::TempDir::new().expect("invariant: temp home");
+        let _home_guard = HomeEnvGuard::set(home.path());
+
+        let (mut app, _) = make_app();
+        app.user_config
+            .providers
+            .push(crate::config::ProviderConfig {
+                provider: crate::config::ProviderKind::MiniMax,
+                role: crate::config::ProviderRole::Primary,
+                model: "MiniMax-M2.7".to_string(),
+                api_key_env: "CUSTOM_MINIMAX_API_KEY".to_string(),
+                base_url: Some("duumbi-test://ok".to_string()),
+                timeout_secs: None,
+                key_storage: None,
+                auth_token_env: None,
+            });
+        app.refresh_effective_config();
+
+        app.save_provider_with_file_credential(
+            crate::config::ProviderKind::MiniMax,
+            "MiniMax-M2.7".to_string(),
+            "sk-test-key".to_string(),
+            false,
+        )
+        .expect("save should succeed");
+
+        let provider = app
+            .user_config
+            .providers
+            .iter()
+            .find(|provider| provider.provider == crate::config::ProviderKind::MiniMax)
+            .expect("provider should be saved");
+        assert_eq!(provider.api_key_env, "CUSTOM_MINIMAX_API_KEY");
+        let credentials = std::fs::read_to_string(home.path().join(".duumbi/credentials.toml"))
+            .expect("credentials file should exist");
+        assert!(credentials.contains("CUSTOM_MINIMAX_API_KEY"));
         assert!(credentials.contains("sk-test-key"));
     }
 
@@ -4645,16 +4784,19 @@ mod tests {
     #[test]
     fn provider_panel_delete_removes_configured_connection() {
         let (mut app, mut textarea) = make_app();
-        app.config.providers.push(crate::config::ProviderConfig {
-            provider: crate::config::ProviderKind::Anthropic,
-            role: crate::config::ProviderRole::Primary,
-            model: "claude-sonnet-4-6".to_string(),
-            api_key_env: "ANTHROPIC_API_KEY".to_string(),
-            base_url: None,
-            timeout_secs: None,
-            key_storage: None,
-            auth_token_env: None,
-        });
+        app.user_config
+            .providers
+            .push(crate::config::ProviderConfig {
+                provider: crate::config::ProviderKind::Anthropic,
+                role: crate::config::ProviderRole::Primary,
+                model: "claude-sonnet-4-6".to_string(),
+                api_key_env: "ANTHROPIC_API_KEY".to_string(),
+                base_url: None,
+                timeout_secs: None,
+                key_storage: None,
+                auth_token_env: None,
+            });
+        app.refresh_effective_config();
         app.panel = PanelState::ProviderManager {
             selected: 0,
             input_mode: Some(PanelInputMode::ConfirmDelete),
@@ -4663,6 +4805,50 @@ mod tests {
         let key = KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE);
         app.handle_key(key, &mut textarea);
         assert!(app.config.providers.is_empty());
+        assert!(app.user_config.providers.is_empty());
+    }
+
+    #[test]
+    fn provider_panel_delete_does_not_remove_system_provider() {
+        let (mut app, mut textarea) = make_app();
+        app.system_config
+            .providers
+            .push(crate::config::ProviderConfig {
+                provider: crate::config::ProviderKind::MiniMax,
+                role: crate::config::ProviderRole::Primary,
+                model: "MiniMax-M2.7".to_string(),
+                api_key_env: "MINIMAX_API_KEY".to_string(),
+                base_url: None,
+                timeout_secs: None,
+                key_storage: None,
+                auth_token_env: None,
+            });
+        app.refresh_effective_config();
+        app.panel = PanelState::ProviderManager {
+            selected: 4,
+            input_mode: None,
+            status_msg: None,
+        };
+
+        let key = KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE);
+        app.handle_key(key, &mut textarea);
+
+        if let PanelState::ProviderManager {
+            input_mode,
+            status_msg,
+            ..
+        } = &app.panel
+        {
+            assert!(input_mode.is_none());
+            assert_eq!(
+                status_msg.as_ref().map(|(msg, _)| msg.as_str()),
+                Some("minimax connection is not stored in user or workspace config.")
+            );
+        } else {
+            panic!("panel should remain ProviderManager");
+        }
+        assert_eq!(app.config.providers.len(), 1);
+        assert_eq!(app.system_config.providers.len(), 1);
     }
 
     #[test]

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -215,6 +215,12 @@ fn parse_provider_kind_by_index(idx: usize) -> Option<crate::config::ProviderKin
     }
 }
 
+fn provider_kind_index(kind: &crate::config::ProviderKind) -> Option<usize> {
+    PROVIDER_KINDS.iter().enumerate().find_map(|(index, _)| {
+        (parse_provider_kind_by_index(index).as_ref() == Some(kind)).then_some(index)
+    })
+}
+
 /// Finds the configured provider entry for a provider kind.
 fn configured_provider_index(
     config: &DuumbiConfig,
@@ -315,13 +321,6 @@ fn append_single_line_input(buf: &mut String, text: &str) {
     buf.extend(text.chars().filter(|c| !matches!(c, '\r' | '\n')));
 }
 
-fn validate_provider_key(key: &str) -> Result<(), &'static str> {
-    if key.trim().chars().count() < 8 {
-        return Err("API key looks too short.");
-    }
-    Ok(())
-}
-
 fn masked_secret_preview(char_count: usize, max_width: usize) -> String {
     if char_count == 0 {
         return "\u{2588}".to_string();
@@ -335,6 +334,59 @@ fn masked_secret_preview(char_count: usize, max_width: usize) -> String {
     } else {
         let dot_count = char_count.min(max_width.saturating_sub(1)).max(1);
         format!("{}{}", ".".repeat(dot_count), "\u{2588}")
+    }
+}
+
+pub(crate) async fn probe_provider_config_with_key(
+    config: crate::config::ProviderConfig,
+    key: String,
+    is_subscription: bool,
+) -> Result<(), String> {
+    #[cfg(test)]
+    if let Some(url) = config.base_url.as_deref() {
+        match url {
+            "duumbi-test://ok" => return Ok(()),
+            "duumbi-test://unauthorized" => {
+                return Err(
+                    "Provider connection test failed with status 401: Unauthorized".to_string(),
+                );
+            }
+            _ => {}
+        }
+    }
+
+    let provider =
+        crate::agents::factory::create_provider_with_api_key(&config, key, is_subscription)
+            .map_err(|e| format_provider_probe_error(&e))?;
+    let probe = provider.call_with_tools(
+        "You are validating DUUMBI provider credentials. Return no graph changes.",
+        "Reply with no tool calls. This request only validates the configured API key.",
+    );
+    match tokio::time::timeout(std::time::Duration::from_secs(15), probe).await {
+        Ok(Ok(_)) => Ok(()),
+        Ok(Err(e)) => Err(format_provider_probe_error(&e)),
+        Err(_) => Err("Provider connection test timed out.".to_string()),
+    }
+}
+
+fn format_provider_probe_error(error: &crate::agents::AgentError) -> String {
+    match error {
+        crate::agents::AgentError::ApiError { status, body } => {
+            let summary = body.lines().next().unwrap_or("").trim();
+            if summary.is_empty() {
+                format!("Provider connection test failed with status {status}.")
+            } else {
+                format!("Provider connection test failed with status {status}: {summary}")
+            }
+        }
+        crate::agents::AgentError::Http(e) => {
+            format!("Provider connection test failed: {e}")
+        }
+        crate::agents::AgentError::Timeout(_) => "Provider connection test timed out.".to_string(),
+        crate::agents::AgentError::RateLimited { .. } => {
+            "Provider connection test was rate limited.".to_string()
+        }
+        other => format!("Provider connection test failed: {other}"),
     }
 }
 
@@ -801,6 +853,7 @@ impl ReplApp {
             PanelState::None => return Action::Continue,
         };
         let mut new_status_msg: Option<(String, OutputStyle)> = None;
+        let mut action = Action::Continue;
 
         if let Some(ref mut mode) = input_mode {
             match mode {
@@ -1034,28 +1087,18 @@ impl ReplApp {
                             }
                         }
                     }
-                    KeyCode::Enter if !key_buf.is_empty() => match validate_provider_key(key_buf) {
-                        Ok(()) => {
-                            match self.save_provider_with_file_credential(
-                                provider.clone(),
-                                model.clone(),
-                                key_buf.clone(),
-                                *is_subscription,
-                            ) {
-                                Ok(()) => {
-                                    self.save_config_and_rebuild_client();
-                                    input_mode = None;
-                                }
-                                Err(e) => {
-                                    new_status_msg = Some((
-                                        format!("Credential save failed: {e}"),
-                                        OutputStyle::Error,
-                                    ));
-                                }
-                            }
-                        }
-                        Err(e) => new_status_msg = Some((e.to_string(), OutputStyle::Error)),
-                    },
+                    KeyCode::Enter if !key_buf.is_empty() => {
+                        new_status_msg = Some((
+                            "Testing provider connection...".to_string(),
+                            OutputStyle::Dim,
+                        ));
+                        action = Action::ProviderKeySubmitted {
+                            provider: provider.clone(),
+                            model: model.clone(),
+                            key: key_buf.clone(),
+                            is_subscription: *is_subscription,
+                        };
+                    }
                     KeyCode::Char(c) if !is_clipboard_shortcut(key_event.modifiers) => {
                         key_buf.push(c);
                     }
@@ -1067,7 +1110,7 @@ impl ReplApp {
                 input_mode,
                 status_msg: new_status_msg,
             };
-            return Action::Continue;
+            return action;
         }
 
         match key_event.code {
@@ -1197,35 +1240,99 @@ impl ReplApp {
         true
     }
 
-    fn save_provider_with_file_credential(
-        &mut self,
+    pub(crate) fn provider_config_for_key_submission(
+        &self,
         provider: crate::config::ProviderKind,
         model: String,
-        key: String,
         is_subscription: bool,
-    ) -> Result<(), String> {
+        key_storage: Option<crate::config::KeyStorage>,
+    ) -> crate::config::ProviderConfig {
+        let existing = self
+            .workspace_config
+            .providers
+            .iter()
+            .chain(self.user_config.providers.iter())
+            .chain(self.config.providers.iter())
+            .find(|candidate| candidate.provider == provider);
         let api_key_env = default_api_key_env(&provider).to_string();
         let token_env = if is_subscription {
             Some(default_auth_token_env(&provider).to_string())
         } else {
             None
         };
-        let store_env = token_env.as_deref().unwrap_or(&api_key_env);
+        crate::config::ProviderConfig {
+            provider,
+            role: existing
+                .map(|provider| provider.role.clone())
+                .unwrap_or(crate::config::ProviderRole::Primary),
+            model,
+            api_key_env,
+            base_url: existing.and_then(|provider| provider.base_url.clone()),
+            timeout_secs: existing.and_then(|provider| provider.timeout_secs),
+            key_storage,
+            auth_token_env: token_env,
+        }
+    }
+
+    pub(crate) async fn probe_provider_key(
+        &self,
+        provider: crate::config::ProviderKind,
+        model: String,
+        key: String,
+        is_subscription: bool,
+    ) -> Result<(), String> {
+        let config =
+            self.provider_config_for_key_submission(provider, model, is_subscription, None);
+        probe_provider_config_with_key(config, key, is_subscription).await
+    }
+
+    pub(crate) fn provider_key_test_failed(&mut self, message: String) {
+        if let PanelState::ProviderManager { status_msg, .. } = &mut self.panel {
+            *status_msg = Some((message, OutputStyle::Error));
+        }
+    }
+
+    pub(crate) fn save_tested_provider_key(
+        &mut self,
+        provider: crate::config::ProviderKind,
+        model: String,
+        key: String,
+        is_subscription: bool,
+    ) -> Result<(), String> {
+        self.save_provider_with_file_credential(provider.clone(), model, key, is_subscription)?;
+        self.save_config_and_rebuild_client();
+        let selected = provider_kind_index(&provider).unwrap_or(0);
+        self.panel = PanelState::ProviderManager {
+            selected,
+            input_mode: None,
+            status_msg: None,
+        };
+        Ok(())
+    }
+
+    pub(crate) fn save_provider_with_file_credential(
+        &mut self,
+        provider: crate::config::ProviderKind,
+        model: String,
+        key: String,
+        is_subscription: bool,
+    ) -> Result<(), String> {
+        let config = self.provider_config_for_key_submission(
+            provider,
+            model,
+            is_subscription,
+            Some(crate::config::KeyStorage::File),
+        );
+        let store_env = config
+            .auth_token_env
+            .as_deref()
+            .unwrap_or(&config.api_key_env);
         super::keystore::store_api_key(store_env, &key)?;
         // SAFETY: single-threaded CLI — no concurrent env access.
         unsafe {
             std::env::set_var(store_env, &key);
         }
-        self.upsert_provider_connection(crate::config::ProviderConfig {
-            provider,
-            role: crate::config::ProviderRole::Primary,
-            model,
-            api_key_env,
-            base_url: None,
-            timeout_secs: None,
-            key_storage: Some(crate::config::KeyStorage::File),
-            auth_token_env: token_env,
-        });
+        self.upsert_provider_connection(config);
         Ok(())
     }
 
@@ -4205,7 +4312,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_panel_api_key_enter_saves_file_and_returns_to_list() {
+    fn provider_panel_api_key_enter_submits_probe_action_without_saving() {
         let _guard = ENV_LOCK.lock().expect("invariant: env lock");
         let home = tempfile::TempDir::new().expect("invariant: temp home");
         let _home_guard = HomeEnvGuard::set(home.path());
@@ -4224,48 +4331,17 @@ mod tests {
         };
 
         let key = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
-        app.handle_key(key, &mut textarea);
+        let action = app.handle_key(key, &mut textarea);
 
-        if let PanelState::ProviderManager {
-            input_mode,
-            status_msg,
-            ..
-        } = &app.panel
-        {
-            assert!(input_mode.is_none());
-            assert!(status_msg.is_none());
-        } else {
-            panic!("panel should remain ProviderManager");
-        }
-        let provider = app
-            .config
-            .providers
-            .iter()
-            .find(|provider| provider.provider == crate::config::ProviderKind::MiniMax)
-            .expect("invariant: provider should be configured");
-        assert_eq!(provider.key_storage, Some(crate::config::KeyStorage::File));
-        let credentials = std::fs::read_to_string(home.path().join(".duumbi/credentials.toml"))
-            .expect("invariant: credentials file should exist");
-        assert!(credentials.contains("MINIMAX_API_KEY"));
-        assert!(credentials.contains("sk-test-key"));
-    }
-
-    #[test]
-    fn provider_panel_invalid_api_key_stays_in_input_with_error() {
-        let (mut app, mut textarea) = make_app();
-        app.panel = PanelState::ProviderManager {
-            selected: 4,
-            input_mode: Some(PanelInputMode::AddStep3Key {
+        assert!(matches!(
+            action,
+            Action::ProviderKeySubmitted {
                 provider: crate::config::ProviderKind::MiniMax,
-                model: "MiniMax-M2.7".to_string(),
-                key_buf: "123".to_string(),
+                model,
+                key,
                 is_subscription: false,
-            }),
-            status_msg: None,
-        };
-
-        let key = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
-        app.handle_key(key, &mut textarea);
+            } if model == "MiniMax-M2.7" && key == "sk-test-key"
+        ));
 
         if let PanelState::ProviderManager {
             input_mode,
@@ -4279,12 +4355,142 @@ mod tests {
             ));
             assert_eq!(
                 status_msg.as_ref().map(|(msg, _)| msg.as_str()),
-                Some("API key looks too short.")
+                Some("Testing provider connection...")
             );
         } else {
             panic!("panel should remain ProviderManager");
         }
         assert!(app.config.providers.is_empty());
+        assert!(!home.path().join(".duumbi/credentials.toml").exists());
+    }
+
+    #[tokio::test]
+    async fn provider_panel_successful_probe_saves_config_and_credentials() {
+        let (mut app, _) = make_app();
+        app.has_workspace = false;
+        app.user_config
+            .providers
+            .push(crate::config::ProviderConfig {
+                provider: crate::config::ProviderKind::MiniMax,
+                role: crate::config::ProviderRole::Primary,
+                model: "MiniMax-M2.7".to_string(),
+                api_key_env: "MINIMAX_API_KEY".to_string(),
+                base_url: Some("duumbi-test://ok".to_string()),
+                timeout_secs: None,
+                key_storage: None,
+                auth_token_env: None,
+            });
+        app.refresh_effective_config();
+
+        app.probe_provider_key(
+            crate::config::ProviderKind::MiniMax,
+            "MiniMax-M2.7".to_string(),
+            "sk-test-key".to_string(),
+            false,
+        )
+        .await
+        .expect("probe should succeed");
+
+        let _guard = ENV_LOCK.lock().expect("invariant: env lock");
+        let home = tempfile::TempDir::new().expect("invariant: temp home");
+        let _home_guard = HomeEnvGuard::set(home.path());
+        app.save_tested_provider_key(
+            crate::config::ProviderKind::MiniMax,
+            "MiniMax-M2.7".to_string(),
+            "sk-test-key".to_string(),
+            false,
+        )
+        .expect("save should succeed");
+
+        assert!(matches!(
+            app.panel,
+            PanelState::ProviderManager {
+                input_mode: None,
+                status_msg: None,
+                ..
+            }
+        ));
+        let provider = app
+            .config
+            .providers
+            .iter()
+            .find(|provider| provider.provider == crate::config::ProviderKind::MiniMax)
+            .expect("invariant: provider should be configured");
+        assert_eq!(provider.key_storage, Some(crate::config::KeyStorage::File));
+        assert_eq!(provider.base_url.as_deref(), Some("duumbi-test://ok"));
+        let credentials = std::fs::read_to_string(home.path().join(".duumbi/credentials.toml"))
+            .expect("invariant: credentials file should exist");
+        assert!(credentials.contains("MINIMAX_API_KEY"));
+        assert!(credentials.contains("sk-test-key"));
+    }
+
+    #[tokio::test]
+    async fn provider_panel_failed_probe_keeps_key_input_without_saving() {
+        let (mut app, mut textarea) = make_app();
+        app.user_config
+            .providers
+            .push(crate::config::ProviderConfig {
+                provider: crate::config::ProviderKind::MiniMax,
+                role: crate::config::ProviderRole::Primary,
+                model: "MiniMax-M2.7".to_string(),
+                api_key_env: "MINIMAX_API_KEY".to_string(),
+                base_url: Some("duumbi-test://unauthorized".to_string()),
+                timeout_secs: None,
+                key_storage: None,
+                auth_token_env: None,
+            });
+        app.refresh_effective_config();
+        app.panel = PanelState::ProviderManager {
+            selected: 4,
+            input_mode: Some(PanelInputMode::AddStep3Key {
+                provider: crate::config::ProviderKind::MiniMax,
+                model: "MiniMax-M2.7".to_string(),
+                key_buf: "123".to_string(),
+                is_subscription: false,
+            }),
+            status_msg: None,
+        };
+
+        let key = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+        let action = app.handle_key(key, &mut textarea);
+        let Action::ProviderKeySubmitted {
+            provider,
+            model,
+            key,
+            is_subscription,
+        } = action
+        else {
+            panic!("expected provider key action");
+        };
+        let error = app
+            .probe_provider_key(provider, model, key, is_subscription)
+            .await
+            .expect_err("probe should fail");
+        app.provider_key_test_failed(error);
+
+        if let PanelState::ProviderManager {
+            input_mode,
+            status_msg,
+            ..
+        } = &app.panel
+        {
+            assert!(matches!(
+                input_mode,
+                Some(PanelInputMode::AddStep3Key { .. })
+            ));
+            assert_eq!(
+                status_msg.as_ref().map(|(msg, _)| msg.as_str()),
+                Some("Provider connection test failed with status 401: Unauthorized")
+            );
+        } else {
+            panic!("panel should remain ProviderManager");
+        }
+        assert!(
+            app.config
+                .providers
+                .iter()
+                .all(|provider| provider.key_storage.is_none())
+        );
     }
 
     #[test]

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -321,20 +321,17 @@ fn append_single_line_input(buf: &mut String, text: &str) {
     buf.extend(text.chars().filter(|c| !matches!(c, '\r' | '\n')));
 }
 
+fn is_submit_key(code: &KeyCode) -> bool {
+    matches!(code, KeyCode::Enter | KeyCode::Char('\n' | '\r'))
+}
+
 fn masked_secret_preview(char_count: usize, max_width: usize) -> String {
     if char_count == 0 {
         return "\u{2588}".to_string();
     }
 
-    let suffix = format!(" ({char_count} chars)");
-    let suffix_width = suffix.chars().count() + 1; // plus cursor
-    if max_width > suffix_width {
-        let dot_count = char_count.min(max_width - suffix_width).max(1);
-        format!("{}{}{}", ".".repeat(dot_count), suffix, "\u{2588}")
-    } else {
-        let dot_count = char_count.min(max_width.saturating_sub(1)).max(1);
-        format!("{}{}", ".".repeat(dot_count), "\u{2588}")
-    }
+    let dot_count = char_count.min(max_width.saturating_sub(1)).max(1);
+    format!("{}{}", ".".repeat(dot_count), "\u{2588}")
 }
 
 pub(crate) async fn probe_provider_config_with_key(
@@ -973,7 +970,7 @@ impl ReplApp {
                             KeyCode::Char(c) if !is_clipboard_shortcut(key_event.modifiers) => {
                                 manual.push(c);
                             }
-                            KeyCode::Enter if !manual.is_empty() => {
+                            code if is_submit_key(&code) && !manual.is_empty() => {
                                 let model = manual.clone();
                                 input_mode = Some(PanelInputMode::AddStep3Key {
                                     provider: provider.clone(),
@@ -1000,7 +997,7 @@ impl ReplApp {
                             KeyCode::Char('m') | KeyCode::Char('M') => {
                                 *manual_input = Some(String::new());
                             }
-                            KeyCode::Enter => {
+                            code if is_submit_key(&code) => {
                                 if let Some((model_name, _)) = models.get(*model_sel) {
                                     input_mode = Some(PanelInputMode::AddStep3Key {
                                         provider: provider.clone(),
@@ -1087,7 +1084,7 @@ impl ReplApp {
                             }
                         }
                     }
-                    KeyCode::Enter if !key_buf.is_empty() => {
+                    code if is_submit_key(&code) && !key_buf.is_empty() => {
                         new_status_msg = Some((
                             "Testing provider connection...".to_string(),
                             OutputStyle::Dim,
@@ -3307,38 +3304,17 @@ impl ReplApp {
                 is_subscription,
                 ..
             }) => {
-                let (env_name, label) = if *is_subscription {
-                    (default_auth_token_env(provider), "Subscription token")
+                let label = if *is_subscription {
+                    "Subscription token"
                 } else {
-                    (default_api_key_env(provider), "API key")
+                    "API key"
                 };
-                let key_set = std::env::var(env_name).is_ok();
                 lines.clear();
                 lines.push(Line::from(vec![
                     Span::styled(format!("  {label} for {provider}"), theme::brand_word()),
                     Span::raw(" ".repeat(inner_width.saturating_sub(50))),
                     Span::styled("(Esc to go back)", theme::out_dim()),
                 ]));
-                lines.push(Line::from(""));
-                let hint = if *is_subscription {
-                    "  Tip: generate a token with `claude setup-token`"
-                } else {
-                    ""
-                };
-                lines.push(Line::from(Span::styled(
-                    format!(
-                        "  {label} env: {env_name}  ({})",
-                        if key_set {
-                            "\u{2713} already set \u{2014} will reuse"
-                        } else {
-                            "\u{2717} not set \u{2014} enter below"
-                        }
-                    ),
-                    theme::out_dim(),
-                )));
-                if !hint.is_empty() {
-                    lines.push(Line::from(Span::styled(hint, theme::label_caps())));
-                }
                 lines.push(Line::from(""));
                 let field_label = format!("  {label}: ");
                 let field_width = field_label.chars().count();
@@ -4581,10 +4557,63 @@ mod tests {
     #[test]
     fn masked_secret_preview_shows_paste_feedback_without_full_secret() {
         let preview = masked_secret_preview(64, 24);
-        assert!(preview.contains("(64 chars)"));
         assert!(preview.starts_with('.'));
         assert!(!preview.contains("sk-"));
         assert!(preview.chars().count() <= 24);
+        assert!(!preview.contains("chars"));
+    }
+
+    #[test]
+    fn provider_panel_api_key_render_has_only_input_field() {
+        let (mut app, textarea) = make_app();
+        app.panel = PanelState::ProviderManager {
+            selected: 4,
+            input_mode: Some(PanelInputMode::AddStep3Key {
+                provider: crate::config::ProviderKind::MiniMax,
+                model: "MiniMax-M2.7".to_string(),
+                key_buf: "sk-test".to_string(),
+                is_subscription: false,
+            }),
+            status_msg: None,
+        };
+
+        let (rendered, _rows) = render_app_to_string(&app, &textarea, 120, 30);
+
+        assert!(rendered.contains("API key for minimax"));
+        assert!(rendered.contains("API key: ......."));
+        assert!(!rendered.contains("API key env"));
+        assert!(!rendered.contains("chars"));
+        assert!(!rendered.contains("MiniMax-M2.7"));
+    }
+
+    #[test]
+    fn provider_panel_api_key_newline_char_submits_probe_action() {
+        let (mut app, mut textarea) = make_app();
+        app.panel = PanelState::ProviderManager {
+            selected: 4,
+            input_mode: Some(PanelInputMode::AddStep3Key {
+                provider: crate::config::ProviderKind::MiniMax,
+                model: "MiniMax-M2.7".to_string(),
+                key_buf: "sk-test-key".to_string(),
+                is_subscription: false,
+            }),
+            status_msg: None,
+        };
+
+        let action = app.handle_key(
+            KeyEvent::new(KeyCode::Char('\n'), KeyModifiers::NONE),
+            &mut textarea,
+        );
+
+        assert!(matches!(
+            action,
+            Action::ProviderKeySubmitted {
+                provider: crate::config::ProviderKind::MiniMax,
+                model,
+                key,
+                is_subscription: false,
+            } if model == "MiniMax-M2.7" && key == "sk-test-key"
+        ));
     }
 
     #[test]

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -781,10 +781,6 @@ impl ReplApp {
         };
 
         match input_mode {
-            Some(PanelInputMode::AddProvider(buf)) => {
-                append_single_line_input(buf, text);
-                true
-            }
             Some(PanelInputMode::AddStep2Model {
                 manual_input: Some(manual),
                 ..
@@ -913,45 +909,6 @@ impl ReplApp {
                     _ => {
                         input_mode = None;
                     }
-                },
-                PanelInputMode::AddStep1Provider { selected: step_sel } => match key_event.code {
-                    KeyCode::Esc => {
-                        input_mode = None;
-                    }
-                    KeyCode::Up if *step_sel > 0 => {
-                        *step_sel -= 1;
-                    }
-                    KeyCode::Down if *step_sel < PROVIDER_KINDS.len() - 1 => {
-                        *step_sel += 1;
-                    }
-                    KeyCode::Enter => {
-                        if let Some(kind) = parse_provider_kind_by_index(*step_sel) {
-                            selected = *step_sel;
-                            input_mode = Some(provider_setup_mode(kind));
-                        }
-                    }
-                    _ => {}
-                },
-                PanelInputMode::AddProvider(buf) => match key_event.code {
-                    KeyCode::Esc => {
-                        input_mode = None;
-                    }
-                    KeyCode::Enter => {
-                        let input_str = buf.clone();
-                        input_mode = None;
-                        let lines = super::provider::add_provider(&mut self.config, &input_str);
-                        for line in lines {
-                            self.output_lines.push(line);
-                        }
-                        self.save_config_and_rebuild_client();
-                    }
-                    KeyCode::Backspace => {
-                        buf.pop();
-                    }
-                    KeyCode::Char(c) if !is_clipboard_shortcut(key_event.modifiers) => {
-                        buf.push(c);
-                    }
-                    _ => {}
                 },
                 PanelInputMode::AddStepAuthType {
                     provider,
@@ -1176,17 +1133,6 @@ impl ReplApp {
                 };
                 Action::Continue
             }
-            KeyCode::Char('a') | KeyCode::Char('A') => {
-                if let Some(kind) = parse_provider_kind_by_index(selected) {
-                    input_mode = Some(provider_setup_mode(kind));
-                }
-                self.panel = PanelState::ProviderManager {
-                    selected,
-                    input_mode,
-                    status_msg: None,
-                };
-                Action::Continue
-            }
             KeyCode::Char('d') | KeyCode::Char('D') => {
                 if parse_provider_kind_by_index(selected)
                     .and_then(|kind| configured_provider_index(&self.config, &kind))
@@ -1203,18 +1149,6 @@ impl ReplApp {
             KeyCode::Char('t') | KeyCode::Char('T') => {
                 if let Some(kind) = parse_provider_kind_by_index(selected) {
                     new_status_msg = Some(self.test_provider_connection_config(&kind));
-                }
-                self.panel = PanelState::ProviderManager {
-                    selected,
-                    input_mode: None,
-                    status_msg: new_status_msg,
-                };
-                Action::Continue
-            }
-            KeyCode::Char('p') | KeyCode::Char('P') => {
-                if let Some(kind) = parse_provider_kind_by_index(selected) {
-                    new_status_msg = Some(self.set_provider_priority(&kind));
-                    self.save_config_and_rebuild_client();
                 }
                 self.panel = PanelState::ProviderManager {
                     selected,
@@ -1359,39 +1293,6 @@ impl ReplApp {
         }
         self.upsert_provider_connection(config);
         Ok(())
-    }
-
-    /// Marks a configured provider as the first provider in the fallback chain.
-    fn set_provider_priority(
-        &mut self,
-        kind: &crate::config::ProviderKind,
-    ) -> (String, OutputStyle) {
-        let Some(index) = configured_provider_index(&self.config, kind) else {
-            return (
-                format!("{} is not configured.", provider_kind_label(kind)),
-                OutputStyle::Dim,
-            );
-        };
-        let target = if configured_provider_index(&self.workspace_config, kind).is_some() {
-            &mut self.workspace_config
-        } else {
-            &mut self.user_config
-        };
-        for (i, provider) in target.providers.iter_mut().enumerate() {
-            provider.role = if i == index {
-                crate::config::ProviderRole::Primary
-            } else {
-                crate::config::ProviderRole::Fallback
-            };
-        }
-        self.refresh_effective_config();
-        (
-            format!(
-                "{} is now first in the fallback chain.",
-                provider_kind_label(kind)
-            ),
-            OutputStyle::Success,
-        )
     }
 
     /// Performs a local provider config check without making a network call.
@@ -2242,7 +2143,6 @@ impl ReplApp {
                 }
             }
             PanelState::ProviderManager { input_mode, .. } => Some(match input_mode {
-                Some(PanelInputMode::AddStep1Provider { .. }) => (PROVIDER_KINDS.len() as u16) + 4,
                 Some(PanelInputMode::AddStep2Model {
                     provider,
                     manual_input,
@@ -2261,7 +2161,6 @@ impl ReplApp {
                 Some(PanelInputMode::AddStep3Key { .. }) => 9,
                 _ => {
                     let provider_count = PROVIDER_KINDS.len().max(1);
-                    let input_line = if input_mode.is_some() { 1 } else { 0 };
                     let status_line = match (&self.panel, input_mode) {
                         (
                             PanelState::ProviderManager {
@@ -2272,7 +2171,7 @@ impl ReplApp {
                         ) => 2,
                         _ => 0,
                     };
-                    (provider_count as u16) + 7 + input_line + status_line
+                    (provider_count as u16) + 8 + status_line
                 }
             }),
         }
@@ -3205,13 +3104,6 @@ impl ReplApp {
         }
 
         match input_mode {
-            Some(PanelInputMode::AddProvider(buf)) => {
-                lines.push(Line::from(vec![
-                    Span::styled("  Add: ", theme::out_help_cmd()),
-                    Span::styled(format!("{buf}\u{2588}"), theme::brand_word()),
-                    Span::styled("  (provider model api_key_env)", theme::out_dim()),
-                ]));
-            }
             Some(PanelInputMode::ConfirmDelete) => {
                 let provider_name = parse_provider_kind_by_index(selected)
                     .map(|kind| provider_kind_label(&kind))
@@ -3220,26 +3112,6 @@ impl ReplApp {
                     format!("  Delete {provider_name} connection? [y/N]"),
                     theme::out_error(),
                 )));
-            }
-            Some(PanelInputMode::AddStep1Provider { selected: step_sel }) => {
-                lines.clear();
-                lines.push(Line::from(vec![
-                    Span::styled("  Select Provider", theme::brand_word()),
-                    Span::raw(" ".repeat(inner_width.saturating_sub(45))),
-                    Span::styled("(Esc to cancel)", theme::out_dim()),
-                ]));
-                lines.push(Line::from(""));
-                for (i, (name, desc)) in PROVIDER_KINDS.iter().enumerate() {
-                    let is_sel = i == *step_sel;
-                    let prefix = if is_sel { "  \u{25cf} " } else { "    " };
-                    let text = format!("{prefix}{}. {:<14} {}", i + 1, name, desc);
-                    let style = if is_sel {
-                        theme::slash_selected()
-                    } else {
-                        theme::out_dim()
-                    };
-                    lines.push(Line::from(Span::styled(text, style)));
-                }
             }
             Some(PanelInputMode::AddStepAuthType {
                 provider,
@@ -3373,8 +3245,9 @@ impl ReplApp {
                     lines.push(Line::from(Span::styled(format!("  {msg}"), s)));
                     lines.push(Line::from(""));
                 }
+                lines.push(Line::from(""));
                 lines.push(Line::from(Span::styled(
-                    "  [Enter] Configure  [A] Add  [D] Delete  [P] Priority  [T] Test",
+                    "  [Enter] Configure  [D] Delete  [T] Test",
                     theme::out_dim(),
                 )));
             }
@@ -4127,41 +4000,34 @@ mod tests {
     }
 
     #[test]
-    fn provider_panel_a_starts_setup_for_selected_provider() {
+    fn provider_panel_a_and_p_are_inactive() {
         let (mut app, mut textarea) = make_app();
         app.panel = PanelState::ProviderManager {
             selected: 1,
             input_mode: None,
             status_msg: None,
         };
-        let key = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE);
-        app.handle_key(key, &mut textarea);
-        if let PanelState::ProviderManager { input_mode, .. } = &app.panel {
-            assert!(matches!(
-                input_mode,
-                Some(PanelInputMode::AddStep2Model {
-                    provider: crate::config::ProviderKind::OpenAI,
-                    is_subscription: false,
-                    ..
-                })
-            ));
-        }
-    }
 
-    #[test]
-    fn provider_panel_add_provider_esc_cancels() {
-        let (mut app, mut textarea) = make_app();
-        app.panel = PanelState::ProviderManager {
-            selected: 0,
-            input_mode: Some(PanelInputMode::AddProvider("partial".to_string())),
-            status_msg: None,
-        };
-        let key = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
-        app.handle_key(key, &mut textarea);
-        if let PanelState::ProviderManager { input_mode, .. } = &app.panel {
+        app.handle_key(
+            KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE),
+            &mut textarea,
+        );
+        app.handle_key(
+            KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE),
+            &mut textarea,
+        );
+
+        if let PanelState::ProviderManager {
+            selected,
+            input_mode,
+            status_msg,
+        } = &app.panel
+        {
+            assert_eq!(*selected, 1);
             assert!(input_mode.is_none());
+            assert!(status_msg.is_none());
         } else {
-            panic!("panel should still be ProviderManager after Esc in AddProvider mode");
+            panic!("panel should remain ProviderManager");
         }
     }
 
@@ -4514,13 +4380,27 @@ mod tests {
             status_msg: None,
         };
 
-        let (rendered, _) = render_app_to_string(&app, &textarea, 180, 40);
+        let (rendered, rows) = render_app_to_string(&app, &textarea, 180, 40);
 
         assert!(rendered.contains("configured      user       api key"));
         assert!(rendered.contains("not configured  missing    api key"));
         assert!(!rendered.contains("priority"));
         assert!(!rendered.contains("fallback"));
         assert!(!rendered.contains("default MiniMax-M2.7"));
+        assert!(!rendered.contains("[A] Add"));
+        assert!(!rendered.contains("[P] Priority"));
+        assert!(rendered.contains("[Enter] Configure  [D] Delete  [T] Test"));
+        let footer_row = rows
+            .iter()
+            .position(|row| row.contains("[Enter] Configure  [D] Delete  [T] Test"))
+            .expect("footer should render");
+        assert!(footer_row > 0);
+        assert!(
+            rows[footer_row - 1]
+                .chars()
+                .all(|c| c.is_whitespace()
+                    || matches!(c, '\u{2502}' | '\u{2551}' | '\u{2503}' | '|'))
+        );
     }
 
     #[test]

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -2143,6 +2143,7 @@ impl ReplApp {
                 }
             }
             PanelState::ProviderManager { input_mode, .. } => Some(match input_mode {
+                Some(PanelInputMode::ConfirmDelete) => (PROVIDER_KINDS.len() as u16) + 11,
                 Some(PanelInputMode::AddStep2Model {
                     provider,
                     manual_input,
@@ -2171,7 +2172,7 @@ impl ReplApp {
                         ) => 2,
                         _ => 0,
                     };
-                    (provider_count as u16) + 8 + status_line
+                    (provider_count as u16) + 9 + status_line
                 }
             }),
         }
@@ -3070,6 +3071,13 @@ impl ReplApp {
             Span::styled("(Esc to close)", theme::out_dim()),
         ]));
         lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            format!(
+                "     {:<3} {:<12} {:<34} {:<15} {:<10} {:<12}",
+                "#", "Provider ID", "Display name", "Connection", "Key source", "Required secret"
+            ),
+            theme::out_dim(),
+        )));
 
         for (i, (name, desc)) in PROVIDER_KINDS.iter().enumerate() {
             let Some(kind) = parse_provider_kind_by_index(i) else {
@@ -3077,24 +3085,36 @@ impl ReplApp {
             };
             let is_sel = i == selected;
             let prefix = if is_sel { "  \u{25cf} " } else { "    " };
-            let status = if let Some(index) = configured_provider_index(&self.config, &kind) {
-                let provider = &self.config.providers[index];
-                let auth = if provider.auth_token_env.is_some() {
-                    "subscription"
+            let (connection, key_source, required_secret) =
+                if let Some(index) = configured_provider_index(&self.config, &kind) {
+                    let provider = &self.config.providers[index];
+                    let auth = if provider.auth_token_env.is_some() {
+                        "subscription"
+                    } else {
+                        "api key"
+                    };
+                    let config_source = self.provider_config_source_label(&kind);
+                    (
+                        "configured".to_string(),
+                        config_source.to_string(),
+                        auth.to_string(),
+                    )
                 } else {
-                    "api key"
+                    (
+                        "not configured".to_string(),
+                        "missing".to_string(),
+                        provider_auth_summary(&kind),
+                    )
                 };
-                let config_source = self.provider_config_source_label(&kind);
-                format!("{:<15} {:<10} {:<12}", "configured", config_source, auth)
-            } else {
-                format!(
-                    "{:<15} {:<10} {:<12}",
-                    "not configured",
-                    "missing",
-                    provider_auth_summary(&kind)
-                )
-            };
-            let text = format!("{prefix}{}. {:<11} {:<34} {}", i + 1, name, desc, status);
+            let text = format!(
+                "{prefix}{:<3} {:<12} {:<34} {:<15} {:<10} {:<12}",
+                format!("{}.", i + 1),
+                name,
+                desc,
+                connection,
+                key_source,
+                required_secret
+            );
             let style = if is_sel {
                 theme::slash_selected()
             } else {
@@ -3108,9 +3128,15 @@ impl ReplApp {
                 let provider_name = parse_provider_kind_by_index(selected)
                     .map(|kind| provider_kind_label(&kind))
                     .unwrap_or("provider");
+                lines.push(Line::from(""));
                 lines.push(Line::from(Span::styled(
                     format!("  Delete {provider_name} connection? [y/N]"),
                     theme::out_error(),
+                )));
+                lines.push(Line::from(""));
+                lines.push(Line::from(Span::styled(
+                    "  [Enter] Configure    [D] Delete key [T] Test connection",
+                    theme::out_dim(),
                 )));
             }
             Some(PanelInputMode::AddStepAuthType {
@@ -3242,12 +3268,14 @@ impl ReplApp {
                         OutputStyle::Error => theme::out_error(),
                         _ => theme::out_dim(),
                     };
+                    lines.push(Line::from(""));
                     lines.push(Line::from(Span::styled(format!("  {msg}"), s)));
                     lines.push(Line::from(""));
+                } else {
+                    lines.push(Line::from(""));
                 }
-                lines.push(Line::from(""));
                 lines.push(Line::from(Span::styled(
-                    "  [Enter] Configure  [D] Delete  [T] Test",
+                    "  [Enter] Configure    [D] Delete key [T] Test connection",
                     theme::out_dim(),
                 )));
             }
@@ -3402,6 +3430,11 @@ mod tests {
     fn render_to_string(width: u16, height: u16) -> (String, Vec<String>) {
         let (app, textarea) = make_app();
         render_app_to_string(&app, &textarea, width, height)
+    }
+
+    fn visually_empty_panel_row(row: &str) -> bool {
+        row.chars()
+            .all(|c| c.is_whitespace() || matches!(c, '\u{2502}' | '\u{2551}' | '\u{2503}' | '|'))
     }
 
     #[test]
@@ -4382,6 +4415,10 @@ mod tests {
 
         let (rendered, rows) = render_app_to_string(&app, &textarea, 180, 40);
 
+        assert!(rendered.contains("#   Provider ID  Display name"));
+        assert!(rendered.contains("Connection"));
+        assert!(rendered.contains("Key source"));
+        assert!(rendered.contains("Required secret"));
         assert!(rendered.contains("configured      user       api key"));
         assert!(rendered.contains("not configured  missing    api key"));
         assert!(!rendered.contains("priority"));
@@ -4389,18 +4426,63 @@ mod tests {
         assert!(!rendered.contains("default MiniMax-M2.7"));
         assert!(!rendered.contains("[A] Add"));
         assert!(!rendered.contains("[P] Priority"));
-        assert!(rendered.contains("[Enter] Configure  [D] Delete  [T] Test"));
+        assert!(rendered.contains("[Enter] Configure    [D] Delete key [T] Test connection"));
         let footer_row = rows
             .iter()
-            .position(|row| row.contains("[Enter] Configure  [D] Delete  [T] Test"))
+            .position(|row| row.contains("[Enter] Configure    [D] Delete key [T] Test connection"))
             .expect("footer should render");
         assert!(footer_row > 0);
-        assert!(
-            rows[footer_row - 1]
-                .chars()
-                .all(|c| c.is_whitespace()
-                    || matches!(c, '\u{2502}' | '\u{2551}' | '\u{2503}' | '|'))
-        );
+        assert!(visually_empty_panel_row(&rows[footer_row - 1]));
+    }
+
+    #[test]
+    fn provider_panel_test_message_has_single_separator_rows() {
+        let (mut app, textarea) = make_app();
+        app.panel = PanelState::ProviderManager {
+            selected: 4,
+            input_mode: None,
+            status_msg: Some(("minimax is not configured.".to_string(), OutputStyle::Dim)),
+        };
+
+        let (_rendered, rows) = render_app_to_string(&app, &textarea, 180, 40);
+        let message_row = rows
+            .iter()
+            .position(|row| row.contains("minimax is not configured."))
+            .expect("test message should render");
+        let footer_row = rows
+            .iter()
+            .position(|row| row.contains("[Enter] Configure    [D] Delete key [T] Test connection"))
+            .expect("footer should render");
+
+        assert!(message_row > 0);
+        assert_eq!(footer_row, message_row + 2);
+        assert!(visually_empty_panel_row(&rows[message_row - 1]));
+        assert!(visually_empty_panel_row(&rows[message_row + 1]));
+    }
+
+    #[test]
+    fn provider_panel_delete_confirmation_has_single_separator_rows() {
+        let (mut app, textarea) = make_app();
+        app.panel = PanelState::ProviderManager {
+            selected: 4,
+            input_mode: Some(PanelInputMode::ConfirmDelete),
+            status_msg: None,
+        };
+
+        let (_rendered, rows) = render_app_to_string(&app, &textarea, 180, 40);
+        let message_row = rows
+            .iter()
+            .position(|row| row.contains("Delete minimax connection? [y/N]"))
+            .expect("delete confirmation should render");
+        let footer_row = rows
+            .iter()
+            .position(|row| row.contains("[Enter] Configure    [D] Delete key [T] Test connection"))
+            .expect("footer should render");
+
+        assert!(message_row > 0);
+        assert_eq!(footer_row, message_row + 2);
+        assert!(visually_empty_panel_row(&rows[message_row - 1]));
+        assert!(visually_empty_panel_row(&rows[message_row + 1]));
     }
 
     #[test]

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -315,6 +315,13 @@ fn append_single_line_input(buf: &mut String, text: &str) {
     buf.extend(text.chars().filter(|c| !matches!(c, '\r' | '\n')));
 }
 
+fn validate_provider_key(key: &str) -> Result<(), &'static str> {
+    if key.trim().chars().count() < 8 {
+        return Err("API key looks too short.");
+    }
+    Ok(())
+}
+
 fn masked_secret_preview(char_count: usize, max_width: usize) -> String {
     if char_count == 0 {
         return "\u{2588}".to_string();
@@ -915,11 +922,11 @@ impl ReplApp {
                             }
                             KeyCode::Enter if !manual.is_empty() => {
                                 let model = manual.clone();
-                                input_mode = Some(PanelInputMode::AddStepCredentialSource {
+                                input_mode = Some(PanelInputMode::AddStep3Key {
                                     provider: provider.clone(),
                                     model,
+                                    key_buf: String::new(),
                                     is_subscription: *is_subscription,
-                                    selected: 0,
                                 });
                             }
                             _ => {}
@@ -942,11 +949,11 @@ impl ReplApp {
                             }
                             KeyCode::Enter => {
                                 if let Some((model_name, _)) = models.get(*model_sel) {
-                                    input_mode = Some(PanelInputMode::AddStepCredentialSource {
+                                    input_mode = Some(PanelInputMode::AddStep3Key {
                                         provider: provider.clone(),
                                         model: (*model_name).to_string(),
+                                        key_buf: String::new(),
                                         is_subscription: *is_subscription,
-                                        selected: 0,
                                     });
                                 }
                             }
@@ -954,49 +961,6 @@ impl ReplApp {
                         }
                     }
                 }
-                PanelInputMode::AddStepCredentialSource {
-                    provider,
-                    model,
-                    is_subscription,
-                    selected: source_sel,
-                } => match key_event.code {
-                    KeyCode::Esc => {
-                        input_mode = Some(PanelInputMode::AddStep2Model {
-                            provider: provider.clone(),
-                            is_subscription: *is_subscription,
-                            selected: 0,
-                            manual_input: None,
-                        });
-                    }
-                    KeyCode::Up if *source_sel > 0 => {
-                        *source_sel -= 1;
-                    }
-                    KeyCode::Down if *source_sel < 1 => {
-                        *source_sel += 1;
-                    }
-                    KeyCode::Enter if *source_sel == 0 => {
-                        self.save_provider_with_env_credential(
-                            provider.clone(),
-                            model.clone(),
-                            *is_subscription,
-                        );
-                        self.save_config_and_rebuild_client();
-                        new_status_msg = Some((
-                            "Provider connection saved.".to_string(),
-                            OutputStyle::Success,
-                        ));
-                        input_mode = None;
-                    }
-                    KeyCode::Enter => {
-                        input_mode = Some(PanelInputMode::AddStep3Key {
-                            provider: provider.clone(),
-                            model: model.clone(),
-                            key_buf: String::new(),
-                            is_subscription: *is_subscription,
-                        });
-                    }
-                    _ => {}
-                },
                 PanelInputMode::AddStep3Key {
                     provider,
                     model,
@@ -1004,11 +968,11 @@ impl ReplApp {
                     is_subscription,
                 } => match key_event.code {
                     KeyCode::Esc => {
-                        input_mode = Some(PanelInputMode::AddStepCredentialSource {
+                        input_mode = Some(PanelInputMode::AddStep2Model {
                             provider: provider.clone(),
-                            model: model.clone(),
                             is_subscription: *is_subscription,
                             selected: 0,
+                            manual_input: None,
                         });
                     }
                     KeyCode::Backspace => {
@@ -1070,29 +1034,28 @@ impl ReplApp {
                             }
                         }
                     }
-                    KeyCode::Enter if !key_buf.is_empty() => {
-                        match self.save_provider_with_file_credential(
-                            provider.clone(),
-                            model.clone(),
-                            key_buf.clone(),
-                            *is_subscription,
-                        ) {
-                            Ok(()) => {
-                                self.save_config_and_rebuild_client();
-                                new_status_msg = Some((
-                                    "Provider connection saved.".to_string(),
-                                    OutputStyle::Success,
-                                ));
-                                input_mode = None;
-                            }
-                            Err(e) => {
-                                new_status_msg = Some((
-                                    format!("Credential save failed: {e}"),
-                                    OutputStyle::Error,
-                                ));
+                    KeyCode::Enter if !key_buf.is_empty() => match validate_provider_key(key_buf) {
+                        Ok(()) => {
+                            match self.save_provider_with_file_credential(
+                                provider.clone(),
+                                model.clone(),
+                                key_buf.clone(),
+                                *is_subscription,
+                            ) {
+                                Ok(()) => {
+                                    self.save_config_and_rebuild_client();
+                                    input_mode = None;
+                                }
+                                Err(e) => {
+                                    new_status_msg = Some((
+                                        format!("Credential save failed: {e}"),
+                                        OutputStyle::Error,
+                                    ));
+                                }
                             }
                         }
-                    }
+                        Err(e) => new_status_msg = Some((e.to_string(), OutputStyle::Error)),
+                    },
                     KeyCode::Char(c) if !is_clipboard_shortcut(key_event.modifiers) => {
                         key_buf.push(c);
                     }
@@ -1232,30 +1195,6 @@ impl ReplApp {
         Self::ensure_primary_provider(&mut self.user_config);
         self.refresh_effective_config();
         true
-    }
-
-    fn save_provider_with_env_credential(
-        &mut self,
-        provider: crate::config::ProviderKind,
-        model: String,
-        is_subscription: bool,
-    ) {
-        let api_key_env = default_api_key_env(&provider).to_string();
-        let token_env = if is_subscription {
-            Some(default_auth_token_env(&provider).to_string())
-        } else {
-            None
-        };
-        self.upsert_provider_connection(crate::config::ProviderConfig {
-            provider,
-            role: crate::config::ProviderRole::Primary,
-            model,
-            api_key_env,
-            base_url: None,
-            timeout_secs: None,
-            key_storage: None,
-            auth_token_env: token_env,
-        });
     }
 
     fn save_provider_with_file_credential(
@@ -2187,8 +2126,7 @@ impl ReplApp {
                 Some(PanelInputMode::AddStepAuthType { provider, .. }) => {
                     provider_auth_modes(provider).len() as u16 + 6
                 }
-                Some(PanelInputMode::AddStepCredentialSource { .. }) => 8,
-                Some(PanelInputMode::AddStep3Key { .. }) => 10,
+                Some(PanelInputMode::AddStep3Key { .. }) => 9,
                 _ => {
                     let provider_count = PROVIDER_KINDS.len().max(1);
                     let input_line = if input_mode.is_some() { 1 } else { 0 };
@@ -3134,12 +3072,6 @@ impl ReplApp {
             lines.push(Line::from(Span::styled(text, style)));
         }
 
-        lines.push(Line::from(""));
-        lines.push(Line::from(Span::styled(
-            "  Providers are saved to ~/.duumbi/config.toml",
-            theme::out_dim(),
-        )));
-
         match input_mode {
             Some(PanelInputMode::AddProvider(buf)) => {
                 lines.push(Line::from(vec![
@@ -3262,55 +3194,11 @@ impl ReplApp {
                     )));
                 }
             }
-            Some(PanelInputMode::AddStepCredentialSource {
-                provider,
-                model,
-                is_subscription,
-                selected: source_sel,
-            }) => {
-                let (env_name, label) = if *is_subscription {
-                    (default_auth_token_env(provider), "Subscription token")
-                } else {
-                    (default_api_key_env(provider), "API key")
-                };
-                lines.clear();
-                lines.push(Line::from(vec![
-                    Span::styled(
-                        format!("  {label} source for {provider}"),
-                        theme::brand_word(),
-                    ),
-                    Span::raw(" ".repeat(inner_width.saturating_sub(58))),
-                    Span::styled("(Esc to go back)", theme::out_dim()),
-                ]));
-                lines.push(Line::from(""));
-                lines.push(Line::from(Span::styled(
-                    format!("  Model: {model}"),
-                    theme::out_dim(),
-                )));
-                lines.push(Line::from(""));
-                let options = [
-                    format!("Use environment variable: {env_name}"),
-                    format!("Enter {label}"),
-                ];
-                for (i, option) in options.iter().enumerate() {
-                    let prefix = if i == *source_sel {
-                        "  \u{25cf} "
-                    } else {
-                        "    "
-                    };
-                    let style = if i == *source_sel {
-                        theme::slash_selected()
-                    } else {
-                        theme::out_dim()
-                    };
-                    lines.push(Line::from(Span::styled(format!("{prefix}{option}"), style)));
-                }
-            }
             Some(PanelInputMode::AddStep3Key {
                 provider,
-                model,
                 key_buf,
                 is_subscription,
+                ..
             }) => {
                 let (env_name, label) = if *is_subscription {
                     (default_auth_token_env(provider), "Subscription token")
@@ -3325,10 +3213,6 @@ impl ReplApp {
                     Span::styled("(Esc to go back)", theme::out_dim()),
                 ]));
                 lines.push(Line::from(""));
-                lines.push(Line::from(Span::styled(
-                    format!("  Model: {model}"),
-                    theme::out_dim(),
-                )));
                 let hint = if *is_subscription {
                     "  Tip: generate a token with `claude setup-token`"
                 } else {
@@ -3359,6 +3243,14 @@ impl ReplApp {
                     Span::styled(field_label, theme::out_help_cmd()),
                     Span::styled(masked, theme::brand_word()),
                 ]));
+                if let Some((msg, style)) = status_msg {
+                    let s = match style {
+                        OutputStyle::Success => theme::out_success(),
+                        OutputStyle::Error => theme::out_error(),
+                        _ => theme::out_dim(),
+                    };
+                    lines.push(Line::from(Span::styled(format!("  {msg}"), s)));
+                }
                 lines.push(Line::from(""));
                 lines.push(Line::from(Span::styled(
                     "  [Enter] Save  [Esc] Back",
@@ -4217,6 +4109,38 @@ mod tests {
     }
 
     #[test]
+    fn provider_panel_model_enter_opens_api_key_input() {
+        let (mut app, mut textarea) = make_app();
+        app.panel = PanelState::ProviderManager {
+            selected: 4,
+            input_mode: Some(PanelInputMode::AddStep2Model {
+                provider: crate::config::ProviderKind::MiniMax,
+                is_subscription: false,
+                selected: 0,
+                manual_input: None,
+            }),
+            status_msg: None,
+        };
+
+        let key = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+        app.handle_key(key, &mut textarea);
+
+        if let PanelState::ProviderManager { input_mode, .. } = &app.panel {
+            assert!(matches!(
+                input_mode,
+                Some(PanelInputMode::AddStep3Key {
+                    provider: crate::config::ProviderKind::MiniMax,
+                    model,
+                    key_buf,
+                    is_subscription: false,
+                }) if model == "MiniMax-M2.7" && key_buf.is_empty()
+            ));
+        } else {
+            panic!("panel should remain ProviderManager");
+        }
+    }
+
+    #[test]
     fn provider_panel_upsert_without_workspace_targets_user_config() {
         let (mut app, _) = make_app();
         app.has_workspace = false;
@@ -4281,27 +4205,6 @@ mod tests {
     }
 
     #[test]
-    fn provider_panel_env_source_saves_config_without_key_input() {
-        let (mut app, _) = make_app();
-
-        app.save_provider_with_env_credential(
-            crate::config::ProviderKind::MiniMax,
-            "MiniMax-M2.7".to_string(),
-            false,
-        );
-
-        let provider = app
-            .config
-            .providers
-            .iter()
-            .find(|provider| provider.provider == crate::config::ProviderKind::MiniMax)
-            .expect("invariant: provider should be configured");
-        assert_eq!(provider.api_key_env, "MINIMAX_API_KEY");
-        assert!(provider.key_storage.is_none());
-        assert!(provider.auth_token_env.is_none());
-    }
-
-    #[test]
     fn provider_panel_api_key_enter_saves_file_and_returns_to_list() {
         let _guard = ENV_LOCK.lock().expect("invariant: env lock");
         let home = tempfile::TempDir::new().expect("invariant: temp home");
@@ -4330,10 +4233,7 @@ mod tests {
         } = &app.panel
         {
             assert!(input_mode.is_none());
-            assert_eq!(
-                status_msg.as_ref().map(|(msg, _)| msg.as_str()),
-                Some("Provider connection saved.")
-            );
+            assert!(status_msg.is_none());
         } else {
             panic!("panel should remain ProviderManager");
         }
@@ -4348,6 +4248,43 @@ mod tests {
             .expect("invariant: credentials file should exist");
         assert!(credentials.contains("MINIMAX_API_KEY"));
         assert!(credentials.contains("sk-test-key"));
+    }
+
+    #[test]
+    fn provider_panel_invalid_api_key_stays_in_input_with_error() {
+        let (mut app, mut textarea) = make_app();
+        app.panel = PanelState::ProviderManager {
+            selected: 4,
+            input_mode: Some(PanelInputMode::AddStep3Key {
+                provider: crate::config::ProviderKind::MiniMax,
+                model: "MiniMax-M2.7".to_string(),
+                key_buf: "123".to_string(),
+                is_subscription: false,
+            }),
+            status_msg: None,
+        };
+
+        let key = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+        app.handle_key(key, &mut textarea);
+
+        if let PanelState::ProviderManager {
+            input_mode,
+            status_msg,
+            ..
+        } = &app.panel
+        {
+            assert!(matches!(
+                input_mode,
+                Some(PanelInputMode::AddStep3Key { .. })
+            ));
+            assert_eq!(
+                status_msg.as_ref().map(|(msg, _)| msg.as_str()),
+                Some("API key looks too short.")
+            );
+        } else {
+            panic!("panel should remain ProviderManager");
+        }
+        assert!(app.config.providers.is_empty());
     }
 
     #[test]

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -31,6 +31,85 @@ const PROVIDER_KINDS: &[(&str, &str)] = &[
     ("minimax", "MiniMax"),
 ];
 
+/// Authentication modes the provider setup TUI can actually configure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProviderAuthMode {
+    /// Direct provider API key stored in an env var or local credentials file.
+    ApiKey,
+}
+
+const API_KEY_AUTH_MODES: &[ProviderAuthMode] = &[ProviderAuthMode::ApiKey];
+
+impl ProviderAuthMode {
+    /// Returns the short label shown in the provider list.
+    const fn summary(self) -> &'static str {
+        match self {
+            Self::ApiKey => "api key",
+        }
+    }
+
+    /// Returns the title shown in the auth chooser.
+    const fn title(self) -> &'static str {
+        match self {
+            Self::ApiKey => "API Key",
+        }
+    }
+
+    /// Returns the explanatory text shown in the auth chooser.
+    const fn hint(self) -> &'static str {
+        match self {
+            Self::ApiKey => "Direct provider API key",
+        }
+    }
+
+    /// Returns whether this mode stores a bearer/subscription token.
+    const fn is_subscription(self) -> bool {
+        match self {
+            Self::ApiKey => false,
+        }
+    }
+}
+
+/// Returns setup modes that are implemented for this direct provider.
+fn provider_auth_modes(_kind: &crate::config::ProviderKind) -> &'static [ProviderAuthMode] {
+    API_KEY_AUTH_MODES
+}
+
+/// Returns a compact list label for configured setup modes.
+fn provider_auth_summary(kind: &crate::config::ProviderKind) -> String {
+    provider_auth_modes(kind)
+        .iter()
+        .map(|mode| mode.summary())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// Returns the selected auth mode, clamped to the provider capability table.
+fn provider_auth_mode_by_index(
+    kind: &crate::config::ProviderKind,
+    selected: usize,
+) -> Option<ProviderAuthMode> {
+    provider_auth_modes(kind).get(selected).copied()
+}
+
+/// Starts the setup wizard for a provider from the main provider list.
+fn provider_setup_mode(kind: crate::config::ProviderKind) -> PanelInputMode {
+    let modes = provider_auth_modes(&kind);
+    if modes.len() == 1 {
+        PanelInputMode::AddStep2Model {
+            provider: kind,
+            is_subscription: modes[0].is_subscription(),
+            selected: 0,
+            manual_input: None,
+        }
+    } else {
+        PanelInputMode::AddStepAuthType {
+            provider: kind,
+            selected: 0,
+        }
+    }
+}
+
 /// Returns a short provider label for the provider manager.
 fn provider_kind_label(kind: &crate::config::ProviderKind) -> &'static str {
     use crate::config::ProviderKind;
@@ -660,10 +739,7 @@ impl ReplApp {
                     KeyCode::Enter => {
                         if let Some(kind) = parse_provider_kind_by_index(*step_sel) {
                             selected = *step_sel;
-                            input_mode = Some(PanelInputMode::AddStepAuthType {
-                                provider: kind,
-                                selected: 0,
-                            });
+                            input_mode = Some(provider_setup_mode(kind));
                         }
                     }
                     _ => {}
@@ -694,18 +770,25 @@ impl ReplApp {
                     selected: auth_sel,
                 } => match key_event.code {
                     KeyCode::Esc => {
-                        input_mode = Some(PanelInputMode::AddStep1Provider { selected });
+                        input_mode = None;
                     }
-                    KeyCode::Up | KeyCode::Down => {
-                        *auth_sel = 1 - *auth_sel;
+                    KeyCode::Up if *auth_sel > 0 => {
+                        *auth_sel -= 1;
+                    }
+                    KeyCode::Down
+                        if *auth_sel < provider_auth_modes(provider).len().saturating_sub(1) =>
+                    {
+                        *auth_sel += 1;
                     }
                     KeyCode::Enter => {
-                        input_mode = Some(PanelInputMode::AddStep2Model {
-                            provider: provider.clone(),
-                            is_subscription: *auth_sel == 1,
-                            selected: 0,
-                            manual_input: None,
-                        });
+                        if let Some(auth_mode) = provider_auth_mode_by_index(provider, *auth_sel) {
+                            input_mode = Some(PanelInputMode::AddStep2Model {
+                                provider: provider.clone(),
+                                is_subscription: auth_mode.is_subscription(),
+                                selected: 0,
+                                manual_input: None,
+                            });
+                        }
                     }
                     _ => {}
                 },
@@ -743,10 +826,7 @@ impl ReplApp {
                         let models = recommended_models(provider);
                         match key_event.code {
                             KeyCode::Esc => {
-                                input_mode = Some(PanelInputMode::AddStepAuthType {
-                                    provider: provider.clone(),
-                                    selected: if *is_subscription { 1 } else { 0 },
-                                });
+                                input_mode = None;
                             }
                             KeyCode::Up if *model_sel > 0 => {
                                 *model_sel -= 1;
@@ -954,10 +1034,7 @@ impl ReplApp {
             }
             KeyCode::Enter => {
                 if let Some(kind) = parse_provider_kind_by_index(selected) {
-                    input_mode = Some(PanelInputMode::AddStepAuthType {
-                        provider: kind,
-                        selected: 0,
-                    });
+                    input_mode = Some(provider_setup_mode(kind));
                 }
                 self.panel = PanelState::ProviderManager {
                     selected,
@@ -967,9 +1044,12 @@ impl ReplApp {
                 Action::Continue
             }
             KeyCode::Char('a') | KeyCode::Char('A') => {
+                if let Some(kind) = parse_provider_kind_by_index(selected) {
+                    input_mode = Some(provider_setup_mode(kind));
+                }
                 self.panel = PanelState::ProviderManager {
                     selected,
-                    input_mode: Some(PanelInputMode::AddStep1Provider { selected }),
+                    input_mode,
                     status_msg: None,
                 };
                 Action::Continue
@@ -1886,7 +1966,9 @@ impl ReplApp {
                         (models.len() as u16) + 6
                     }
                 }
-                Some(PanelInputMode::AddStepAuthType { .. }) => 8,
+                Some(PanelInputMode::AddStepAuthType { provider, .. }) => {
+                    provider_auth_modes(provider).len() as u16 + 6
+                }
                 Some(PanelInputMode::AddStep3Key { .. }) => 10,
                 Some(PanelInputMode::AddStep3Confirm { .. }) => 5,
                 _ => {
@@ -2813,7 +2895,7 @@ impl ReplApp {
                 let auth = if provider.auth_token_env.is_some() {
                     "subscription"
                 } else {
-                    "key"
+                    "api key"
                 };
                 let credential_env = active_credential_env(provider);
                 let source = if std::env::var(credential_env).is_ok() {
@@ -2833,7 +2915,7 @@ impl ReplApp {
                     auth, source, priority, provider.model
                 )
             } else {
-                "not configured  key/subscription".to_string()
+                format!("not configured  {}", provider_auth_summary(&kind))
             };
             let text = format!("{prefix}{}. {:<11} {:<34} {}", i + 1, name, desc, status);
             let style = if is_sel {
@@ -2897,14 +2979,8 @@ impl ReplApp {
                     Span::styled("(Esc to go back)", theme::out_dim()),
                 ]));
                 lines.push(Line::from(""));
-                let options = [
-                    ("API Key", "Traditional API key (X-Api-Key header)"),
-                    (
-                        "Subscription Token",
-                        "Claude Pro/Max or OAuth token (Bearer header, via `claude setup-token`)",
-                    ),
-                ];
-                for (i, (label, hint)) in options.iter().enumerate() {
+                let options = provider_auth_modes(provider);
+                for (i, auth_mode) in options.iter().enumerate() {
                     let marker = if i == *auth_sel { "> " } else { "  " };
                     let style = if i == *auth_sel {
                         theme::slash_selected()
@@ -2912,8 +2988,8 @@ impl ReplApp {
                         theme::out_dim()
                     };
                     lines.push(Line::from(vec![
-                        Span::styled(format!("  {marker}{label}"), style),
-                        Span::styled(format!("  \u{2014} {hint}"), theme::out_dim()),
+                        Span::styled(format!("  {marker}{}", auth_mode.title()), style),
+                        Span::styled(format!("  \u{2014} {}", auth_mode.hint()), theme::out_dim()),
                     ]));
                 }
                 lines.push(Line::from(""));
@@ -2943,7 +3019,7 @@ impl ReplApp {
                         if *is_subscription {
                             "subscription"
                         } else {
-                            "key"
+                            "api key"
                         }
                     ),
                     theme::out_dim(),
@@ -3770,10 +3846,24 @@ mod tests {
     }
 
     #[test]
-    fn provider_panel_a_opens_provider_selection() {
+    fn provider_capability_table_exposes_only_api_key_setup() {
+        for kind in [
+            crate::config::ProviderKind::Anthropic,
+            crate::config::ProviderKind::OpenAI,
+            crate::config::ProviderKind::Grok,
+            crate::config::ProviderKind::OpenRouter,
+            crate::config::ProviderKind::MiniMax,
+        ] {
+            assert_eq!(provider_auth_summary(&kind), "api key");
+            assert_eq!(provider_auth_modes(&kind), &[ProviderAuthMode::ApiKey]);
+        }
+    }
+
+    #[test]
+    fn provider_panel_a_starts_setup_for_selected_provider() {
         let (mut app, mut textarea) = make_app();
         app.panel = PanelState::ProviderManager {
-            selected: 0,
+            selected: 1,
             input_mode: None,
             status_msg: None,
         };
@@ -3782,7 +3872,11 @@ mod tests {
         if let PanelState::ProviderManager { input_mode, .. } = &app.panel {
             assert!(matches!(
                 input_mode,
-                Some(PanelInputMode::AddStep1Provider { .. })
+                Some(PanelInputMode::AddStep2Model {
+                    provider: crate::config::ProviderKind::OpenAI,
+                    is_subscription: false,
+                    ..
+                })
             ));
         }
     }
@@ -3805,7 +3899,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_panel_enter_starts_auth_step_for_selected_provider() {
+    fn provider_panel_enter_skips_auth_step_for_api_key_only_provider() {
         let (mut app, mut textarea) = make_app();
         app.panel = PanelState::ProviderManager {
             selected: 1,
@@ -3817,13 +3911,39 @@ mod tests {
         if let PanelState::ProviderManager { input_mode, .. } = &app.panel {
             assert!(matches!(
                 input_mode,
-                Some(PanelInputMode::AddStepAuthType {
+                Some(PanelInputMode::AddStep2Model {
                     provider: crate::config::ProviderKind::OpenAI,
+                    is_subscription: false,
                     ..
                 })
             ));
         } else {
             panic!("panel should remain ProviderManager");
+        }
+    }
+
+    #[test]
+    fn provider_panel_direct_providers_do_not_offer_subscription_setup() {
+        for selected in 0..PROVIDER_KINDS.len() {
+            let (mut app, mut textarea) = make_app();
+            app.panel = PanelState::ProviderManager {
+                selected,
+                input_mode: None,
+                status_msg: None,
+            };
+            let key = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+            app.handle_key(key, &mut textarea);
+            if let PanelState::ProviderManager { input_mode, .. } = &app.panel {
+                assert!(matches!(
+                    input_mode,
+                    Some(PanelInputMode::AddStep2Model {
+                        is_subscription: false,
+                        ..
+                    })
+                ));
+            } else {
+                panic!("panel should remain ProviderManager");
+            }
         }
     }
 
@@ -3851,7 +3971,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_panel_auth_back_navigation_returns_to_provider_selection() {
+    fn provider_panel_auth_back_navigation_returns_to_main_list() {
         let (mut app, mut textarea) = make_app();
         app.panel = PanelState::ProviderManager {
             selected: 0,
@@ -3864,10 +3984,29 @@ mod tests {
         let key = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
         app.handle_key(key, &mut textarea);
         if let PanelState::ProviderManager { input_mode, .. } = &app.panel {
-            assert!(matches!(
-                input_mode,
-                Some(PanelInputMode::AddStep1Provider { selected: 0 })
-            ));
+            assert!(input_mode.is_none());
+        } else {
+            panic!("panel should remain ProviderManager");
+        }
+    }
+
+    #[test]
+    fn provider_panel_model_back_navigation_returns_to_main_list() {
+        let (mut app, mut textarea) = make_app();
+        app.panel = PanelState::ProviderManager {
+            selected: 0,
+            input_mode: Some(PanelInputMode::AddStep2Model {
+                provider: crate::config::ProviderKind::Anthropic,
+                is_subscription: false,
+                selected: 0,
+                manual_input: None,
+            }),
+            status_msg: None,
+        };
+        let key = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
+        app.handle_key(key, &mut textarea);
+        if let PanelState::ProviderManager { input_mode, .. } = &app.panel {
+            assert!(input_mode.is_none());
         } else {
             panic!("panel should remain ProviderManager");
         }

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -305,6 +305,24 @@ fn copy_text_to_clipboard(text: &str) -> Result<(), String> {
     }
 }
 
+fn read_text_from_clipboard() -> Result<String, String> {
+    let output = std::process::Command::new("pbpaste")
+        .output()
+        .map_err(|e| e.to_string())?;
+    if !output.status.success() {
+        return Err(output.status.to_string());
+    }
+    String::from_utf8(output.stdout).map_err(|e| e.to_string())
+}
+
+fn is_clipboard_shortcut(modifiers: KeyModifiers) -> bool {
+    modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::SUPER | KeyModifiers::META)
+}
+
+fn append_single_line_input(buf: &mut String, text: &str) {
+    buf.extend(text.chars().filter(|c| !matches!(c, '\r' | '\n')));
+}
+
 // ---------------------------------------------------------------------------
 // ReplApp
 // ---------------------------------------------------------------------------
@@ -613,6 +631,45 @@ impl ReplApp {
         }
     }
 
+    /// Processes a bracketed paste event.
+    ///
+    /// When a popup input is active, pasted text belongs to that field instead
+    /// of the underlying REPL prompt.
+    pub fn handle_paste(&mut self, text: &str, textarea: &mut TextArea<'_>) {
+        if self.insert_text_into_active_panel_field(text) {
+            return;
+        }
+
+        textarea.insert_str(text);
+        let current = textarea.lines().join("\n");
+        self.update_slash_matches(&current);
+    }
+
+    fn insert_text_into_active_panel_field(&mut self, text: &str) -> bool {
+        let PanelState::ProviderManager { input_mode, .. } = &mut self.panel else {
+            return false;
+        };
+
+        match input_mode {
+            Some(PanelInputMode::AddProvider(buf)) => {
+                append_single_line_input(buf, text);
+                true
+            }
+            Some(PanelInputMode::AddStep2Model {
+                manual_input: Some(manual),
+                ..
+            }) => {
+                append_single_line_input(manual, text);
+                true
+            }
+            Some(PanelInputMode::AddStep3Key { key_buf, .. }) => {
+                append_single_line_input(key_buf, text);
+                true
+            }
+            _ => false,
+        }
+    }
+
     /// Handles mouse events when the terminal delivers them.
     ///
     /// Handles wheel scrolling, block clicks, and app-managed text selection.
@@ -760,7 +817,7 @@ impl ReplApp {
                     KeyCode::Backspace => {
                         buf.pop();
                     }
-                    KeyCode::Char(c) => {
+                    KeyCode::Char(c) if !is_clipboard_shortcut(key_event.modifiers) => {
                         buf.push(c);
                     }
                     _ => {}
@@ -807,7 +864,7 @@ impl ReplApp {
                             KeyCode::Backspace => {
                                 manual.pop();
                             }
-                            KeyCode::Char(c) => {
+                            KeyCode::Char(c) if !is_clipboard_shortcut(key_event.modifiers) => {
                                 manual.push(c);
                             }
                             KeyCode::Enter if !manual.is_empty() => {
@@ -868,6 +925,62 @@ impl ReplApp {
                     KeyCode::Backspace => {
                         key_buf.pop();
                     }
+                    KeyCode::Char('c' | 'C') if is_clipboard_shortcut(key_event.modifiers) => {
+                        if key_buf.is_empty() {
+                            new_status_msg =
+                                Some(("API key field is empty.".to_string(), OutputStyle::Dim));
+                        } else {
+                            match copy_text_to_clipboard(key_buf) {
+                                Ok(()) => {
+                                    new_status_msg = Some((
+                                        "API key copied to clipboard.".to_string(),
+                                        OutputStyle::Success,
+                                    ));
+                                }
+                                Err(e) => {
+                                    new_status_msg = Some((
+                                        format!("Clipboard copy failed: {e}"),
+                                        OutputStyle::Error,
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                    KeyCode::Char('x' | 'X') if is_clipboard_shortcut(key_event.modifiers) => {
+                        if key_buf.is_empty() {
+                            new_status_msg =
+                                Some(("API key field is empty.".to_string(), OutputStyle::Dim));
+                        } else {
+                            match copy_text_to_clipboard(key_buf) {
+                                Ok(()) => {
+                                    key_buf.clear();
+                                    new_status_msg = Some((
+                                        "API key cut to clipboard.".to_string(),
+                                        OutputStyle::Success,
+                                    ));
+                                }
+                                Err(e) => {
+                                    new_status_msg = Some((
+                                        format!("Clipboard cut failed: {e}"),
+                                        OutputStyle::Error,
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                    KeyCode::Char('v' | 'V') if is_clipboard_shortcut(key_event.modifiers) => {
+                        match read_text_from_clipboard() {
+                            Ok(text) => {
+                                append_single_line_input(key_buf, &text);
+                            }
+                            Err(e) => {
+                                new_status_msg = Some((
+                                    format!("Clipboard paste failed: {e}"),
+                                    OutputStyle::Error,
+                                ));
+                            }
+                        }
+                    }
                     KeyCode::Enter if !key_buf.is_empty() => {
                         // Transition to storage-choice confirmation step.
                         input_mode = Some(PanelInputMode::AddStep3Confirm {
@@ -877,7 +990,7 @@ impl ReplApp {
                             is_subscription: *is_subscription,
                         });
                     }
-                    KeyCode::Char(c) => {
+                    KeyCode::Char(c) if !is_clipboard_shortcut(key_event.modifiers) => {
                         key_buf.push(c);
                     }
                     _ => {}
@@ -3944,6 +4057,68 @@ mod tests {
             } else {
                 panic!("panel should remain ProviderManager");
             }
+        }
+    }
+
+    #[test]
+    fn provider_panel_paste_goes_to_api_key_field_not_prompt() {
+        let (mut app, mut textarea) = make_app();
+        app.panel = PanelState::ProviderManager {
+            selected: 4,
+            input_mode: Some(PanelInputMode::AddStep3Key {
+                provider: crate::config::ProviderKind::MiniMax,
+                model: "MiniMax-M2.7".to_string(),
+                key_buf: String::new(),
+                is_subscription: false,
+            }),
+            status_msg: None,
+        };
+
+        app.handle_paste("sk-test-key\n", &mut textarea);
+
+        assert_eq!(textarea.lines(), &[""]);
+        if let PanelState::ProviderManager {
+            input_mode:
+                Some(PanelInputMode::AddStep3Key {
+                    key_buf,
+                    is_subscription,
+                    ..
+                }),
+            ..
+        } = &app.panel
+        {
+            assert_eq!(key_buf, "sk-test-key");
+            assert!(!is_subscription);
+        } else {
+            panic!("panel should remain in API key input mode");
+        }
+    }
+
+    #[test]
+    fn provider_panel_clipboard_shortcut_does_not_type_into_api_key_field() {
+        let (mut app, mut textarea) = make_app();
+        app.panel = PanelState::ProviderManager {
+            selected: 4,
+            input_mode: Some(PanelInputMode::AddStep3Key {
+                provider: crate::config::ProviderKind::MiniMax,
+                model: "MiniMax-M2.7".to_string(),
+                key_buf: String::new(),
+                is_subscription: false,
+            }),
+            status_msg: None,
+        };
+
+        let key = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+        app.handle_key(key, &mut textarea);
+
+        if let PanelState::ProviderManager {
+            input_mode: Some(PanelInputMode::AddStep3Key { key_buf, .. }),
+            ..
+        } = &app.panel
+        {
+            assert!(key_buf.is_empty());
+        } else {
+            panic!("panel should remain in API key input mode");
         }
     }
 

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -323,6 +323,22 @@ fn append_single_line_input(buf: &mut String, text: &str) {
     buf.extend(text.chars().filter(|c| !matches!(c, '\r' | '\n')));
 }
 
+fn masked_secret_preview(char_count: usize, max_width: usize) -> String {
+    if char_count == 0 {
+        return "\u{2588}".to_string();
+    }
+
+    let suffix = format!(" ({char_count} chars)");
+    let suffix_width = suffix.chars().count() + 1; // plus cursor
+    if max_width > suffix_width {
+        let dot_count = char_count.min(max_width - suffix_width).max(1);
+        format!("{}{}{}", ".".repeat(dot_count), suffix, "\u{2588}")
+    } else {
+        let dot_count = char_count.min(max_width.saturating_sub(1)).max(1);
+        format!("{}{}", ".".repeat(dot_count), "\u{2588}")
+    }
+}
+
 // ---------------------------------------------------------------------------
 // ReplApp
 // ---------------------------------------------------------------------------
@@ -3206,10 +3222,15 @@ impl ReplApp {
                     lines.push(Line::from(Span::styled(hint, theme::label_caps())));
                 }
                 lines.push(Line::from(""));
-                let masked = "\u{25cf}".repeat(key_buf.len());
+                let field_label = format!("  {label}: ");
+                let field_width = field_label.chars().count();
+                let masked = masked_secret_preview(
+                    key_buf.chars().count(),
+                    inner_width.saturating_sub(field_width),
+                );
                 lines.push(Line::from(vec![
-                    Span::styled(format!("  {label}: "), theme::out_help_cmd()),
-                    Span::styled(format!("{masked}\u{2588}"), theme::brand_word()),
+                    Span::styled(field_label, theme::out_help_cmd()),
+                    Span::styled(masked, theme::brand_word()),
                 ]));
                 lines.push(Line::from(""));
                 lines.push(Line::from(Span::styled(
@@ -4092,6 +4113,15 @@ mod tests {
         } else {
             panic!("panel should remain in API key input mode");
         }
+    }
+
+    #[test]
+    fn masked_secret_preview_shows_paste_feedback_without_full_secret() {
+        let preview = masked_secret_preview(64, 24);
+        assert!(preview.contains("(64 chars)"));
+        assert!(preview.starts_with('.'));
+        assert!(!preview.contains("sk-"));
+        assert!(preview.chars().count() <= 24);
     }
 
     #[test]

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -31,6 +31,18 @@ const PROVIDER_KINDS: &[(&str, &str)] = &[
     ("minimax", "MiniMax"),
 ];
 
+/// Returns a short provider label for the provider manager.
+fn provider_kind_label(kind: &crate::config::ProviderKind) -> &'static str {
+    use crate::config::ProviderKind;
+    match kind {
+        ProviderKind::Anthropic => "anthropic",
+        ProviderKind::OpenAI => "openai",
+        ProviderKind::Grok => "grok",
+        ProviderKind::OpenRouter => "openrouter",
+        ProviderKind::MiniMax => "minimax",
+    }
+}
+
 /// Returns recommended models for a given provider kind.
 fn recommended_models(kind: &crate::config::ProviderKind) -> Vec<(&'static str, &'static str)> {
     use crate::config::ProviderKind;
@@ -122,6 +134,22 @@ fn parse_provider_kind_by_index(idx: usize) -> Option<crate::config::ProviderKin
         4 => Some(ProviderKind::MiniMax),
         _ => None,
     }
+}
+
+/// Finds the configured provider entry for a provider kind.
+fn configured_provider_index(
+    config: &DuumbiConfig,
+    kind: &crate::config::ProviderKind,
+) -> Option<usize> {
+    config.providers.iter().position(|p| &p.provider == kind)
+}
+
+/// Returns the credential env var that is active for a provider config.
+fn active_credential_env(config: &crate::config::ProviderConfig) -> &str {
+    config
+        .auth_token_env
+        .as_deref()
+        .unwrap_or(&config.api_key_env)
 }
 
 use super::completion::{SLASH_COMMANDS, SLASH_GROUPS, SlashGroup};
@@ -364,8 +392,8 @@ impl ReplApp {
     /// mode toggles, slash-menu navigation, and output buffer updates.
     pub fn handle_key(&mut self, key: KeyEvent, textarea: &mut TextArea<'_>) -> Action {
         // Interactive panel gets priority over normal key handling.
-        if matches!(self.panel, PanelState::ModelSelector { .. }) {
-            return self.handle_model_panel_key(key, textarea);
+        if matches!(self.panel, PanelState::ProviderManager { .. }) {
+            return self.handle_provider_panel_key(key, textarea);
         }
 
         if self.conversation_action_menu.is_some() {
@@ -567,29 +595,79 @@ impl ReplApp {
         Action::Continue
     }
 
-    /// Handles key events when the model selector panel is active.
+    /// Handles key events when the provider manager panel is active.
     ///
     /// Extracts panel state by value, processes the key, then writes back.
-    fn handle_model_panel_key(
+    fn handle_provider_panel_key(
         &mut self,
         key_event: KeyEvent,
         textarea: &mut TextArea<'_>,
     ) -> Action {
-        // Extract current panel state (take ownership to avoid borrow issues).
         let (mut selected, mut input_mode) = match &self.panel {
-            PanelState::ModelSelector {
+            PanelState::ProviderManager {
                 selected,
                 input_mode,
                 ..
             } => (*selected, input_mode.clone()),
             PanelState::None => return Action::Continue,
         };
-        // Status message is cleared on every key press; handlers may set a new one.
         let mut new_status_msg: Option<(String, OutputStyle)> = None;
 
-        // --- Sub-mode input handling ---
         if let Some(ref mut mode) = input_mode {
             match mode {
+                PanelInputMode::ConfirmDelete => match key_event.code {
+                    KeyCode::Char('y') | KeyCode::Char('Y') => {
+                        let Some(kind) = parse_provider_kind_by_index(selected) else {
+                            self.panel = PanelState::ProviderManager {
+                                selected,
+                                input_mode: None,
+                                status_msg: Some((
+                                    "Unknown provider selection.".to_string(),
+                                    OutputStyle::Error,
+                                )),
+                            };
+                            return Action::Continue;
+                        };
+                        let removed = self.remove_provider_connection(&kind);
+                        input_mode = None;
+                        if removed {
+                            self.save_config_and_rebuild_client();
+                            new_status_msg = Some((
+                                format!("{} connection deleted.", provider_kind_label(&kind)),
+                                OutputStyle::Success,
+                            ));
+                        } else {
+                            new_status_msg = Some((
+                                format!("{} is not configured.", provider_kind_label(&kind)),
+                                OutputStyle::Dim,
+                            ));
+                        }
+                    }
+                    _ => {
+                        input_mode = None;
+                    }
+                },
+                PanelInputMode::AddStep1Provider { selected: step_sel } => match key_event.code {
+                    KeyCode::Esc => {
+                        input_mode = None;
+                    }
+                    KeyCode::Up if *step_sel > 0 => {
+                        *step_sel -= 1;
+                    }
+                    KeyCode::Down if *step_sel < PROVIDER_KINDS.len() - 1 => {
+                        *step_sel += 1;
+                    }
+                    KeyCode::Enter => {
+                        if let Some(kind) = parse_provider_kind_by_index(*step_sel) {
+                            selected = *step_sel;
+                            input_mode = Some(PanelInputMode::AddStepAuthType {
+                                provider: kind,
+                                selected: 0,
+                            });
+                        }
+                    }
+                    _ => {}
+                },
                 PanelInputMode::AddProvider(buf) => match key_event.code {
                     KeyCode::Esc => {
                         input_mode = None;
@@ -611,47 +689,29 @@ impl ReplApp {
                     }
                     _ => {}
                 },
-                PanelInputMode::ConfirmDelete => match key_event.code {
-                    KeyCode::Char('y') | KeyCode::Char('Y') => {
-                        let selector = (selected + 1).to_string();
-                        input_mode = None;
-                        let lines = super::provider::remove_provider(&mut self.config, &selector);
-                        for line in lines {
-                            self.output_lines.push(line);
-                        }
-                        self.save_config_and_rebuild_client();
-                        let count = self.config.effective_providers().len();
-                        if selected >= count && count > 0 {
-                            selected = count - 1;
-                        }
-                    }
-                    _ => {
-                        input_mode = None;
-                    }
-                },
-                PanelInputMode::AddStep1Provider { selected: step_sel } => match key_event.code {
+                PanelInputMode::AddStepAuthType {
+                    provider,
+                    selected: auth_sel,
+                } => match key_event.code {
                     KeyCode::Esc => {
-                        input_mode = None;
+                        input_mode = Some(PanelInputMode::AddStep1Provider { selected });
                     }
-                    KeyCode::Up if *step_sel > 0 => {
-                        *step_sel -= 1;
-                    }
-                    KeyCode::Down if *step_sel < PROVIDER_KINDS.len() - 1 => {
-                        *step_sel += 1;
+                    KeyCode::Up | KeyCode::Down => {
+                        *auth_sel = 1 - *auth_sel;
                     }
                     KeyCode::Enter => {
-                        if let Some(kind) = parse_provider_kind_by_index(*step_sel) {
-                            input_mode = Some(PanelInputMode::AddStep2Model {
-                                provider: kind,
-                                selected: 0,
-                                manual_input: None,
-                            });
-                        }
+                        input_mode = Some(PanelInputMode::AddStep2Model {
+                            provider: provider.clone(),
+                            is_subscription: *auth_sel == 1,
+                            selected: 0,
+                            manual_input: None,
+                        });
                     }
                     _ => {}
                 },
                 PanelInputMode::AddStep2Model {
                     provider,
+                    is_subscription,
                     selected: model_sel,
                     manual_input,
                 } => {
@@ -669,10 +729,11 @@ impl ReplApp {
                             }
                             KeyCode::Enter if !manual.is_empty() => {
                                 let model = manual.clone();
-                                input_mode = Some(PanelInputMode::AddStepAuthType {
+                                input_mode = Some(PanelInputMode::AddStep3Key {
                                     provider: provider.clone(),
                                     model,
-                                    selected: 0,
+                                    key_buf: String::new(),
+                                    is_subscription: *is_subscription,
                                 });
                             }
                             _ => {}
@@ -682,7 +743,10 @@ impl ReplApp {
                         let models = recommended_models(provider);
                         match key_event.code {
                             KeyCode::Esc => {
-                                input_mode = Some(PanelInputMode::AddStep1Provider { selected: 0 });
+                                input_mode = Some(PanelInputMode::AddStepAuthType {
+                                    provider: provider.clone(),
+                                    selected: if *is_subscription { 1 } else { 0 },
+                                });
                             }
                             KeyCode::Up if *model_sel > 0 => {
                                 *model_sel -= 1;
@@ -695,10 +759,11 @@ impl ReplApp {
                             }
                             KeyCode::Enter => {
                                 if let Some((model_name, _)) = models.get(*model_sel) {
-                                    input_mode = Some(PanelInputMode::AddStepAuthType {
+                                    input_mode = Some(PanelInputMode::AddStep3Key {
                                         provider: provider.clone(),
                                         model: (*model_name).to_string(),
-                                        selected: 0,
+                                        key_buf: String::new(),
+                                        is_subscription: *is_subscription,
                                     });
                                 }
                             }
@@ -706,32 +771,6 @@ impl ReplApp {
                         }
                     }
                 }
-                PanelInputMode::AddStepAuthType {
-                    provider,
-                    model,
-                    selected: auth_sel,
-                } => match key_event.code {
-                    KeyCode::Esc => {
-                        input_mode = Some(PanelInputMode::AddStep2Model {
-                            provider: provider.clone(),
-                            selected: 0,
-                            manual_input: None,
-                        });
-                    }
-                    KeyCode::Up | KeyCode::Down => {
-                        *auth_sel = 1 - *auth_sel;
-                    }
-                    KeyCode::Enter => {
-                        let is_subscription = *auth_sel == 1;
-                        input_mode = Some(PanelInputMode::AddStep3Key {
-                            provider: provider.clone(),
-                            model: model.clone(),
-                            key_buf: String::new(),
-                            is_subscription,
-                        });
-                    }
-                    _ => {}
-                },
                 PanelInputMode::AddStep3Key {
                     provider,
                     model,
@@ -739,10 +778,11 @@ impl ReplApp {
                     is_subscription,
                 } => match key_event.code {
                     KeyCode::Esc => {
-                        input_mode = Some(PanelInputMode::AddStepAuthType {
+                        input_mode = Some(PanelInputMode::AddStep2Model {
                             provider: provider.clone(),
-                            model: model.clone(),
-                            selected: if *is_subscription { 1 } else { 0 },
+                            is_subscription: *is_subscription,
+                            selected: 0,
+                            manual_input: None,
                         });
                     }
                     KeyCode::Backspace => {
@@ -785,13 +825,9 @@ impl ReplApp {
                                 unsafe {
                                     std::env::set_var(store_env, &key_clone);
                                 }
-                                self.config.providers.push(crate::config::ProviderConfig {
+                                self.upsert_provider_connection(crate::config::ProviderConfig {
                                     provider: prov_clone,
-                                    role: if self.config.providers.is_empty() {
-                                        crate::config::ProviderRole::Primary
-                                    } else {
-                                        crate::config::ProviderRole::Fallback
-                                    },
+                                    role: crate::config::ProviderRole::Primary,
                                     model: model_clone,
                                     api_key_env: api_key_env.clone(),
                                     base_url: None,
@@ -800,11 +836,10 @@ impl ReplApp {
                                     auth_token_env: token_env,
                                 });
                                 self.save_config_and_rebuild_client();
-                                selected = self.config.providers.len() - 1;
                                 let auth_msg = if *is_subscription {
-                                    "Provider added (subscription/Bearer). Token saved to ~/.duumbi/credentials.toml."
+                                    "Provider connection saved (subscription/Bearer token in ~/.duumbi/credentials.toml)."
                                 } else {
-                                    "Provider added. Key saved to ~/.duumbi/credentials.toml."
+                                    "Provider connection saved (API key in ~/.duumbi/credentials.toml)."
                                 };
                                 new_status_msg = Some((auth_msg.to_string(), OutputStyle::Success));
                             }
@@ -814,13 +849,9 @@ impl ReplApp {
                                 unsafe {
                                     std::env::set_var(store_env, &key_clone);
                                 }
-                                self.config.providers.push(crate::config::ProviderConfig {
+                                self.upsert_provider_connection(crate::config::ProviderConfig {
                                     provider: prov_clone,
-                                    role: if self.config.providers.is_empty() {
-                                        crate::config::ProviderRole::Primary
-                                    } else {
-                                        crate::config::ProviderRole::Fallback
-                                    },
+                                    role: crate::config::ProviderRole::Primary,
                                     model: model_clone,
                                     api_key_env,
                                     base_url: None,
@@ -829,7 +860,6 @@ impl ReplApp {
                                     auth_token_env: token_env,
                                 });
                                 self.save_config_and_rebuild_client();
-                                selected = self.config.providers.len() - 1;
                                 new_status_msg = Some((
                                     format!("File storage error: {e}. Token set for session only."),
                                     OutputStyle::Error,
@@ -854,13 +884,9 @@ impl ReplApp {
                         unsafe {
                             std::env::set_var(&store_env_name, &key_clone);
                         }
-                        self.config.providers.push(crate::config::ProviderConfig {
+                        self.upsert_provider_connection(crate::config::ProviderConfig {
                             provider: prov_clone,
-                            role: if self.config.providers.is_empty() {
-                                crate::config::ProviderRole::Primary
-                            } else {
-                                crate::config::ProviderRole::Fallback
-                            },
+                            role: crate::config::ProviderRole::Primary,
                             model: model_clone,
                             api_key_env: api_key_env.clone(),
                             base_url: None,
@@ -869,13 +895,12 @@ impl ReplApp {
                             auth_token_env: token_env,
                         });
                         self.save_config_and_rebuild_client();
-                        selected = self.config.providers.len() - 1;
                         let auth_msg = if *is_subscription {
                             format!(
-                                "Provider added (subscription/Bearer, {store_env_name}, session only)."
+                                "Provider connection saved (subscription/Bearer, {store_env_name}, session only)."
                             )
                         } else {
-                            format!("Provider added ({api_key_env}, session only).")
+                            format!("Provider connection saved ({api_key_env}, session only).")
                         };
                         new_status_msg = Some((auth_msg, OutputStyle::Success));
                         input_mode = None; // back to list view
@@ -892,16 +917,13 @@ impl ReplApp {
                     _ => {}
                 },
             }
-            self.panel = PanelState::ModelSelector {
+            self.panel = PanelState::ProviderManager {
                 selected,
                 input_mode,
                 status_msg: new_status_msg,
             };
             return Action::Continue;
         }
-
-        // --- Main panel key handling (no sub-mode) ---
-        let provider_count = self.config.effective_providers().len();
 
         match key_event.code {
             KeyCode::Esc => {
@@ -912,7 +934,7 @@ impl ReplApp {
             }
             KeyCode::Up => {
                 selected = selected.saturating_sub(1);
-                self.panel = PanelState::ModelSelector {
+                self.panel = PanelState::ProviderManager {
                     selected,
                     input_mode: None,
                     status_msg: None,
@@ -920,10 +942,10 @@ impl ReplApp {
                 Action::Continue
             }
             KeyCode::Down => {
-                if provider_count > 0 && selected < provider_count - 1 {
+                if selected < PROVIDER_KINDS.len().saturating_sub(1) {
                     selected += 1;
                 }
-                self.panel = PanelState::ModelSelector {
+                self.panel = PanelState::ProviderManager {
                     selected,
                     input_mode: None,
                     status_msg: None,
@@ -931,35 +953,33 @@ impl ReplApp {
                 Action::Continue
             }
             KeyCode::Enter => {
-                // Set selected provider as primary, all others as fallback.
-                if provider_count > 0 && selected < self.config.providers.len() {
-                    for (i, p) in self.config.providers.iter_mut().enumerate() {
-                        p.role = if i == selected {
-                            crate::config::ProviderRole::Primary
-                        } else {
-                            crate::config::ProviderRole::Fallback
-                        };
-                    }
-                    let model = self.config.providers[selected].model.clone();
-                    self.push_output(format!("Selected: {model}"), OutputStyle::Success);
-                    self.save_config_and_rebuild_client();
+                if let Some(kind) = parse_provider_kind_by_index(selected) {
+                    input_mode = Some(PanelInputMode::AddStepAuthType {
+                        provider: kind,
+                        selected: 0,
+                    });
                 }
-                self.panel = PanelState::None;
-                textarea.move_cursor(CursorMove::Head);
-                textarea.delete_line_by_end();
+                self.panel = PanelState::ProviderManager {
+                    selected,
+                    input_mode,
+                    status_msg: None,
+                };
                 Action::Continue
             }
             KeyCode::Char('a') | KeyCode::Char('A') => {
-                self.panel = PanelState::ModelSelector {
+                self.panel = PanelState::ProviderManager {
                     selected,
-                    input_mode: Some(PanelInputMode::AddStep1Provider { selected: 0 }),
+                    input_mode: Some(PanelInputMode::AddStep1Provider { selected }),
                     status_msg: None,
                 };
                 Action::Continue
             }
             KeyCode::Char('d') | KeyCode::Char('D') => {
-                if provider_count > 0 {
-                    self.panel = PanelState::ModelSelector {
+                if parse_provider_kind_by_index(selected)
+                    .and_then(|kind| configured_provider_index(&self.config, &kind))
+                    .is_some()
+                {
+                    self.panel = PanelState::ProviderManager {
                         selected,
                         input_mode: Some(PanelInputMode::ConfirmDelete),
                         status_msg: None,
@@ -968,21 +988,118 @@ impl ReplApp {
                 Action::Continue
             }
             KeyCode::Char('t') | KeyCode::Char('T') => {
-                if provider_count > 0 && selected < self.config.providers.len() {
-                    self.config.providers[selected].role =
-                        match self.config.providers[selected].role {
-                            crate::config::ProviderRole::Primary => {
-                                crate::config::ProviderRole::Fallback
-                            }
-                            crate::config::ProviderRole::Fallback => {
-                                crate::config::ProviderRole::Primary
-                            }
-                        };
+                if let Some(kind) = parse_provider_kind_by_index(selected) {
+                    new_status_msg = Some(self.test_provider_connection_config(&kind));
+                }
+                self.panel = PanelState::ProviderManager {
+                    selected,
+                    input_mode: None,
+                    status_msg: new_status_msg,
+                };
+                Action::Continue
+            }
+            KeyCode::Char('p') | KeyCode::Char('P') => {
+                if let Some(kind) = parse_provider_kind_by_index(selected) {
+                    new_status_msg = Some(self.set_provider_priority(&kind));
                     self.save_config_and_rebuild_client();
                 }
+                self.panel = PanelState::ProviderManager {
+                    selected,
+                    input_mode: None,
+                    status_msg: new_status_msg,
+                };
                 Action::Continue
             }
             _ => Action::Continue,
+        }
+    }
+
+    /// Inserts or replaces one provider-kind connection while preserving fallback priority.
+    fn upsert_provider_connection(&mut self, mut provider: crate::config::ProviderConfig) {
+        if let Some(index) = configured_provider_index(&self.config, &provider.provider) {
+            provider.role = self.config.providers[index].role.clone();
+            self.config.providers[index] = provider;
+        } else {
+            provider.role = if self.config.providers.is_empty() {
+                crate::config::ProviderRole::Primary
+            } else {
+                crate::config::ProviderRole::Fallback
+            };
+            self.config.providers.push(provider);
+        }
+    }
+
+    /// Removes a provider connection and its file-stored credential, when present.
+    fn remove_provider_connection(&mut self, kind: &crate::config::ProviderKind) -> bool {
+        let Some(index) = configured_provider_index(&self.config, kind) else {
+            return false;
+        };
+        let removed = self.config.providers.remove(index);
+        if matches!(removed.key_storage, Some(crate::config::KeyStorage::File)) {
+            let _ = super::keystore::delete_api_key(&removed.api_key_env);
+            if let Some(token_env) = removed.auth_token_env {
+                let _ = super::keystore::delete_api_key(&token_env);
+            }
+        }
+        if !self
+            .config
+            .providers
+            .iter()
+            .any(|p| p.role == crate::config::ProviderRole::Primary)
+            && let Some(first) = self.config.providers.first_mut()
+        {
+            first.role = crate::config::ProviderRole::Primary;
+        }
+        true
+    }
+
+    /// Marks a configured provider as the first provider in the fallback chain.
+    fn set_provider_priority(
+        &mut self,
+        kind: &crate::config::ProviderKind,
+    ) -> (String, OutputStyle) {
+        let Some(index) = configured_provider_index(&self.config, kind) else {
+            return (
+                format!("{} is not configured.", provider_kind_label(kind)),
+                OutputStyle::Dim,
+            );
+        };
+        for (i, provider) in self.config.providers.iter_mut().enumerate() {
+            provider.role = if i == index {
+                crate::config::ProviderRole::Primary
+            } else {
+                crate::config::ProviderRole::Fallback
+            };
+        }
+        (
+            format!(
+                "{} is now first in the fallback chain.",
+                provider_kind_label(kind)
+            ),
+            OutputStyle::Success,
+        )
+    }
+
+    /// Performs a local provider config check without making a network call.
+    fn test_provider_connection_config(
+        &self,
+        kind: &crate::config::ProviderKind,
+    ) -> (String, OutputStyle) {
+        let Some(index) = configured_provider_index(&self.config, kind) else {
+            return (
+                format!("{} is not configured.", provider_kind_label(kind)),
+                OutputStyle::Dim,
+            );
+        };
+        match crate::agents::factory::create_provider(&self.config.providers[index]) {
+            Ok(_) => (
+                format!("{} connection config is ready.", provider_kind_label(kind)),
+                OutputStyle::Success,
+            ),
+            Err(e) => (
+                format!("{} connection is not ready: {e}", provider_kind_label(kind)),
+                OutputStyle::Error,
+            ),
         }
     }
 
@@ -1008,12 +1125,17 @@ impl ReplApp {
             .effective_providers()
             .iter()
             .filter(|p| matches!(p.key_storage, Some(crate::config::KeyStorage::File)))
-            .filter_map(|p| {
+            .flat_map(|p| {
+                let mut names = Vec::new();
                 if super::keystore::load_api_key(&p.api_key_env).is_some() {
-                    Some(p.api_key_env.clone())
-                } else {
-                    None
+                    names.push(p.api_key_env.clone());
                 }
+                if let Some(token_env) = &p.auth_token_env
+                    && super::keystore::load_api_key(token_env).is_some()
+                {
+                    names.push(token_env.clone());
+                }
+                names
             })
             .collect()
     }
@@ -1699,7 +1821,7 @@ impl ReplApp {
                     self.render_slash_menu(frame, overlay_area);
                 }
             }
-            PanelState::ModelSelector {
+            PanelState::ProviderManager {
                 selected,
                 input_mode,
                 status_msg,
@@ -1707,8 +1829,14 @@ impl ReplApp {
                 if let Some(overlay_height) = self.overlay_height() {
                     let overlay_width = page.width.saturating_sub(4).clamp(52, 110);
                     let overlay_area =
-                        Self::overlay_rect(page, chunks[6], overlay_width, overlay_height);
-                    self.render_model_panel(frame, overlay_area, *selected, input_mode, status_msg)
+                        Self::centered_overlay_rect(page, overlay_width, overlay_height);
+                    self.render_provider_panel(
+                        frame,
+                        overlay_area,
+                        *selected,
+                        input_mode,
+                        status_msg,
+                    )
                 }
             }
         }
@@ -1744,7 +1872,7 @@ impl ReplApp {
                     })
                 }
             }
-            PanelState::ModelSelector { input_mode, .. } => Some(match input_mode {
+            PanelState::ProviderManager { input_mode, .. } => Some(match input_mode {
                 Some(PanelInputMode::AddStep1Provider { .. }) => (PROVIDER_KINDS.len() as u16) + 4,
                 Some(PanelInputMode::AddStep2Model {
                     provider,
@@ -1762,11 +1890,11 @@ impl ReplApp {
                 Some(PanelInputMode::AddStep3Key { .. }) => 10,
                 Some(PanelInputMode::AddStep3Confirm { .. }) => 5,
                 _ => {
-                    let provider_count = self.config.effective_providers().len().max(1);
+                    let provider_count = PROVIDER_KINDS.len().max(1);
                     let input_line = if input_mode.is_some() { 1 } else { 0 };
                     let status_line = match (&self.panel, input_mode) {
                         (
-                            PanelState::ModelSelector {
+                            PanelState::ProviderManager {
                                 status_msg: Some(_),
                                 ..
                             },
@@ -1802,14 +1930,12 @@ impl ReplApp {
         Some(Rect::new(page.x, y, page.width, height))
     }
 
-    /// Returns an overlay rectangle anchored above the prompt well.
-    fn overlay_rect(page: Rect, anchor: Rect, width: u16, height: u16) -> Rect {
+    /// Returns a centered overlay rectangle inside the page.
+    fn centered_overlay_rect(page: Rect, width: u16, height: u16) -> Rect {
         let width = width.min(page.width).max(1);
         let height = height.min(page.height).max(1);
         let x = page.x + page.width.saturating_sub(width) / 2;
-        let min_y = page.y.saturating_add(1);
-        let preferred_y = anchor.y.saturating_sub(height.saturating_add(1));
-        let y = preferred_y.max(min_y);
+        let y = page.y + page.height.saturating_sub(height) / 2;
         Rect::new(x, y, width, height)
     }
 
@@ -2645,8 +2771,8 @@ impl ReplApp {
         ])
     }
 
-    /// Renders the interactive model/provider selector panel.
-    fn render_model_panel(
+    /// Renders the interactive provider connection manager panel.
+    fn render_provider_panel(
         &self,
         frame: &mut Frame,
         area: Rect,
@@ -2665,63 +2791,61 @@ impl ReplApp {
         let inner = block.inner(area);
         frame.render_widget(block, area);
 
-        let providers = self.config.effective_providers();
         let mut lines: Vec<Line<'_>> = Vec::new();
 
         let inner_width = inner.width as usize;
 
-        // Header
         lines.push(Line::from(vec![
-            Span::styled("  Select Model", theme::brand_word()),
-            Span::raw(" ".repeat(inner_width.saturating_sub(40))),
+            Span::styled("  Provider Connections", theme::brand_word()),
+            Span::raw(" ".repeat(inner_width.saturating_sub(48))),
             Span::styled("(Esc to close)", theme::out_dim()),
         ]));
-
-        // Empty line
         lines.push(Line::from(""));
 
-        // Provider list
-        if providers.is_empty() {
-            lines.push(Line::from(Span::styled(
-                "  No providers configured. Press [A] to add one.",
-                theme::out_dim(),
-            )));
-        } else {
-            for (i, p) in providers.iter().enumerate() {
-                let is_sel = i == selected;
-                let prefix = if is_sel { "  \u{25cf} " } else { "    " };
-                let key_indicator = if std::env::var(&p.api_key_env).is_ok() {
-                    "key (env)"
-                } else if self.keychain_cache.contains(&p.api_key_env) {
-                    "key (file)"
+        for (i, (name, desc)) in PROVIDER_KINDS.iter().enumerate() {
+            let Some(kind) = parse_provider_kind_by_index(i) else {
+                continue;
+            };
+            let is_sel = i == selected;
+            let prefix = if is_sel { "  \u{25cf} " } else { "    " };
+            let status = if let Some(index) = configured_provider_index(&self.config, &kind) {
+                let provider = &self.config.providers[index];
+                let auth = if provider.auth_token_env.is_some() {
+                    "subscription"
                 } else {
-                    "no key"
+                    "key"
                 };
-                let role_str = format!("{:?}", p.role).to_lowercase();
-
-                let text = format!(
-                    "{prefix}{}. {:<12} {:<25} ({:<8})  {}",
-                    i + 1,
-                    format!("{:?}", p.provider).to_lowercase(),
-                    p.model,
-                    role_str,
-                    key_indicator,
-                );
-
-                let style = if is_sel {
-                    theme::slash_selected()
+                let credential_env = active_credential_env(provider);
+                let source = if std::env::var(credential_env).is_ok() {
+                    "env"
+                } else if self.keychain_cache.contains(credential_env) {
+                    "file"
                 } else {
-                    theme::out_dim()
+                    "missing"
                 };
-
-                lines.push(Line::from(Span::styled(text, style)));
-            }
+                let priority = if provider.role == crate::config::ProviderRole::Primary {
+                    "priority"
+                } else {
+                    "fallback"
+                };
+                format!(
+                    "configured  {:<12} {:<8} {:<8} default {}",
+                    auth, source, priority, provider.model
+                )
+            } else {
+                "not configured  key/subscription".to_string()
+            };
+            let text = format!("{prefix}{}. {:<11} {:<34} {}", i + 1, name, desc, status);
+            let style = if is_sel {
+                theme::slash_selected()
+            } else {
+                theme::out_dim()
+            };
+            lines.push(Line::from(Span::styled(text, style)));
         }
 
-        // Empty line
         lines.push(Line::from(""));
 
-        // Footer / input mode — wizard steps replace the footer entirely.
         match input_mode {
             Some(PanelInputMode::AddProvider(buf)) => {
                 lines.push(Line::from(vec![
@@ -2731,16 +2855,18 @@ impl ReplApp {
                 ]));
             }
             Some(PanelInputMode::ConfirmDelete) => {
+                let provider_name = parse_provider_kind_by_index(selected)
+                    .map(|kind| provider_kind_label(&kind))
+                    .unwrap_or("provider");
                 lines.push(Line::from(Span::styled(
-                    format!("  Delete provider #{}? [y/N]", selected + 1),
+                    format!("  Delete {provider_name} connection? [y/N]"),
                     theme::out_error(),
                 )));
             }
             Some(PanelInputMode::AddStep1Provider { selected: step_sel }) => {
-                // Replace entire panel with provider selection.
                 lines.clear();
                 lines.push(Line::from(vec![
-                    Span::styled("  Add Provider", theme::brand_word()),
+                    Span::styled("  Select Provider", theme::brand_word()),
                     Span::raw(" ".repeat(inner_width.saturating_sub(45))),
                     Span::styled("(Esc to cancel)", theme::out_dim()),
                 ]));
@@ -2757,55 +2883,14 @@ impl ReplApp {
                     lines.push(Line::from(Span::styled(text, style)));
                 }
             }
-            Some(PanelInputMode::AddStep2Model {
-                provider,
-                selected: model_sel,
-                manual_input,
-            }) => {
-                lines.clear();
-                lines.push(Line::from(vec![
-                    Span::styled(
-                        format!("  Select Model for {provider}"),
-                        theme::brand_word(),
-                    ),
-                    Span::raw(" ".repeat(inner_width.saturating_sub(55))),
-                    Span::styled("(Esc to go back)", theme::out_dim()),
-                ]));
-                lines.push(Line::from(""));
-                if let Some(manual) = manual_input {
-                    lines.push(Line::from(vec![
-                        Span::styled("  Model: ", theme::out_help_cmd()),
-                        Span::styled(format!("{manual}\u{2588}"), theme::brand_word()),
-                    ]));
-                } else {
-                    let models = recommended_models(provider);
-                    for (i, (name, desc)) in models.iter().enumerate() {
-                        let is_sel = i == *model_sel;
-                        let prefix = if is_sel { "  \u{25cf} " } else { "    " };
-                        let text = format!("{prefix}{}. {:<30} {}", i + 1, name, desc);
-                        let style = if is_sel {
-                            theme::slash_selected()
-                        } else {
-                            theme::out_dim()
-                        };
-                        lines.push(Line::from(Span::styled(text, style)));
-                    }
-                    lines.push(Line::from(""));
-                    lines.push(Line::from(Span::styled(
-                        "  [M] Enter model name manually",
-                        theme::out_dim(),
-                    )));
-                }
-            }
             Some(PanelInputMode::AddStepAuthType {
                 provider,
-                model,
                 selected: auth_sel,
             }) => {
                 lines.clear();
                 lines.push(Line::from(vec![
                     Span::styled(
-                        format!("  Authentication for {provider} ({model})"),
+                        format!("  Authentication for {provider}"),
                         theme::brand_word(),
                     ),
                     Span::raw(" ".repeat(inner_width.saturating_sub(60))),
@@ -2836,6 +2921,58 @@ impl ReplApp {
                     "  [\u{2191}/\u{2193}] Select  [Enter] Continue  [Esc] Back",
                     theme::out_dim(),
                 )));
+            }
+            Some(PanelInputMode::AddStep2Model {
+                provider,
+                is_subscription,
+                selected: model_sel,
+                manual_input,
+            }) => {
+                lines.clear();
+                lines.push(Line::from(vec![
+                    Span::styled(
+                        format!("  Default Model for {provider}"),
+                        theme::brand_word(),
+                    ),
+                    Span::raw(" ".repeat(inner_width.saturating_sub(56))),
+                    Span::styled("(Esc to go back)", theme::out_dim()),
+                ]));
+                lines.push(Line::from(Span::styled(
+                    format!(
+                        "  Auth: {}",
+                        if *is_subscription {
+                            "subscription"
+                        } else {
+                            "key"
+                        }
+                    ),
+                    theme::out_dim(),
+                )));
+                lines.push(Line::from(""));
+                if let Some(manual) = manual_input {
+                    lines.push(Line::from(vec![
+                        Span::styled("  Model: ", theme::out_help_cmd()),
+                        Span::styled(format!("{manual}\u{2588}"), theme::brand_word()),
+                    ]));
+                } else {
+                    let models = recommended_models(provider);
+                    for (i, (name, desc)) in models.iter().enumerate() {
+                        let is_sel = i == *model_sel;
+                        let prefix = if is_sel { "  \u{25cf} " } else { "    " };
+                        let text = format!("{prefix}{}. {:<30} {}", i + 1, name, desc);
+                        let style = if is_sel {
+                            theme::slash_selected()
+                        } else {
+                            theme::out_dim()
+                        };
+                        lines.push(Line::from(Span::styled(text, style)));
+                    }
+                    lines.push(Line::from(""));
+                    lines.push(Line::from(Span::styled(
+                        "  [M] Enter model name manually",
+                        theme::out_dim(),
+                    )));
+                }
             }
             Some(PanelInputMode::AddStep3Key {
                 provider,
@@ -2914,7 +3051,6 @@ impl ReplApp {
                 )));
             }
             None => {
-                // Show status message if present (e.g. "Provider added").
                 if let Some((msg, style)) = status_msg {
                     let s = match style {
                         OutputStyle::Success => theme::out_success(),
@@ -2925,7 +3061,7 @@ impl ReplApp {
                     lines.push(Line::from(""));
                 }
                 lines.push(Line::from(Span::styled(
-                    "  [A] Add  [D] Delete  [T] Toggle role  [Enter] Select primary",
+                    "  [Enter] Configure  [A] Add  [D] Delete  [P] Priority  [T] Test",
                     theme::out_dim(),
                 )));
             }
@@ -3599,9 +3735,9 @@ mod tests {
     }
 
     #[test]
-    fn model_panel_esc_closes_panel() {
+    fn provider_panel_esc_closes_panel() {
         let (mut app, mut textarea) = make_app();
-        app.panel = PanelState::ModelSelector {
+        app.panel = PanelState::ProviderManager {
             selected: 0,
             input_mode: None,
             status_msg: None,
@@ -3613,40 +3749,37 @@ mod tests {
     }
 
     #[test]
-    fn model_panel_up_down_stays_in_bounds() {
+    fn provider_panel_up_down_stays_in_bounds() {
         let (mut app, mut textarea) = make_app();
-        app.panel = PanelState::ModelSelector {
+        app.panel = PanelState::ProviderManager {
             selected: 0,
             input_mode: None,
             status_msg: None,
         };
-        // No providers — Down should not panic or change selected.
         let down = KeyEvent::new(KeyCode::Down, KeyModifiers::NONE);
         app.handle_key(down, &mut textarea);
-        // Still 0 because no providers.
-        if let PanelState::ModelSelector { selected, .. } = &app.panel {
-            assert_eq!(*selected, 0);
+        if let PanelState::ProviderManager { selected, .. } = &app.panel {
+            assert_eq!(*selected, 1);
         }
 
-        // Up from 0 should also stay at 0.
         let up = KeyEvent::new(KeyCode::Up, KeyModifiers::NONE);
         app.handle_key(up, &mut textarea);
-        if let PanelState::ModelSelector { selected, .. } = &app.panel {
+        if let PanelState::ProviderManager { selected, .. } = &app.panel {
             assert_eq!(*selected, 0);
         }
     }
 
     #[test]
-    fn model_panel_a_opens_add_provider_mode() {
+    fn provider_panel_a_opens_provider_selection() {
         let (mut app, mut textarea) = make_app();
-        app.panel = PanelState::ModelSelector {
+        app.panel = PanelState::ProviderManager {
             selected: 0,
             input_mode: None,
             status_msg: None,
         };
         let key = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE);
         app.handle_key(key, &mut textarea);
-        if let PanelState::ModelSelector { input_mode, .. } = &app.panel {
+        if let PanelState::ProviderManager { input_mode, .. } = &app.panel {
             assert!(matches!(
                 input_mode,
                 Some(PanelInputMode::AddStep1Provider { .. })
@@ -3655,20 +3788,88 @@ mod tests {
     }
 
     #[test]
-    fn model_panel_add_provider_esc_cancels() {
+    fn provider_panel_add_provider_esc_cancels() {
         let (mut app, mut textarea) = make_app();
-        app.panel = PanelState::ModelSelector {
+        app.panel = PanelState::ProviderManager {
             selected: 0,
             input_mode: Some(PanelInputMode::AddProvider("partial".to_string())),
             status_msg: None,
         };
         let key = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
         app.handle_key(key, &mut textarea);
-        // input_mode cleared, panel still open
-        if let PanelState::ModelSelector { input_mode, .. } = &app.panel {
+        if let PanelState::ProviderManager { input_mode, .. } = &app.panel {
             assert!(input_mode.is_none());
         } else {
-            panic!("panel should still be ModelSelector after Esc in AddProvider mode");
+            panic!("panel should still be ProviderManager after Esc in AddProvider mode");
+        }
+    }
+
+    #[test]
+    fn provider_panel_enter_starts_auth_step_for_selected_provider() {
+        let (mut app, mut textarea) = make_app();
+        app.panel = PanelState::ProviderManager {
+            selected: 1,
+            input_mode: None,
+            status_msg: None,
+        };
+        let key = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+        app.handle_key(key, &mut textarea);
+        if let PanelState::ProviderManager { input_mode, .. } = &app.panel {
+            assert!(matches!(
+                input_mode,
+                Some(PanelInputMode::AddStepAuthType {
+                    provider: crate::config::ProviderKind::OpenAI,
+                    ..
+                })
+            ));
+        } else {
+            panic!("panel should remain ProviderManager");
+        }
+    }
+
+    #[test]
+    fn provider_panel_delete_removes_configured_connection() {
+        let (mut app, mut textarea) = make_app();
+        app.config.providers.push(crate::config::ProviderConfig {
+            provider: crate::config::ProviderKind::Anthropic,
+            role: crate::config::ProviderRole::Primary,
+            model: "claude-sonnet-4-6".to_string(),
+            api_key_env: "ANTHROPIC_API_KEY".to_string(),
+            base_url: None,
+            timeout_secs: None,
+            key_storage: None,
+            auth_token_env: None,
+        });
+        app.panel = PanelState::ProviderManager {
+            selected: 0,
+            input_mode: Some(PanelInputMode::ConfirmDelete),
+            status_msg: None,
+        };
+        let key = KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE);
+        app.handle_key(key, &mut textarea);
+        assert!(app.config.providers.is_empty());
+    }
+
+    #[test]
+    fn provider_panel_auth_back_navigation_returns_to_provider_selection() {
+        let (mut app, mut textarea) = make_app();
+        app.panel = PanelState::ProviderManager {
+            selected: 0,
+            input_mode: Some(PanelInputMode::AddStepAuthType {
+                provider: crate::config::ProviderKind::Anthropic,
+                selected: 0,
+            }),
+            status_msg: None,
+        };
+        let key = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
+        app.handle_key(key, &mut textarea);
+        if let PanelState::ProviderManager { input_mode, .. } = &app.panel {
+            assert!(matches!(
+                input_mode,
+                Some(PanelInputMode::AddStep1Provider { selected: 0 })
+            ));
+        } else {
+            panic!("panel should remain ProviderManager");
         }
     }
 }

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -15,7 +15,7 @@ use ratatui::widgets::{Block, Clear, Paragraph, Wrap};
 use ratatui_textarea::{CursorMove, TextArea};
 
 use crate::agents::LlmClient;
-use crate::config::DuumbiConfig;
+use crate::config::{DuumbiConfig, ProviderConfigSource};
 use crate::session::SessionManager;
 
 // ---------------------------------------------------------------------------
@@ -358,6 +358,12 @@ pub struct ReplApp {
     pub workspace_root: PathBuf,
     /// Parsed workspace configuration.
     pub config: DuumbiConfig,
+    /// User-level configuration from `~/.duumbi/config.toml`.
+    pub user_config: DuumbiConfig,
+    /// Workspace-level configuration from `<workspace>/.duumbi/config.toml`.
+    pub workspace_config: DuumbiConfig,
+    /// Source layer that provides the active provider settings.
+    pub provider_config_source: ProviderConfigSource,
     /// LLM client, or `None` when no provider is configured.
     pub client: Option<LlmClient>,
     /// Completed conversation turns for context injection.
@@ -420,8 +426,36 @@ impl ReplApp {
 
     /// Creates a new `ReplApp` with the given workspace context.
     #[must_use]
+    #[allow(dead_code)]
     pub fn new(
         config: DuumbiConfig,
+        workspace_root: PathBuf,
+        client: Option<LlmClient>,
+        session_mgr: Option<SessionManager>,
+        has_workspace: bool,
+        show_tip: bool,
+    ) -> Self {
+        Self::new_with_config_layers(
+            config.clone(),
+            DuumbiConfig::default(),
+            config,
+            ProviderConfigSource::Workspace,
+            workspace_root,
+            client,
+            session_mgr,
+            has_workspace,
+            show_tip,
+        )
+    }
+
+    /// Creates a new `ReplApp` with explicit config layer metadata.
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_config_layers(
+        config: DuumbiConfig,
+        user_config: DuumbiConfig,
+        workspace_config: DuumbiConfig,
+        provider_config_source: ProviderConfigSource,
         workspace_root: PathBuf,
         client: Option<LlmClient>,
         session_mgr: Option<SessionManager>,
@@ -434,6 +468,9 @@ impl ReplApp {
             focused_intent: None,
             workspace_root,
             config,
+            user_config,
+            workspace_config,
+            provider_config_source,
             client,
             history: Vec::new(),
             session_mgr,
@@ -1224,41 +1261,40 @@ impl ReplApp {
     }
 
     /// Inserts or replaces one provider-kind connection while preserving fallback priority.
-    fn upsert_provider_connection(&mut self, mut provider: crate::config::ProviderConfig) {
-        if let Some(index) = configured_provider_index(&self.config, &provider.provider) {
-            provider.role = self.config.providers[index].role.clone();
-            self.config.providers[index] = provider;
-        } else {
-            provider.role = if self.config.providers.is_empty() {
-                crate::config::ProviderRole::Primary
+    fn upsert_provider_connection(&mut self, provider: crate::config::ProviderConfig) {
+        let target =
+            if configured_provider_index(&self.workspace_config, &provider.provider).is_some() {
+                &mut self.workspace_config
             } else {
-                crate::config::ProviderRole::Fallback
+                &mut self.user_config
             };
-            self.config.providers.push(provider);
-        }
+        Self::upsert_provider_in_config(target, provider);
+        self.refresh_effective_config();
     }
 
     /// Removes a provider connection and its file-stored credential, when present.
     fn remove_provider_connection(&mut self, kind: &crate::config::ProviderKind) -> bool {
-        let Some(index) = configured_provider_index(&self.config, kind) else {
+        let removed = if let Some(index) = configured_provider_index(&self.workspace_config, kind) {
+            Some(self.workspace_config.providers.remove(index))
+        } else if let Some(index) = configured_provider_index(&self.user_config, kind) {
+            Some(self.user_config.providers.remove(index))
+        } else if let Some(index) = configured_provider_index(&self.config, kind) {
+            Some(self.config.providers.remove(index))
+        } else {
+            None
+        };
+        let Some(removed) = removed else {
             return false;
         };
-        let removed = self.config.providers.remove(index);
         if matches!(removed.key_storage, Some(crate::config::KeyStorage::File)) {
             let _ = super::keystore::delete_api_key(&removed.api_key_env);
             if let Some(token_env) = removed.auth_token_env {
                 let _ = super::keystore::delete_api_key(&token_env);
             }
         }
-        if !self
-            .config
-            .providers
-            .iter()
-            .any(|p| p.role == crate::config::ProviderRole::Primary)
-            && let Some(first) = self.config.providers.first_mut()
-        {
-            first.role = crate::config::ProviderRole::Primary;
-        }
+        Self::ensure_primary_provider(&mut self.workspace_config);
+        Self::ensure_primary_provider(&mut self.user_config);
+        self.refresh_effective_config();
         true
     }
 
@@ -1273,13 +1309,19 @@ impl ReplApp {
                 OutputStyle::Dim,
             );
         };
-        for (i, provider) in self.config.providers.iter_mut().enumerate() {
+        let target = if configured_provider_index(&self.workspace_config, kind).is_some() {
+            &mut self.workspace_config
+        } else {
+            &mut self.user_config
+        };
+        for (i, provider) in target.providers.iter_mut().enumerate() {
             provider.role = if i == index {
                 crate::config::ProviderRole::Primary
             } else {
                 crate::config::ProviderRole::Fallback
             };
         }
+        self.refresh_effective_config();
         (
             format!(
                 "{} is now first in the fallback chain.",
@@ -1314,9 +1356,11 @@ impl ReplApp {
 
     /// Persists the current config to disk and rebuilds the LLM client.
     pub fn save_config_and_rebuild_client(&mut self) {
-        if self.has_workspace {
-            let _ = crate::config::save_config(&self.workspace_root, &self.config);
+        let _ = crate::config::save_user_config(&self.user_config);
+        if self.has_workspace && self.workspace_root.join(".duumbi/config.toml").exists() {
+            let _ = crate::config::save_config(&self.workspace_root, &self.workspace_config);
         }
+        self.refresh_effective_config();
         let providers = self.config.effective_providers();
         self.client = if providers.is_empty() {
             None
@@ -1324,6 +1368,59 @@ impl ReplApp {
             crate::agents::factory::create_provider_chain(&providers).ok()
         };
         self.keychain_cache = Self::build_keychain_cache(&self.config);
+    }
+
+    fn upsert_provider_in_config(
+        config: &mut DuumbiConfig,
+        mut provider: crate::config::ProviderConfig,
+    ) {
+        if let Some(index) = configured_provider_index(config, &provider.provider) {
+            provider.role = config.providers[index].role.clone();
+            config.providers[index] = provider;
+        } else {
+            provider.role = if config.providers.is_empty() {
+                crate::config::ProviderRole::Primary
+            } else {
+                crate::config::ProviderRole::Fallback
+            };
+            config.providers.push(provider);
+        }
+    }
+
+    fn ensure_primary_provider(config: &mut DuumbiConfig) {
+        if !config
+            .providers
+            .iter()
+            .any(|p| p.role == crate::config::ProviderRole::Primary)
+            && let Some(first) = config.providers.first_mut()
+        {
+            first.role = crate::config::ProviderRole::Primary;
+        }
+    }
+
+    fn refresh_effective_config(&mut self) {
+        let effective = crate::config::merge_config_layers(
+            DuumbiConfig::default(),
+            self.user_config.clone(),
+            self.workspace_config.clone(),
+        );
+        self.config = effective.config;
+        self.provider_config_source = effective.provider_source;
+    }
+
+    fn provider_config_source_label(&self, kind: &crate::config::ProviderKind) -> &'static str {
+        if configured_provider_index(&self.workspace_config, kind).is_some() {
+            "workspace"
+        } else if configured_provider_index(&self.user_config, kind).is_some() {
+            "user"
+        } else {
+            match self.provider_config_source {
+                ProviderConfigSource::LegacyWorkspace => "workspace",
+                ProviderConfigSource::LegacyUser => "user",
+                ProviderConfigSource::System | ProviderConfigSource::LegacySystem => "system",
+                _ => "missing",
+            }
+        }
     }
 
     /// Reads `~/.duumbi/credentials.toml` once to build a cache of which env
@@ -2113,7 +2210,7 @@ impl ReplApp {
                         ) => 2,
                         _ => 0,
                     };
-                    (provider_count as u16) + 6 + input_line + status_line
+                    (provider_count as u16) + 7 + input_line + status_line
                 }
             }),
         }
@@ -3039,12 +3136,13 @@ impl ReplApp {
                 } else {
                     "fallback"
                 };
+                let config_source = self.provider_config_source_label(&kind);
                 format!(
-                    "configured  {:<12} {:<8} {:<8} default {}",
-                    auth, source, priority, provider.model
+                    "configured  {:<9} {:<12} {:<8} {:<8} default {}",
+                    config_source, auth, source, priority, provider.model
                 )
             } else {
-                format!("not configured  {}", provider_auth_summary(&kind))
+                format!("not configured  missing  {}", provider_auth_summary(&kind))
             };
             let text = format!("{prefix}{}. {:<11} {:<34} {}", i + 1, name, desc, status);
             let style = if is_sel {
@@ -3056,6 +3154,10 @@ impl ReplApp {
         }
 
         lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "  Providers are saved to ~/.duumbi/config.toml",
+            theme::out_dim(),
+        )));
 
         match input_mode {
             Some(PanelInputMode::AddProvider(buf)) => {
@@ -4079,6 +4181,70 @@ mod tests {
                 panic!("panel should remain ProviderManager");
             }
         }
+    }
+
+    #[test]
+    fn provider_panel_upsert_without_workspace_targets_user_config() {
+        let (mut app, _) = make_app();
+        app.has_workspace = false;
+
+        app.upsert_provider_connection(crate::config::ProviderConfig {
+            provider: crate::config::ProviderKind::MiniMax,
+            role: crate::config::ProviderRole::Primary,
+            model: "MiniMax-M2.7".to_string(),
+            api_key_env: "MINIMAX_API_KEY".to_string(),
+            base_url: None,
+            timeout_secs: None,
+            key_storage: None,
+            auth_token_env: None,
+        });
+
+        assert!(
+            configured_provider_index(&app.user_config, &crate::config::ProviderKind::MiniMax)
+                .is_some()
+        );
+        assert!(
+            configured_provider_index(&app.config, &crate::config::ProviderKind::MiniMax).is_some()
+        );
+        assert_eq!(app.provider_config_source, ProviderConfigSource::User);
+    }
+
+    #[test]
+    fn provider_panel_workspace_provider_overrides_user_provider() {
+        let (mut app, _) = make_app();
+        app.user_config
+            .providers
+            .push(crate::config::ProviderConfig {
+                provider: crate::config::ProviderKind::OpenAI,
+                role: crate::config::ProviderRole::Primary,
+                model: "gpt-4o-mini".to_string(),
+                api_key_env: "OPENAI_API_KEY".to_string(),
+                base_url: None,
+                timeout_secs: None,
+                key_storage: None,
+                auth_token_env: None,
+            });
+        app.workspace_config
+            .providers
+            .push(crate::config::ProviderConfig {
+                provider: crate::config::ProviderKind::OpenAI,
+                role: crate::config::ProviderRole::Primary,
+                model: "gpt-4o".to_string(),
+                api_key_env: "OPENAI_API_KEY".to_string(),
+                base_url: None,
+                timeout_secs: None,
+                key_storage: None,
+                auth_token_env: None,
+            });
+
+        app.refresh_effective_config();
+
+        assert_eq!(app.provider_config_source, ProviderConfigSource::Workspace);
+        assert_eq!(app.config.providers[0].model, "gpt-4o");
+        assert_eq!(
+            app.provider_config_source_label(&crate::config::ProviderKind::OpenAI),
+            "workspace"
+        );
     }
 
     #[test]

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -248,8 +248,8 @@ pub const SLASH_COMMANDS: &[SlashCommand] = &[
         group: SlashGroup::WorkspaceConfig,
     },
     SlashCommand {
-        command: "/model",
-        description: "Manage LLM providers and models",
+        command: "/provider",
+        description: "Manage LLM provider connections",
         group: SlashGroup::WorkspaceConfig,
     },
     SlashCommand {
@@ -333,5 +333,15 @@ mod tests {
                 .iter()
                 .any(|entry| entry.command == "/intent unfocus")
         );
+    }
+
+    #[test]
+    fn provider_command_replaces_model_in_completion() {
+        assert!(
+            SLASH_COMMANDS
+                .iter()
+                .any(|entry| entry.command == "/provider")
+        );
+        assert!(!SLASH_COMMANDS.iter().any(|entry| entry.command == "/model"));
     }
 }

--- a/src/cli/mode.rs
+++ b/src/cli/mode.rs
@@ -171,18 +171,16 @@ pub enum Action {
 // Interactive panel state
 // ---------------------------------------------------------------------------
 
-/// Active interactive panel rendered below the prompt.
-// ModelSelector is constructed by the /model slash command handler in repl.rs
-// and by tests; the variant is intentionally used only when the panel is opened.
+/// Active interactive panel rendered above the REPL.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Default)]
 pub enum PanelState {
     /// No panel open — normal REPL mode.
     #[default]
     None,
-    /// Model/provider selector panel.
-    ModelSelector {
-        /// Index of highlighted provider (0-based).
+    /// Provider connection manager panel.
+    ProviderManager {
+        /// Index of highlighted provider kind (0-based).
         selected: usize,
         /// Sub-mode for inline input within the panel.
         input_mode: Option<PanelInputMode>,
@@ -202,25 +200,25 @@ pub enum PanelInputMode {
         /// Index of the highlighted provider kind.
         selected: usize,
     },
-    /// Step 2: Selecting a model for the chosen provider.
+    /// Step 2: Choose authentication type (API Key vs Subscription Token).
+    AddStepAuthType {
+        /// The provider kind chosen in step 1.
+        provider: crate::config::ProviderKind,
+        /// 0 = API Key, 1 = Subscription Token (Bearer).
+        selected: usize,
+    },
+    /// Step 3: Selecting a default model for the chosen provider.
     AddStep2Model {
         /// The provider kind chosen in step 1.
         provider: crate::config::ProviderKind,
+        /// If true, the key is a subscription/Bearer token.
+        is_subscription: bool,
         /// Index of highlighted model in the recommendations list.
         selected: usize,
         /// When `Some`, the user is typing a manual model name.
         manual_input: Option<String>,
     },
-    /// Step 2.5: Choose authentication type (API Key vs Subscription Token).
-    AddStepAuthType {
-        /// The provider kind chosen in step 1.
-        provider: crate::config::ProviderKind,
-        /// The model chosen in step 2.
-        model: String,
-        /// 0 = API Key, 1 = Subscription Token (Bearer).
-        selected: usize,
-    },
-    /// Step 3: Entering the API key or subscription token (characters are masked).
+    /// Step 4: Entering the API key or subscription token (characters are masked).
     AddStep3Key {
         /// The provider kind chosen in step 1.
         provider: crate::config::ProviderKind,
@@ -231,7 +229,7 @@ pub enum PanelInputMode {
         /// If true, the key is a subscription/Bearer token.
         is_subscription: bool,
     },
-    /// Step 3 confirmation: choose keychain vs session-only storage.
+    /// Step 5 confirmation: choose keychain vs session-only storage.
     AddStep3Confirm {
         /// The provider kind chosen in step 1.
         provider: crate::config::ProviderKind,

--- a/src/cli/mode.rs
+++ b/src/cli/mode.rs
@@ -218,18 +218,7 @@ pub enum PanelInputMode {
         /// When `Some`, the user is typing a manual model name.
         manual_input: Option<String>,
     },
-    /// Step 4: Choose whether to use an environment variable or enter a key.
-    AddStepCredentialSource {
-        /// The provider kind chosen in step 1.
-        provider: crate::config::ProviderKind,
-        /// The model chosen in step 2.
-        model: String,
-        /// If true, the key is a subscription/Bearer token.
-        is_subscription: bool,
-        /// 0 = environment variable, 1 = entered key stored in credentials.
-        selected: usize,
-    },
-    /// Step 5: Entering the API key or subscription token (characters are masked).
+    /// Step 4: Entering the API key or subscription token (characters are masked).
     AddStep3Key {
         /// The provider kind chosen in step 1.
         provider: crate::config::ProviderKind,

--- a/src/cli/mode.rs
+++ b/src/cli/mode.rs
@@ -165,6 +165,17 @@ pub enum Action {
     Exit,
     /// Submit the given input for processing.
     Submit(String),
+    /// Test and save an API key submitted from the provider manager.
+    ProviderKeySubmitted {
+        /// Provider kind being configured.
+        provider: crate::config::ProviderKind,
+        /// Default model selected for this provider.
+        model: String,
+        /// Raw API key or token to test.
+        key: String,
+        /// If true, the key is a subscription/Bearer token.
+        is_subscription: bool,
+    },
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli/mode.rs
+++ b/src/cli/mode.rs
@@ -204,13 +204,6 @@ pub enum PanelState {
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub enum PanelInputMode {
-    /// Legacy: single-line text input for adding a provider.
-    AddProvider(String),
-    /// Step 1: Selecting provider type from a list.
-    AddStep1Provider {
-        /// Index of the highlighted provider kind.
-        selected: usize,
-    },
     /// Step 2: Choose authentication type (API Key vs Subscription Token).
     AddStepAuthType {
         /// The provider kind chosen in step 1.

--- a/src/cli/mode.rs
+++ b/src/cli/mode.rs
@@ -218,7 +218,18 @@ pub enum PanelInputMode {
         /// When `Some`, the user is typing a manual model name.
         manual_input: Option<String>,
     },
-    /// Step 4: Entering the API key or subscription token (characters are masked).
+    /// Step 4: Choose whether to use an environment variable or enter a key.
+    AddStepCredentialSource {
+        /// The provider kind chosen in step 1.
+        provider: crate::config::ProviderKind,
+        /// The model chosen in step 2.
+        model: String,
+        /// If true, the key is a subscription/Bearer token.
+        is_subscription: bool,
+        /// 0 = environment variable, 1 = entered key stored in credentials.
+        selected: usize,
+    },
+    /// Step 5: Entering the API key or subscription token (characters are masked).
     AddStep3Key {
         /// The provider kind chosen in step 1.
         provider: crate::config::ProviderKind,
@@ -226,17 +237,6 @@ pub enum PanelInputMode {
         model: String,
         /// Raw key text (shown masked in UI).
         key_buf: String,
-        /// If true, the key is a subscription/Bearer token.
-        is_subscription: bool,
-    },
-    /// Step 5 confirmation: choose keychain vs session-only storage.
-    AddStep3Confirm {
-        /// The provider kind chosen in step 1.
-        provider: crate::config::ProviderKind,
-        /// The model chosen in step 2.
-        model: String,
-        /// The API key or token entered in step 3.
-        key: String,
         /// If true, the key is a subscription/Bearer token.
         is_subscription: bool,
     },

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -16,7 +16,7 @@ use crossterm::execute;
 use ratatui_textarea::TextArea;
 
 use crate::agents::{LlmClient, orchestrator};
-use crate::config::DuumbiConfig;
+use crate::config::{DuumbiConfig, EffectiveConfig};
 use crate::intent;
 use crate::session::SessionManager;
 use crate::snapshot;
@@ -36,7 +36,8 @@ const DISABLE_ALL_MOUSE_REPORTING: &str = "\x1b[?1006l\x1b[?1015l\x1b[?1003l\x1b
 ///
 /// Initialises a ratatui terminal, creates [`ReplApp`] with all workspace
 /// state, and drives the event loop. On exit the session is archived.
-pub async fn run(workspace_root: PathBuf, config: DuumbiConfig) -> Result<()> {
+pub async fn run(workspace_root: PathBuf, effective_config: EffectiveConfig) -> Result<()> {
+    let config = effective_config.config.clone();
     let client = build_client(&config);
     let has_workspace = workspace_root.join(".duumbi").exists();
 
@@ -69,8 +70,11 @@ pub async fn run(workspace_root: PathBuf, config: DuumbiConfig) -> Result<()> {
         }
     };
 
-    let mut app = ReplApp::new(
+    let mut app = ReplApp::new_with_config_layers(
         config,
+        effective_config.user_config,
+        effective_config.workspace_config,
+        effective_config.provider_source,
         workspace_root,
         client,
         session_mgr,
@@ -422,8 +426,11 @@ async fn handle_slash(
                 match init_result {
                     Ok(()) => {
                         app.has_workspace = true;
-                        app.config =
-                            crate::config::load_config(&app.workspace_root).unwrap_or_default();
+                        let effective = crate::config::load_effective_config(&app.workspace_root);
+                        app.config = effective.config;
+                        app.user_config = effective.user_config;
+                        app.workspace_config = effective.workspace_config;
+                        app.provider_config_source = effective.provider_source;
                         app.client = build_client(&app.config);
                         app.session_mgr = SessionManager::load_or_create(&app.workspace_root).ok();
                         app.show_tip = true;

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -155,6 +155,40 @@ async fn event_loop(
                         app.working = false;
                         should_redraw = true;
                     }
+                    super::mode::Action::ProviderKeySubmitted {
+                        provider,
+                        model,
+                        key,
+                        is_subscription,
+                    } => {
+                        terminal.draw(|frame| app.render(frame, textarea))?;
+                        last_draw = Instant::now();
+
+                        match app
+                            .probe_provider_key(
+                                provider.clone(),
+                                model.clone(),
+                                key.clone(),
+                                is_subscription,
+                            )
+                            .await
+                        {
+                            Ok(()) => {
+                                if let Err(e) = app.save_tested_provider_key(
+                                    provider,
+                                    model,
+                                    key,
+                                    is_subscription,
+                                ) {
+                                    app.provider_key_test_failed(format!(
+                                        "Credential save failed: {e}"
+                                    ));
+                                }
+                            }
+                            Err(e) => app.provider_key_test_failed(e),
+                        }
+                        should_redraw = true;
+                    }
                 },
                 Event::Paste(text) => {
                     app.handle_paste(&text, textarea);

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -153,7 +153,7 @@ async fn event_loop(
                     }
                 },
                 Event::Paste(text) => {
-                    textarea.insert_str(&text);
+                    app.handle_paste(&text, textarea);
                     should_redraw = true;
                 }
                 Event::Mouse(mouse) => {

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -320,17 +320,14 @@ async fn handle_slash(
         }
 
         "/model" => {
-            // Open the interactive model selector panel with the primary provider selected.
-            let primary_idx = app
-                .config
-                .effective_providers()
-                .iter()
-                .position(|p| p.role == crate::config::ProviderRole::Primary)
-                .unwrap_or(0);
-            app.panel = super::mode::PanelState::ModelSelector {
-                selected: primary_idx,
+            app.push_output("Use /provider to manage LLM connections.", OutputStyle::Dim);
+            app.panel = super::mode::PanelState::ProviderManager {
+                selected: 0,
                 input_mode: None,
-                status_msg: None,
+                status_msg: Some((
+                    "/model is a compatibility alias for /provider.".to_string(),
+                    OutputStyle::Dim,
+                )),
             };
             textarea.move_cursor(ratatui_textarea::CursorMove::Head);
             textarea.delete_line_by_end();
@@ -440,11 +437,13 @@ async fn handle_slash(
         }
 
         "/provider" => {
-            app.push_output("The /provider command has been removed.", OutputStyle::Dim);
-            app.push_output(
-                "Use /model for interactive provider management, or `duumbi provider` from the CLI.",
-                OutputStyle::Dim,
-            );
+            app.panel = super::mode::PanelState::ProviderManager {
+                selected: 0,
+                input_mode: None,
+                status_msg: None,
+            };
+            textarea.move_cursor(ratatui_textarea::CursorMove::Head);
+            textarea.delete_line_by_end();
         }
 
         "/help" => {
@@ -1590,6 +1589,16 @@ fn build_client(config: &DuumbiConfig) -> Option<LlmClient> {
             // SAFETY: single-threaded CLI — no concurrent env access.
             unsafe {
                 std::env::set_var(&p.api_key_env, &key);
+            }
+        }
+        if let Some(token_env) = &p.auth_token_env
+            && matches!(p.key_storage, Some(crate::config::KeyStorage::File))
+            && std::env::var(token_env).is_err()
+            && let Some(token) = super::keystore::load_api_key(token_env)
+        {
+            // SAFETY: single-threaded CLI — no concurrent env access.
+            unsafe {
+                std::env::set_var(token_env, &token);
             }
         }
     }

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -72,6 +72,7 @@ pub async fn run(workspace_root: PathBuf, effective_config: EffectiveConfig) -> 
 
     let mut app = ReplApp::new_with_config_layers(
         config,
+        effective_config.system_config,
         effective_config.user_config,
         effective_config.workspace_config,
         effective_config.provider_source,
@@ -460,15 +461,26 @@ async fn handle_slash(
                 match init_result {
                     Ok(()) => {
                         app.has_workspace = true;
-                        let effective = crate::config::load_effective_config(&app.workspace_root);
-                        app.config = effective.config;
-                        app.user_config = effective.user_config;
-                        app.workspace_config = effective.workspace_config;
-                        app.provider_config_source = effective.provider_source;
-                        app.client = build_client(&app.config);
-                        app.session_mgr = SessionManager::load_or_create(&app.workspace_root).ok();
-                        app.show_tip = true;
-                        app.push_output("Workspace initialised.", OutputStyle::Success);
+                        match crate::config::load_effective_config(&app.workspace_root) {
+                            Ok(effective) => {
+                                app.config = effective.config;
+                                app.system_config = effective.system_config;
+                                app.user_config = effective.user_config;
+                                app.workspace_config = effective.workspace_config;
+                                app.provider_config_source = effective.provider_source;
+                                app.client = build_client(&app.config);
+                                app.session_mgr =
+                                    SessionManager::load_or_create(&app.workspace_root).ok();
+                                app.show_tip = true;
+                                app.push_output("Workspace initialised.", OutputStyle::Success);
+                            }
+                            Err(e) => {
+                                app.push_output(
+                                    format!("Workspace initialised, but config reload failed: {e}"),
+                                    OutputStyle::Error,
+                                );
+                            }
+                        }
                     }
                     Err(e) => {
                         app.push_output(format!("Init failed: {e:#}"), OutputStyle::Error);

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@
 
 use std::fmt;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -485,23 +485,155 @@ impl DuumbiConfig {
     }
 }
 
+/// Source layer that provides the active provider configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderConfigSource {
+    /// No provider or legacy LLM configuration exists in any loaded layer.
+    None,
+    /// Providers came from `/etc/duumbi/config.toml`.
+    System,
+    /// Providers came from `~/.duumbi/config.toml`.
+    User,
+    /// Providers came from `<workspace>/.duumbi/config.toml`.
+    Workspace,
+    /// Legacy `[llm]` came from `/etc/duumbi/config.toml`.
+    LegacySystem,
+    /// Legacy `[llm]` came from `~/.duumbi/config.toml`.
+    LegacyUser,
+    /// Legacy `[llm]` came from `<workspace>/.duumbi/config.toml`.
+    LegacyWorkspace,
+}
+
+/// Configuration assembled from system, user, and workspace layers.
+#[derive(Debug, Clone)]
+pub struct EffectiveConfig {
+    /// Merged config used by runtime clients.
+    pub config: DuumbiConfig,
+    /// User-level config loaded from `~/.duumbi/config.toml`, or default.
+    pub user_config: DuumbiConfig,
+    /// Workspace config loaded from `<workspace>/.duumbi/config.toml`, or default.
+    pub workspace_config: DuumbiConfig,
+    /// Layer that supplied the active provider settings.
+    pub provider_source: ProviderConfigSource,
+}
+
+/// Returns the user-level config path, `~/.duumbi/config.toml`.
+#[must_use]
+pub fn user_config_path() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    PathBuf::from(home).join(".duumbi").join("config.toml")
+}
+
+/// Loads `~/.duumbi/config.toml`.
+pub fn load_user_config() -> Result<DuumbiConfig, ConfigError> {
+    load_config_file(&user_config_path())
+}
+
+/// Saves `~/.duumbi/config.toml`, creating `~/.duumbi/` if needed.
+#[must_use = "save errors should be handled"]
+pub fn save_user_config(config: &DuumbiConfig) -> Result<(), ConfigError> {
+    save_config_file(&user_config_path(), config)
+}
+
+/// Loads system, user, and workspace config layers and returns the effective runtime config.
+pub fn load_effective_config(workspace_root: &Path) -> EffectiveConfig {
+    let system_config = load_config_file(Path::new("/etc/duumbi/config.toml")).unwrap_or_default();
+    let user_config = load_user_config().unwrap_or_default();
+    let workspace_config = load_config(workspace_root).unwrap_or_default();
+
+    merge_config_layers(system_config, user_config, workspace_config)
+}
+
+/// Merges system, user, and workspace config layers into one runtime config.
+pub fn merge_config_layers(
+    system_config: DuumbiConfig,
+    user_config: DuumbiConfig,
+    workspace_config: DuumbiConfig,
+) -> EffectiveConfig {
+    let mut config = system_config.clone();
+    merge_non_provider_fields(&mut config, &user_config);
+    merge_non_provider_fields(&mut config, &workspace_config);
+
+    let provider_source = if !workspace_config.providers.is_empty() {
+        config.providers = workspace_config.providers.clone();
+        config.llm = workspace_config.llm.clone();
+        ProviderConfigSource::Workspace
+    } else if !user_config.providers.is_empty() {
+        config.providers = user_config.providers.clone();
+        config.llm = user_config.llm.clone();
+        ProviderConfigSource::User
+    } else if !system_config.providers.is_empty() {
+        config.providers = system_config.providers.clone();
+        config.llm = system_config.llm.clone();
+        ProviderConfigSource::System
+    } else if workspace_config.llm.is_some() {
+        config.providers.clear();
+        config.llm = workspace_config.llm.clone();
+        ProviderConfigSource::LegacyWorkspace
+    } else if user_config.llm.is_some() {
+        config.providers.clear();
+        config.llm = user_config.llm.clone();
+        ProviderConfigSource::LegacyUser
+    } else if system_config.llm.is_some() {
+        config.providers.clear();
+        config.llm = system_config.llm.clone();
+        ProviderConfigSource::LegacySystem
+    } else {
+        config.providers.clear();
+        config.llm = None;
+        ProviderConfigSource::None
+    };
+
+    EffectiveConfig {
+        config,
+        user_config,
+        workspace_config,
+        provider_source,
+    }
+}
+
+fn merge_non_provider_fields(base: &mut DuumbiConfig, overlay: &DuumbiConfig) {
+    if overlay.workspace.is_some() {
+        base.workspace = overlay.workspace.clone();
+    }
+    if !overlay.mcp_clients.is_empty() {
+        base.mcp_clients = overlay.mcp_clients.clone();
+    }
+    if !overlay.registries.is_empty() {
+        base.registries = overlay.registries.clone();
+    }
+    if !overlay.dependencies.is_empty() {
+        base.dependencies = overlay.dependencies.clone();
+    }
+    if overlay.vendor.is_some() {
+        base.vendor = overlay.vendor.clone();
+    }
+    if overlay.cost.is_some() {
+        base.cost = overlay.cost.clone();
+    }
+}
+
 /// Saves a [`DuumbiConfig`] to `<workspace_root>/.duumbi/config.toml`.
 ///
 /// Creates the `.duumbi/` directory if it does not exist.
 /// Overwrites any existing `config.toml`.
 #[must_use = "save errors should be handled"]
 pub fn save_config(workspace_root: &Path, config: &DuumbiConfig) -> Result<(), ConfigError> {
-    let duumbi_dir = workspace_root.join(".duumbi");
-    fs::create_dir_all(&duumbi_dir).map_err(|source| ConfigError::Io {
-        path: duumbi_dir.display().to_string(),
-        source,
-    })?;
-    let path = duumbi_dir.join("config.toml");
+    save_config_file(&workspace_root.join(".duumbi").join("config.toml"), config)
+}
+
+fn save_config_file(path: &Path, config: &DuumbiConfig) -> Result<(), ConfigError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|source| ConfigError::Io {
+            path: parent.display().to_string(),
+            source,
+        })?;
+    }
     let contents = toml::to_string_pretty(config).map_err(|e| ConfigError::Invalid {
         field: "config".to_string(),
         reason: e.to_string(),
     })?;
-    fs::write(&path, contents).map_err(|source| ConfigError::Io {
+    fs::write(path, contents).map_err(|source| ConfigError::Io {
         path: path.display().to_string(),
         source,
     })?;
@@ -515,12 +647,15 @@ pub fn save_config(workspace_root: &Path, config: &DuumbiConfig) -> Result<(), C
 #[allow(dead_code)] // Called in Issue #31 orchestrator and #32 duumbi-add CLI
 pub fn load_config(workspace_root: &Path) -> Result<DuumbiConfig, ConfigError> {
     let path = workspace_root.join(".duumbi").join("config.toml");
+    load_config_file(&path)
+}
 
+fn load_config_file(path: &Path) -> Result<DuumbiConfig, ConfigError> {
     if !path.exists() {
         return Err(ConfigError::NotFound(path.display().to_string()));
     }
 
-    let contents = fs::read_to_string(&path).map_err(|source| ConfigError::Io {
+    let contents = fs::read_to_string(path).map_err(|source| ConfigError::Io {
         path: path.display().to_string(),
         source,
     })?;
@@ -579,6 +714,67 @@ api_key_env = "OPENAI_API_KEY"
         let llm = cfg.llm.expect("llm section must be present");
         assert_eq!(llm.provider, LlmProvider::OpenAI);
         assert_eq!(llm.model, "gpt-4o");
+    }
+
+    fn test_provider(kind: ProviderKind, model: &str) -> ProviderConfig {
+        ProviderConfig {
+            provider: kind,
+            role: ProviderRole::Primary,
+            model: model.to_string(),
+            api_key_env: "TEST_API_KEY".to_string(),
+            base_url: None,
+            timeout_secs: None,
+            key_storage: None,
+            auth_token_env: None,
+        }
+    }
+
+    #[test]
+    fn effective_config_uses_user_provider_without_workspace_provider() {
+        let mut user = DuumbiConfig::default();
+        user.providers
+            .push(test_provider(ProviderKind::Anthropic, "user-model"));
+
+        let effective = merge_config_layers(DuumbiConfig::default(), user, DuumbiConfig::default());
+
+        assert_eq!(effective.provider_source, ProviderConfigSource::User);
+        assert_eq!(effective.config.providers[0].model, "user-model");
+    }
+
+    #[test]
+    fn effective_config_workspace_provider_overrides_user_provider() {
+        let mut user = DuumbiConfig::default();
+        user.providers
+            .push(test_provider(ProviderKind::Anthropic, "user-model"));
+        let mut workspace = DuumbiConfig::default();
+        workspace
+            .providers
+            .push(test_provider(ProviderKind::Anthropic, "workspace-model"));
+
+        let effective = merge_config_layers(DuumbiConfig::default(), user, workspace);
+
+        assert_eq!(effective.provider_source, ProviderConfigSource::Workspace);
+        assert_eq!(effective.config.providers[0].model, "workspace-model");
+    }
+
+    #[test]
+    fn effective_config_falls_back_to_user_legacy_llm() {
+        let user = DuumbiConfig {
+            llm: Some(LlmConfig {
+                provider: LlmProvider::Anthropic,
+                model: "claude-test".to_string(),
+                api_key_env: "ANTHROPIC_API_KEY".to_string(),
+            }),
+            ..DuumbiConfig::default()
+        };
+
+        let effective = merge_config_layers(DuumbiConfig::default(), user, DuumbiConfig::default());
+
+        assert_eq!(effective.provider_source, ProviderConfigSource::LegacyUser);
+        assert_eq!(
+            effective.config.effective_providers()[0].model,
+            "claude-test"
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -509,6 +509,8 @@ pub enum ProviderConfigSource {
 pub struct EffectiveConfig {
     /// Merged config used by runtime clients.
     pub config: DuumbiConfig,
+    /// System-level config loaded from `/etc/duumbi/config.toml`, or default.
+    pub system_config: DuumbiConfig,
     /// User-level config loaded from `~/.duumbi/config.toml`, or default.
     pub user_config: DuumbiConfig,
     /// Workspace config loaded from `<workspace>/.duumbi/config.toml`, or default.
@@ -536,12 +538,28 @@ pub fn save_user_config(config: &DuumbiConfig) -> Result<(), ConfigError> {
 }
 
 /// Loads system, user, and workspace config layers and returns the effective runtime config.
-pub fn load_effective_config(workspace_root: &Path) -> EffectiveConfig {
-    let system_config = load_config_file(Path::new("/etc/duumbi/config.toml")).unwrap_or_default();
-    let user_config = load_user_config().unwrap_or_default();
-    let workspace_config = load_config(workspace_root).unwrap_or_default();
+pub fn load_effective_config(workspace_root: &Path) -> Result<EffectiveConfig, ConfigError> {
+    let system_config = match load_config_file(Path::new("/etc/duumbi/config.toml")) {
+        Ok(config) => config,
+        Err(ConfigError::NotFound(_)) => DuumbiConfig::default(),
+        Err(err) => return Err(err),
+    };
+    let user_config = match load_user_config() {
+        Ok(config) => config,
+        Err(ConfigError::NotFound(_)) => DuumbiConfig::default(),
+        Err(err) => return Err(err),
+    };
+    let workspace_config = match load_config(workspace_root) {
+        Ok(config) => config,
+        Err(ConfigError::NotFound(_)) => DuumbiConfig::default(),
+        Err(err) => return Err(err),
+    };
 
-    merge_config_layers(system_config, user_config, workspace_config)
+    Ok(merge_config_layers(
+        system_config,
+        user_config,
+        workspace_config,
+    ))
 }
 
 /// Merges system, user, and workspace config layers into one runtime config.
@@ -558,22 +576,22 @@ pub fn merge_config_layers(
         config.providers = workspace_config.providers.clone();
         config.llm = workspace_config.llm.clone();
         ProviderConfigSource::Workspace
-    } else if !user_config.providers.is_empty() {
-        config.providers = user_config.providers.clone();
-        config.llm = user_config.llm.clone();
-        ProviderConfigSource::User
-    } else if !system_config.providers.is_empty() {
-        config.providers = system_config.providers.clone();
-        config.llm = system_config.llm.clone();
-        ProviderConfigSource::System
     } else if workspace_config.llm.is_some() {
         config.providers.clear();
         config.llm = workspace_config.llm.clone();
         ProviderConfigSource::LegacyWorkspace
+    } else if !user_config.providers.is_empty() {
+        config.providers = user_config.providers.clone();
+        config.llm = user_config.llm.clone();
+        ProviderConfigSource::User
     } else if user_config.llm.is_some() {
         config.providers.clear();
         config.llm = user_config.llm.clone();
         ProviderConfigSource::LegacyUser
+    } else if !system_config.providers.is_empty() {
+        config.providers = system_config.providers.clone();
+        config.llm = system_config.llm.clone();
+        ProviderConfigSource::System
     } else if system_config.llm.is_some() {
         config.providers.clear();
         config.llm = system_config.llm.clone();
@@ -586,6 +604,7 @@ pub fn merge_config_layers(
 
     EffectiveConfig {
         config,
+        system_config,
         user_config,
         workspace_config,
         provider_source,
@@ -755,6 +774,56 @@ api_key_env = "OPENAI_API_KEY"
 
         assert_eq!(effective.provider_source, ProviderConfigSource::Workspace);
         assert_eq!(effective.config.providers[0].model, "workspace-model");
+    }
+
+    #[test]
+    fn effective_config_workspace_legacy_overrides_user_provider() {
+        let mut user = DuumbiConfig::default();
+        user.providers
+            .push(test_provider(ProviderKind::Anthropic, "user-model"));
+        let workspace = DuumbiConfig {
+            llm: Some(LlmConfig {
+                provider: LlmProvider::Anthropic,
+                model: "workspace-legacy-model".to_string(),
+                api_key_env: "ANTHROPIC_API_KEY".to_string(),
+            }),
+            ..DuumbiConfig::default()
+        };
+
+        let effective = merge_config_layers(DuumbiConfig::default(), user, workspace);
+
+        assert_eq!(
+            effective.provider_source,
+            ProviderConfigSource::LegacyWorkspace
+        );
+        assert_eq!(
+            effective.config.effective_providers()[0].model,
+            "workspace-legacy-model"
+        );
+    }
+
+    #[test]
+    fn effective_config_user_legacy_overrides_system_provider() {
+        let mut system = DuumbiConfig::default();
+        system
+            .providers
+            .push(test_provider(ProviderKind::Anthropic, "system-model"));
+        let user = DuumbiConfig {
+            llm: Some(LlmConfig {
+                provider: LlmProvider::Anthropic,
+                model: "user-legacy-model".to_string(),
+                api_key_env: "ANTHROPIC_API_KEY".to_string(),
+            }),
+            ..DuumbiConfig::default()
+        };
+
+        let effective = merge_config_layers(system, user, DuumbiConfig::default());
+
+        assert_eq!(effective.provider_source, ProviderConfigSource::LegacyUser);
+        assert_eq!(
+            effective.config.effective_providers()[0].model,
+            "user-legacy-model"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,13 @@ async fn main() {
     // interactive REPL — even without an initialised workspace.
     if std::env::args().len() == 1 && io::stdin().is_terminal() {
         let workspace_root = PathBuf::from(".");
-        let config = config::load_effective_config(&workspace_root);
+        let config = match config::load_effective_config(&workspace_root) {
+            Ok(config) => config,
+            Err(e) => {
+                eprintln!("error: {e}");
+                process::exit(1);
+            }
+        };
         if let Err(e) = cli::repl::run(workspace_root, config).await {
             eprintln!("error: {e:#}");
             process::exit(1);
@@ -552,7 +558,7 @@ async fn run_registry(subcommand: cli::RegistrySubcommand, workspace: &Path) -> 
 /// Uses the `[[providers]]` config if available, falling back to the legacy
 /// `[llm]` section for backward compatibility.
 fn require_llm_client(workspace: &Path) -> Result<agents::LlmClient> {
-    let cfg = config::load_effective_config(workspace).config;
+    let cfg = config::load_effective_config(workspace)?.config;
 
     let providers = cfg.effective_providers();
     if providers.is_empty() {
@@ -610,7 +616,7 @@ async fn run_benchmark(
     baseline: Option<PathBuf>,
 ) -> Result<()> {
     let workspace = PathBuf::from(".");
-    let cfg = config::load_effective_config(&workspace).config;
+    let cfg = config::load_effective_config(&workspace)?.config;
 
     let providers = cfg.effective_providers();
     if providers.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ async fn main() {
     // interactive REPL — even without an initialised workspace.
     if std::env::args().len() == 1 && io::stdin().is_terminal() {
         let workspace_root = PathBuf::from(".");
-        let config = config::load_config(&workspace_root).unwrap_or_default();
+        let config = config::load_effective_config(&workspace_root);
         if let Err(e) = cli::repl::run(workspace_root, config).await {
             eprintln!("error: {e:#}");
             process::exit(1);
@@ -476,8 +476,8 @@ fn run_knowledge(subcommand: cli::KnowledgeSubcommand, workspace: PathBuf) -> Re
 }
 
 /// Dispatches `duumbi provider` subcommands.
-fn run_provider(subcommand: cli::ProviderSubcommand, workspace: &Path) -> Result<()> {
-    let mut cfg = config::load_config(workspace).unwrap_or_default();
+fn run_provider(subcommand: cli::ProviderSubcommand, _workspace: &Path) -> Result<()> {
+    let mut cfg = config::load_user_config().unwrap_or_default();
 
     let lines = match subcommand {
         cli::ProviderSubcommand::List => cli::provider::list_providers(&cfg),
@@ -518,7 +518,7 @@ fn run_provider(subcommand: cli::ProviderSubcommand, workspace: &Path) -> Result
         .iter()
         .any(|l| l.style == cli::mode::OutputStyle::Success)
     {
-        config::save_config(workspace, &cfg)
+        config::save_user_config(&cfg)
             .map_err(|e| anyhow::anyhow!("Failed to save config: {e}"))?;
     }
 
@@ -552,16 +552,13 @@ async fn run_registry(subcommand: cli::RegistrySubcommand, workspace: &Path) -> 
 /// Uses the `[[providers]]` config if available, falling back to the legacy
 /// `[llm]` section for backward compatibility.
 fn require_llm_client(workspace: &Path) -> Result<agents::LlmClient> {
-    let cfg = config::load_config(workspace).context(
-        "Cannot run AI commands: no .duumbi/config.toml found.\n\
-         Run `duumbi init` and add a [[providers]] section to .duumbi/config.toml.",
-    )?;
+    let cfg = config::load_effective_config(workspace).config;
 
     let providers = cfg.effective_providers();
     if providers.is_empty() {
         anyhow::bail!(
-            "No LLM provider configured in .duumbi/config.toml.\n\
-             Add a [[providers]] section or a legacy [llm] section."
+            "No LLM provider configured.\n\
+             Use `/provider` in the REPL or `duumbi provider add ...` to save a user-level provider."
         );
     }
 
@@ -613,15 +610,12 @@ async fn run_benchmark(
     baseline: Option<PathBuf>,
 ) -> Result<()> {
     let workspace = PathBuf::from(".");
-    let cfg = config::load_config(&workspace).context(
-        "Cannot run benchmarks: no .duumbi/config.toml found.\n\
-         Run `duumbi init` and add a [[providers]] section to .duumbi/config.toml.",
-    )?;
+    let cfg = config::load_effective_config(&workspace).config;
 
     let providers = cfg.effective_providers();
     if providers.is_empty() {
         anyhow::bail!(
-            "No LLM providers configured. Add [[providers]] sections to .duumbi/config.toml."
+            "No LLM providers configured. Use `duumbi provider add ...` to save a user-level provider."
         );
     }
 


### PR DESCRIPTION
## Summary
- adds a standalone centered `/provider` TUI popup for managing LLM provider connections
- removes `/model` from slash completion while keeping it as a compatibility alias to `/provider`
- stores provider connections in user-level `~/.duumbi/config.toml` by default, with workspace overrides still supported
- supports provider setup, API key paste/input, deletion, and connection testing without Add/Priority TUI actions
- tests submitted API keys with a real provider probe before saving credentials
- saves file-backed API keys to `~/.duumbi/credentials.toml` only after a successful probe
- renders the Provider Connections screen as a labeled table with `Provider ID`, `Display name`, `Connection`, `Key source`, and `Required secret` columns
- improves provider TUI spacing, footer text, paste handling, masked input feedback, and user-friendly provider error messages

## Tests
- `cargo fmt --check`
- `cargo test provider_panel`
- `cargo test provider_probe_error_prefers_json_message`
- `cargo test provider_command_replaces_model_in_completion`
- `cargo test --test integration_phase9b`
- `cargo test create_provider`
- `cargo test --all`
- `cargo clippy --all-targets -- -D warnings`