### PR TITLE
[codex] Retire grok-code-fast-1 model

### DIFF
--- a/src/agents/factory.rs
+++ b/src/agents/factory.rs
@@ -418,8 +418,10 @@ mod tests {
 
     #[test]
     fn retired_grok_access_metadata_is_ignored() {
-        let active =
-            active_model_access_models(&ProviderKind::Grok, vec!["grok-code-fast-1".to_string()]);
+        let active = active_model_access_models(
+            &ProviderKind::Grok,
+            vec![model_catalog::RETIRED_GROK_CODE_FAST_1.to_string()],
+        );
 
         assert!(active.is_empty());
     }
@@ -429,7 +431,7 @@ mod tests {
         let active = active_model_access_models(
             &ProviderKind::Grok,
             vec![
-                "grok-code-fast-1".to_string(),
+                model_catalog::RETIRED_GROK_CODE_FAST_1.to_string(),
                 "grok-4-1-fast-non-reasoning".to_string(),
             ],
         );

--- a/src/agents/factory.rs
+++ b/src/agents/factory.rs
@@ -64,15 +64,26 @@ pub fn create_provider_for_global_access_context(
     let mut context = context.clone();
     if let Some(fingerprint) = crate::agents::model_access::credential_fingerprint_from_env(config)
     {
-        context.accessible_models =
-            ModelAccessStore::accessible_models(&config.provider, &fingerprint)
-                .into_iter()
-                .collect();
-        context.denied_models = ModelAccessStore::denied_models(&config.provider, &fingerprint)
-            .into_iter()
-            .collect();
+        context.accessible_models = active_model_access_models(
+            &config.provider,
+            ModelAccessStore::accessible_models(&config.provider, &fingerprint),
+        );
+        context.denied_models = active_model_access_models(
+            &config.provider,
+            ModelAccessStore::denied_models(&config.provider, &fingerprint),
+        );
     }
     create_provider_for_context(config, &context)
+}
+
+fn active_model_access_models(
+    provider: &ProviderKind,
+    models: impl IntoIterator<Item = String>,
+) -> Vec<String> {
+    models
+        .into_iter()
+        .filter(|model| !model_catalog::is_retired_model(provider, model))
+        .collect()
 }
 
 fn create_resolved_provider(
@@ -403,5 +414,34 @@ mod tests {
 
         assert_eq!(provider.name(), "grok");
         unsafe { std::env::remove_var("DUUMBI_TEST_GLOBAL_CHAIN_KEY") };
+    }
+
+    #[test]
+    fn retired_grok_access_metadata_is_ignored() {
+        let active =
+            active_model_access_models(&ProviderKind::Grok, vec!["grok-code-fast-1".to_string()]);
+
+        assert!(active.is_empty());
+    }
+
+    #[test]
+    fn retired_grok_denial_metadata_is_ignored_without_affecting_active_models() {
+        let active = active_model_access_models(
+            &ProviderKind::Grok,
+            vec![
+                "grok-code-fast-1".to_string(),
+                "grok-4-1-fast-non-reasoning".to_string(),
+            ],
+        );
+
+        assert_eq!(active, vec!["grok-4-1-fast-non-reasoning"]);
+    }
+
+    #[test]
+    fn active_model_access_filter_keeps_non_retired_models() {
+        let active =
+            active_model_access_models(&ProviderKind::MiniMax, vec!["MiniMax-M2.5".to_string()]);
+
+        assert_eq!(active, vec!["MiniMax-M2.5"]);
     }
 }

--- a/src/agents/model_catalog.rs
+++ b/src/agents/model_catalog.rs
@@ -8,6 +8,8 @@ use crate::agents::analyzer::{Complexity, Risk, TaskProfile, TaskType};
 use crate::agents::template::AgentRole;
 use crate::config::{ProviderConfig, ProviderKind, ResolvedProviderConfig};
 
+const RETIRED_GROK_CODE_FAST_1: &str = "grok-code-fast-1";
+
 /// Static metadata for a model that Duumbi may select.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ModelCatalogEntry {
@@ -143,15 +145,6 @@ pub fn catalog() -> &'static [ModelCatalogEntry] {
             coding: true,
         },
         ModelCatalogEntry {
-            provider: ProviderKind::Grok,
-            model: "grok-code-fast-1",
-            quality: 86,
-            speed: 95,
-            cost_efficiency: 92,
-            reasoning: false,
-            coding: true,
-        },
-        ModelCatalogEntry {
             provider: ProviderKind::MiniMax,
             model: "MiniMax-M2.7",
             quality: 92,
@@ -199,6 +192,12 @@ pub fn catalog() -> &'static [ModelCatalogEntry] {
     ]
 }
 
