### PR TITLE
[codex] Clarify provider model UX guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,15 @@ cargo fmt --check                    # Format check
   lockfile v1 with integrity hashes, vendor layer for offline builds
 - Dependency resolution: workspace → vendor → cache → registry (E011 if not found)
 
+## Provider and model UX
+- Prefer provider setup flows that collect credentials and verify access; do not
+  ask users to choose or maintain a default model unless the task explicitly
+  concerns backward compatibility or low-level config editing.
+- Keep model choice internal to the model catalog, routing inputs, or performance
+  knowledge. When changing provider behavior, update CLI, REPL/TUI, Studio, config
+  examples, tests, and docs together so `/provider` remains the user-facing entry
+  point and `/model` stays compatibility-only.
+
 ## CLI commands (Phase 7 + 12)
 - `duumbi mcp` — start the MCP server (JSON-RPC over stdio, 10 tools)
 - `duumbi search <query>` — search modules in configured registries


### PR DESCRIPTION
## Summary

- Adds concise AGENTS.md guidance for provider setup flows to collect credentials and verify access instead of asking users to maintain a default model.
- Documents that model choice should stay internal to catalog/routing/performance knowledge, with `/provider` as the user-facing entry point and `/model` compatibility-only.

## Why

Recent provider-management work repeatedly simplified the CLI/TUI setup surface and the open model-selection cleanup continues that direction. Capturing this in AGENTS.md should reduce future agent drift when touching provider behavior.

## Validation

- Documentation-only change; no code tests run.