+/// Returns true when a model identifier is intentionally retired by this release.
+#[must_use]
+pub(crate) fn is_retired_model(provider: &ProviderKind, model: &str) -> bool {
+    matches!(provider, ProviderKind::Grok) && model == RETIRED_GROK_CODE_FAST_1
+}
+
 /// Selects the best model for the given provider and call context.
 #[must_use]
 pub fn select_model(
@@ -220,7 +219,9 @@ pub fn resolve_provider_config(
 ) -> Option<ResolvedProviderConfig> {
     let selected = config
         .model
-        .clone()
+        .as_deref()
+        .filter(|model| !is_retired_model(&config.provider, model))
+        .map(str::to_string)
         .or_else(|| select_model(&config.provider, context).map(|entry| entry.model.to_string()))?;
 
     Some(ResolvedProviderConfig {
@@ -334,6 +335,40 @@ mod tests {
         let resolved = resolve_provider_config(&config, &ModelSelectionContext::default());
 
         assert_eq!(resolved.expect("model must resolve").model, "legacy-model");
+    }
+
+    #[test]
+    fn grok_code_fast_is_not_in_catalog() {
+        assert!(
+            !catalog()
+                .iter()
+                .any(|entry| entry.provider == ProviderKind::Grok
+                    && entry.model == RETIRED_GROK_CODE_FAST_1)
+        );
+    }
+
+    #[test]
+    fn retired_grok_legacy_model_falls_back_to_catalog_selection() {
+        let config = ProviderConfig {
+            provider: ProviderKind::Grok,
+            role: crate::config::ProviderRole::Primary,
+            model: Some(RETIRED_GROK_CODE_FAST_1.to_string()),
+            api_key_env: "XAI_API_KEY".to_string(),
+            base_url: None,
+            timeout_secs: None,
+            key_storage: None,
+            auth_token_env: None,
+        };
+
+        let resolved = resolve_provider_config(&config, &ModelSelectionContext::default())
+            .expect("model must resolve");
+
+        assert_ne!(resolved.model, RETIRED_GROK_CODE_FAST_1);
+        assert!(
+            catalog()
+                .iter()
+                .any(|entry| entry.provider == ProviderKind::Grok && entry.model == resolved.model)
+        );
     }
 
     #[test]

--- a/src/agents/model_catalog.rs
+++ b/src/agents/model_catalog.rs
@@ -8,7 +8,7 @@ use crate::agents::analyzer::{Complexity, Risk, TaskProfile, TaskType};
 use crate::agents::template::AgentRole;
 use crate::config::{ProviderConfig, ProviderKind, ResolvedProviderConfig};
 
-const RETIRED_GROK_CODE_FAST_1: &str = "grok-code-fast-1";
+pub(crate) const RETIRED_GROK_CODE_FAST_1: &str = "grok-code-fast-1";
 
 /// Static metadata for a model that Duumbi may select.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -195,7 +195,7 @@ pub fn catalog() -> &'static [ModelCatalogEntry] {
 /// Returns true when a model identifier is intentionally retired by this release.
 #[must_use]
 pub(crate) fn is_retired_model(provider: &ProviderKind, model: &str) -> bool {
-    matches!(provider, ProviderKind::Grok) && model == RETIRED_GROK_CODE_FAST_1
+    matches!(provider, &ProviderKind::Grok) && model == RETIRED_GROK_CODE_FAST_1
 }
 
 /// Selects the best model for the given provider and call context.

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -3426,9 +3426,6 @@ mod tests {
     use super::*;
     use crate::session::SessionManager;
     use std::ffi::OsString;
-    use std::sync::Mutex;
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     struct HomeEnvGuard(Option<OsString>);
 
@@ -4394,7 +4391,9 @@ mod tests {
 
     #[test]
     fn provider_panel_api_key_enter_submits_probe_action_without_saving() {
-        let _guard = ENV_LOCK.lock().expect("invariant: env lock");
+        let _guard = crate::cli::TEST_ENV_LOCK
+            .lock()
+            .expect("invariant: env lock");
         let home = tempfile::TempDir::new().expect("invariant: temp home");
         let _home_guard = HomeEnvGuard::set(home.path());
 
@@ -4470,7 +4469,9 @@ mod tests {
             .await
             .expect("probe should succeed");
 
-        let _guard = ENV_LOCK.lock().expect("invariant: env lock");
+        let _guard = crate::cli::TEST_ENV_LOCK
+            .lock()
+            .expect("invariant: env lock");
         let home = tempfile::TempDir::new().expect("invariant: temp home");
         let _home_guard = HomeEnvGuard::set(home.path());
         app.save_tested_provider_key(
@@ -4546,7 +4547,9 @@ mod tests {
             .expect("probe should succeed when at least one model is accessible");
         assert_eq!(probe_report.accessible_count(), 2);
 
-        let _guard = ENV_LOCK.lock().expect("invariant: env lock");
+        let _guard = crate::cli::TEST_ENV_LOCK
+            .lock()
+            .expect("invariant: env lock");
         let home = tempfile::TempDir::new().expect("invariant: temp home");
         let _home_guard = HomeEnvGuard::set(home.path());
         app.save_tested_provider_key(
@@ -4580,7 +4583,9 @@ mod tests {
 
     #[test]
     fn provider_panel_file_credential_preserves_custom_api_key_env() {
-        let _guard = ENV_LOCK.lock().expect("invariant: env lock");
+        let _guard = crate::cli::TEST_ENV_LOCK
+            .lock()
+            .expect("invariant: env lock");
         let home = tempfile::TempDir::new().expect("invariant: temp home");
         let _home_guard = HomeEnvGuard::set(home.path());
 
@@ -5018,7 +5023,9 @@ mod tests {
 
     #[test]
     fn provider_panel_delete_removes_global_model_access_snapshot() {
-        let _guard = ENV_LOCK.lock().expect("invariant: env lock");
+        let _guard = crate::cli::TEST_ENV_LOCK
+            .lock()
+            .expect("invariant: env lock");
         let home = tempfile::TempDir::new().expect("invariant: temp home");
         let _home_guard = HomeEnvGuard::set(home.path());
         let fingerprint = crate::agents::model_access::credential_fingerprint_for_secret(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -24,6 +24,9 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 
+#[cfg(test)]
+pub(crate) static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Duumbi — AI-first semantic graph compiler.
 #[derive(Parser, Debug)]
 #[command(name = "duumbi", version, about)]

--- a/src/cli/provider_startup.rs
+++ b/src/cli/provider_startup.rs
@@ -297,7 +297,6 @@ mod tests {
     use super::*;
     use crate::agents::model_access::ModelAccessStore;
     use crate::config::{ProviderConfigSource, merge_config_layers};
-    use std::sync::{Mutex, OnceLock};
     use tempfile::TempDir;
 
     struct EnvGuard {
@@ -327,13 +326,10 @@ mod tests {
         }
     }
 
-    fn env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
-
     fn lock_env() -> std::sync::MutexGuard<'static, ()> {
-        env_lock().lock().unwrap_or_else(|err| err.into_inner())
+        crate::cli::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
     }
 
     fn effective_with(


### PR DESCRIPTION
## Summary

- Remove `grok-code-fast-1` from the internal Grok model catalog.
- Treat `grok-code-fast-1` as a retired Grok model so legacy config overrides fall back to active catalog routing.
- Filter stale model-access metadata before routing so old access records cannot pin Grok to the retired model.

## Why

`grok-code-fast-1` is no longer available under the Grok provider. Catalog removal alone would not be enough because older configs and saved model-access snapshots could still reference the retired model.

## Validation

- `cargo fmt --check`
- `cargo test model_catalog`
- `cargo test agents::factory`
- `cargo test provider_startup`
- `cargo test --all -- --test-threads=1`

Note: parallel `cargo test --all` exposed pre-existing provider test isolation failures around global `HOME` mutation; affected tests passed in isolation, and the full suite passed single-threaded.