### PR TITLE
Fix interactive workspace init

### DIFF
--- a/docs/testing/phase11-cli-ux.md
+++ b/docs/testing/phase11-cli-ux.md
@@ -68,16 +68,16 @@ unset DUUMBI
 
 ---
 
-## T1 — Post-Init Guidance (Track E)
+## T1 — Init Output (Track E)
 
 > Futtatasi hely: **ures temp konyvtar** (NEM a mar init-elt workspace)
 
 | # | Lepes | Elvart eredmeny | ✓/✗ | Megjegyzes |
 |---|-------|-----------------|-----|------------|
 | 1.1 | `mkdir /tmp/p11-init-test && cd /tmp/p11-init-test && $DUUMBI init .` | "✓ Project initialized at ..." megjelenik | ✓ | |
-| 1.2 | Az init kimenet tartalmaz "Next steps:" szekciót | Lepesek listaja: API key, config.toml, REPL | ✓ | |
-| 1.3 | Ha `ANTHROPIC_API_KEY` be van allitva: "Uncomment a [[providers]] section" az elso lepes | Felismeri a meglévo API key-t | | |
-| 1.4 | Ha `ANTHROPIC_API_KEY` NINCS beallitva: "Set an API key: export ANTHROPIC_API_KEY=sk-..." az elso lepes | Utmutatast ad az API key beallitasahoz | ✓ | |
+| 1.2 | Az init kimenet nem tartalmaz "Next steps:" szekciót | Csak rovid sikeruzenetet ir ki | | |
+| 1.3 | Az init kimenet nem tartalmaz provider warningot | Nem validal LLM providert init kozben | | |
+| 1.4 | `.duumbi/config.toml` tartalmazza a workspace nevet es namespace slugot | A directory nev alapjan generalja | | |
 | 1.5 | Takaritas: `cd ~ && rm -rf /tmp/p11-init-test` |  | | |
 
 ---

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -3425,7 +3425,7 @@ impl ReplApp {
             )));
         } else {
             lines.push(Line::from(Span::styled(
-                "  [Enter] Initialize    [Esc] Cancel",
+                "  [Enter] Initialize",
                 theme::out_dim(),
             )));
         }

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -2488,7 +2488,7 @@ impl ReplApp {
             }),
             PanelState::InitWorkspace {
                 confirm_overwrite, ..
-            } => Some(if *confirm_overwrite { 10 } else { 9 }),
+            } => Some(if *confirm_overwrite { 16 } else { 12 }),
         }
     }
 
@@ -3361,7 +3361,7 @@ impl ReplApp {
 
         let PanelState::InitWorkspace {
             name_buf,
-            default_name,
+            default_name: _,
             existing_non_empty,
             confirm_overwrite,
             status_msg,
@@ -3396,10 +3396,6 @@ impl ReplApp {
                 "  Namespace:      {}",
                 crate::cli::init::namespace_slug(name_buf)
             ),
-            theme::out_dim(),
-        )));
-        lines.push(Line::from(Span::styled(
-            format!("  Default:        {default_name}"),
             theme::out_dim(),
         )));
 
@@ -3784,6 +3780,22 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn init_panel_existing_workspace_renders_confirmation() {
+        let (mut app, textarea) = make_app();
+        app.open_init_panel("myproject".to_string(), true);
+        let _ = app.handle_key(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            &mut TextArea::default(),
+        );
+
+        let (rendered, _rows) = render_app_to_string(&app, &textarea, 120, 30);
+
+        assert!(rendered.contains("Existing non-empty .duumbi directory detected."));
+        assert!(rendered.contains("Delete .duumbi and initialize again? [y/N]"));
+        assert!(!rendered.contains("Default:"));
     }
 
     #[test]

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -871,6 +871,9 @@ impl ReplApp {
         if matches!(self.panel, PanelState::ProviderManager { .. }) {
             return self.handle_provider_panel_key(key, textarea);
         }
+        if matches!(self.panel, PanelState::InitWorkspace { .. }) {
+            return self.handle_init_panel_key(key);
+        }
 
         if self.conversation_action_menu.is_some() {
             return self.handle_conversation_action_menu_key(key);
@@ -1019,10 +1022,128 @@ impl ReplApp {
             let _ = self.insert_text_into_active_panel_field(text);
             return;
         }
+        if matches!(self.panel, PanelState::InitWorkspace { .. }) {
+            self.insert_text_into_init_panel(text);
+            return;
+        }
 
         textarea.insert_str(text);
         let current = textarea.lines().join("\n");
         self.update_slash_matches(&current);
+    }
+
+    /// Opens the workspace initialization panel with a prefilled name.
+    pub(crate) fn open_init_panel(&mut self, default_name: String, existing_non_empty: bool) {
+        self.clear_slash_menu();
+        self.panel = PanelState::InitWorkspace {
+            name_buf: default_name.clone(),
+            default_name,
+            existing_non_empty,
+            confirm_overwrite: false,
+            status_msg: None,
+        };
+    }
+
+    fn handle_init_panel_key(&mut self, key_event: KeyEvent) -> Action {
+        let PanelState::InitWorkspace {
+            mut name_buf,
+            default_name,
+            existing_non_empty,
+            mut confirm_overwrite,
+            ..
+        } = self.panel.clone()
+        else {
+            return Action::Continue;
+        };
+
+        let mut status_msg: Option<(String, OutputStyle)> = None;
+        if confirm_overwrite {
+            match key_event.code {
+                KeyCode::Esc | KeyCode::Char('n' | 'N') => {
+                    self.panel = PanelState::None;
+                    return Action::Continue;
+                }
+                KeyCode::Char('y' | 'Y') => {
+                    match crate::cli::init::validate_workspace_name(&name_buf) {
+                        Ok(workspace_name) => {
+                            self.panel = PanelState::None;
+                            return Action::InitWorkspaceSubmitted {
+                                workspace_name,
+                                overwrite_existing: true,
+                            };
+                        }
+                        Err(e) => {
+                            confirm_overwrite = false;
+                            status_msg = Some((e.to_string(), OutputStyle::Error));
+                        }
+                    }
+                }
+                _ => {}
+            }
+            self.panel = PanelState::InitWorkspace {
+                name_buf,
+                default_name,
+                existing_non_empty,
+                confirm_overwrite,
+                status_msg,
+            };
+            return Action::Continue;
+        }
+
+        match key_event.code {
+            KeyCode::Esc => {
+                self.panel = PanelState::None;
+            }
+            KeyCode::Backspace => {
+                name_buf.pop();
+            }
+            KeyCode::Enter => match crate::cli::init::validate_workspace_name(&name_buf) {
+                Ok(workspace_name) if existing_non_empty => {
+                    name_buf = workspace_name;
+                    confirm_overwrite = true;
+                    status_msg = Some((
+                        ".duumbi already exists and will be deleted before initialization."
+                            .to_string(),
+                        OutputStyle::Error,
+                    ));
+                }
+                Ok(workspace_name) => {
+                    self.panel = PanelState::None;
+                    return Action::InitWorkspaceSubmitted {
+                        workspace_name,
+                        overwrite_existing: false,
+                    };
+                }
+                Err(e) => {
+                    status_msg = Some((e.to_string(), OutputStyle::Error));
+                }
+            },
+            KeyCode::Char(c) if !is_clipboard_shortcut(key_event.modifiers) => {
+                name_buf.push(c);
+            }
+            _ => {}
+        }
+
+        self.panel = PanelState::InitWorkspace {
+            name_buf,
+            default_name,
+            existing_non_empty,
+            confirm_overwrite,
+            status_msg,
+        };
+        Action::Continue
+    }
+
+    fn insert_text_into_init_panel(&mut self, text: &str) {
+        if let PanelState::InitWorkspace {
+            name_buf,
+            confirm_overwrite,
+            ..
+        } = &mut self.panel
+            && !*confirm_overwrite
+        {
+            append_single_line_input(name_buf, text);
+        }
     }
 
     fn insert_text_into_active_panel_field(&mut self, text: &str) -> bool {
@@ -1114,7 +1235,7 @@ impl ReplApp {
                 input_mode,
                 ..
             } => (*selected, input_mode.clone()),
-            PanelState::None => return Action::Continue,
+            PanelState::None | PanelState::InitWorkspace { .. } => return Action::Continue,
         };
         let mut new_status_msg: Option<(String, OutputStyle)> = None;
         let mut action = Action::Continue;
@@ -2303,6 +2424,14 @@ impl ReplApp {
                     )
                 }
             }
+            PanelState::InitWorkspace { .. } => {
+                if let Some(overlay_height) = self.overlay_height() {
+                    let overlay_width = page.width.saturating_sub(4).clamp(52, 96);
+                    let overlay_area =
+                        Self::centered_overlay_rect(page, overlay_width, overlay_height);
+                    self.render_init_panel(frame, overlay_area, &self.panel);
+                }
+            }
         }
     }
 
@@ -2357,6 +2486,9 @@ impl ReplApp {
                     (provider_count as u16) + 9 + status_line
                 }
             }),
+            PanelState::InitWorkspace {
+                confirm_overwrite, ..
+            } => Some(if *confirm_overwrite { 10 } else { 9 }),
         }
     }
 
@@ -3223,6 +3355,88 @@ impl ReplApp {
         ])
     }
 
+    /// Renders the workspace initialization panel.
+    fn render_init_panel(&self, frame: &mut Frame, area: Rect, panel: &PanelState) {
+        use ratatui::widgets::{Block, Borders, Padding};
+
+        let PanelState::InitWorkspace {
+            name_buf,
+            default_name,
+            existing_non_empty,
+            confirm_overwrite,
+            status_msg,
+        } = panel
+        else {
+            return;
+        };
+
+        frame.render_widget(Clear, area);
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(theme::panel_border())
+            .padding(Padding::new(1, 1, 1, 1))
+            .style(theme::panel_surface());
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        let inner_width = inner.width as usize;
+        let mut lines: Vec<Line<'_>> = Vec::new();
+        lines.push(Line::from(vec![
+            Span::styled("  Initialize Workspace", theme::brand_word()),
+            Span::raw(" ".repeat(inner_width.saturating_sub(50))),
+            Span::styled("(Esc to cancel)", theme::out_dim()),
+        ]));
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            format!("  Workspace name: {name_buf}\u{2588}"),
+            theme::out_help_cmd(),
+        )));
+        lines.push(Line::from(Span::styled(
+            format!(
+                "  Namespace:      {}",
+                crate::cli::init::namespace_slug(name_buf)
+            ),
+            theme::out_dim(),
+        )));
+        lines.push(Line::from(Span::styled(
+            format!("  Default:        {default_name}"),
+            theme::out_dim(),
+        )));
+
+        if *existing_non_empty {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "  Existing non-empty .duumbi directory detected.",
+                theme::out_error(),
+            )));
+        }
+
+        if let Some((msg, style)) = status_msg {
+            let s = match style {
+                OutputStyle::Success => theme::out_success(),
+                OutputStyle::Error => theme::out_error(),
+                _ => theme::out_dim(),
+            };
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(format!("  {msg}"), s)));
+        }
+
+        lines.push(Line::from(""));
+        if *confirm_overwrite {
+            lines.push(Line::from(Span::styled(
+                "  Delete .duumbi and initialize again? [y/N]",
+                theme::out_error(),
+            )));
+        } else {
+            lines.push(Line::from(Span::styled(
+                "  [Enter] Initialize    [Esc] Cancel",
+                theme::out_dim(),
+            )));
+        }
+
+        frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
+    }
+
     /// Renders the interactive provider connection manager panel.
     fn render_provider_panel(
         &self,
@@ -3489,6 +3703,111 @@ mod tests {
         );
         let textarea = TextArea::default();
         (app, textarea)
+    }
+
+    #[test]
+    fn init_panel_prefills_default_workspace_name() {
+        let (mut app, _textarea) = make_app();
+        app.open_init_panel("myproject".to_string(), false);
+
+        assert!(matches!(
+            app.panel,
+            PanelState::InitWorkspace {
+                ref name_buf,
+                ref default_name,
+                existing_non_empty: false,
+                confirm_overwrite: false,
+                ..
+            } if name_buf == "myproject" && default_name == "myproject"
+        ));
+    }
+
+    #[test]
+    fn init_panel_enter_accepts_default_name() {
+        let (mut app, mut textarea) = make_app();
+        app.open_init_panel("myproject".to_string(), false);
+
+        let action = app.handle_key(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            &mut textarea,
+        );
+
+        assert!(matches!(
+            action,
+            Action::InitWorkspaceSubmitted {
+                workspace_name,
+                overwrite_existing: false
+            } if workspace_name == "myproject"
+        ));
+        assert!(matches!(app.panel, PanelState::None));
+    }
+
+    #[test]
+    fn init_panel_rejects_names_over_thirty_chars() {
+        let (mut app, mut textarea) = make_app();
+        app.open_init_panel(
+            "a".repeat(crate::cli::init::MAX_WORKSPACE_NAME_CHARS + 1),
+            false,
+        );
+
+        let action = app.handle_key(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            &mut textarea,
+        );
+
+        assert!(matches!(action, Action::Continue));
+        assert!(matches!(
+            app.panel,
+            PanelState::InitWorkspace {
+                status_msg: Some((_, OutputStyle::Error)),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn init_panel_existing_workspace_requires_confirmation() {
+        let (mut app, mut textarea) = make_app();
+        app.open_init_panel("myproject".to_string(), true);
+
+        let action = app.handle_key(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            &mut textarea,
+        );
+
+        assert!(matches!(action, Action::Continue));
+        assert!(matches!(
+            app.panel,
+            PanelState::InitWorkspace {
+                confirm_overwrite: true,
+                status_msg: Some((_, OutputStyle::Error)),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn init_panel_confirmation_submits_overwrite() {
+        let (mut app, mut textarea) = make_app();
+        app.open_init_panel("myproject".to_string(), true);
+        let _ = app.handle_key(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            &mut textarea,
+        );
+
+        let action = app.handle_key(
+            KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE),
+            &mut textarea,
+        );
+
+        assert!(matches!(
+            action,
+            Action::InitWorkspaceSubmitted {
+                workspace_name,
+                overwrite_existing: true
+            } if workspace_name == "myproject"
+        ));
+        assert!(matches!(app.panel, PanelState::None));
     }
 
     #[test]

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -3403,7 +3403,7 @@ impl ReplApp {
         if *existing_non_empty {
             lines.push(Line::from(""));
             lines.push(Line::from(Span::styled(
-                "  Existing non-empty .duumbi directory detected.",
+                "  This workspace has already been initialized.",
                 theme::out_error(),
             )));
         }
@@ -3808,7 +3808,7 @@ mod tests {
 
         let (rendered, _rows) = render_app_to_string(&app, &textarea, 120, 30);
 
-        assert!(rendered.contains("Existing non-empty .duumbi directory detected."));
+        assert!(rendered.contains("This workspace has already been initialized."));
         assert!(rendered.contains("Delete .duumbi and initialize again? [y/N]"));
         assert!(!rendered.contains("Default:"));
     }

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -1639,6 +1639,13 @@ impl ReplApp {
             let _ = crate::config::save_config(&self.workspace_root, &self.workspace_config);
         }
         self.refresh_effective_config();
+        self.rebuild_client_and_keychain_cache();
+    }
+
+    /// Rebuilds the LLM client and keychain cache from the current effective
+    /// config. Used after the config layers have been refreshed externally
+    /// (e.g. after interactive workspace init).
+    pub(super) fn rebuild_client_and_keychain_cache(&mut self) {
         let providers = self.config.effective_providers();
         self.client = if providers.is_empty() {
             None

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -1093,6 +1093,7 @@ impl ReplApp {
         match key_event.code {
             KeyCode::Esc => {
                 self.panel = PanelState::None;
+                return Action::Continue;
             }
             KeyCode::Backspace => {
                 name_buf.pop();
@@ -3739,6 +3740,20 @@ mod tests {
     }
 
     #[test]
+    fn init_panel_esc_closes_name_entry() {
+        let (mut app, mut textarea) = make_app();
+        app.open_init_panel("myproject".to_string(), false);
+
+        let action = app.handle_key(
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+            &mut textarea,
+        );
+
+        assert!(matches!(action, Action::Continue));
+        assert!(matches!(app.panel, PanelState::None));
+    }
+
+    #[test]
     fn init_panel_rejects_names_over_thirty_chars() {
         let (mut app, mut textarea) = make_app();
         app.open_init_panel(
@@ -3819,6 +3834,24 @@ mod tests {
                 overwrite_existing: true
             } if workspace_name == "myproject"
         ));
+        assert!(matches!(app.panel, PanelState::None));
+    }
+
+    #[test]
+    fn init_panel_esc_closes_overwrite_confirmation() {
+        let (mut app, mut textarea) = make_app();
+        app.open_init_panel("myproject".to_string(), true);
+        let _ = app.handle_key(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            &mut textarea,
+        );
+
+        let action = app.handle_key(
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+            &mut textarea,
+        );
+
+        assert!(matches!(action, Action::Continue));
         assert!(matches!(app.panel, PanelState::None));
     }
 

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -1059,7 +1059,10 @@ impl ReplApp {
         let mut status_msg: Option<(String, OutputStyle)> = None;
         if confirm_overwrite {
             match key_event.code {
-                KeyCode::Esc | KeyCode::Char('n' | 'N') => {
+                KeyCode::Esc => {
+                    confirm_overwrite = false;
+                }
+                KeyCode::Enter | KeyCode::Char('n' | 'N') => {
                     self.panel = PanelState::None;
                     return Action::Continue;
                 }
@@ -1102,11 +1105,6 @@ impl ReplApp {
                 Ok(workspace_name) if existing_non_empty => {
                     name_buf = workspace_name;
                     confirm_overwrite = true;
-                    status_msg = Some((
-                        ".duumbi already exists and will be deleted before initialization."
-                            .to_string(),
-                        OutputStyle::Error,
-                    ));
                 }
                 Ok(workspace_name) => {
                     self.panel = PanelState::None;
@@ -3388,10 +3386,17 @@ impl ReplApp {
             Span::styled("(Esc to cancel)", theme::out_dim()),
         ]));
         lines.push(Line::from(""));
-        lines.push(Line::from(Span::styled(
-            format!("  Workspace name: {name_buf}\u{2588}"),
-            theme::out_help_cmd(),
-        )));
+        let workspace_value = if *confirm_overwrite {
+            format!("  Workspace name: {name_buf}")
+        } else {
+            format!("  Workspace name: {name_buf}\u{2588}")
+        };
+        let workspace_style = if *confirm_overwrite {
+            theme::out_dim()
+        } else {
+            theme::out_help_cmd()
+        };
+        lines.push(Line::from(Span::styled(workspace_value, workspace_style)));
         lines.push(Line::from(Span::styled(
             format!(
                 "  Namespace:      {}",
@@ -3400,7 +3405,7 @@ impl ReplApp {
             theme::out_dim(),
         )));
 
-        if *existing_non_empty {
+        if *existing_non_empty && !*confirm_overwrite {
             lines.push(Line::from(""));
             lines.push(Line::from(Span::styled(
                 "  This workspace has already been initialized.",
@@ -3421,7 +3426,7 @@ impl ReplApp {
         lines.push(Line::from(""));
         if *confirm_overwrite {
             lines.push(Line::from(Span::styled(
-                "  Delete .duumbi and initialize again? [y/N]",
+                "  May I delete and reinitialize this workspace? [y/N]",
                 theme::out_error(),
             )));
         } else {
@@ -3791,7 +3796,7 @@ mod tests {
             app.panel,
             PanelState::InitWorkspace {
                 confirm_overwrite: true,
-                status_msg: Some((_, OutputStyle::Error)),
+                status_msg: None,
                 ..
             }
         ));
@@ -3808,8 +3813,10 @@ mod tests {
 
         let (rendered, _rows) = render_app_to_string(&app, &textarea, 120, 30);
 
-        assert!(rendered.contains("This workspace has already been initialized."));
-        assert!(rendered.contains("Delete .duumbi and initialize again? [y/N]"));
+        assert!(!rendered.contains("This workspace has already been initialized."));
+        assert!(rendered.contains("May I delete and reinitialize this workspace? [y/N]"));
+        assert!(rendered.contains("Workspace name: myproject"));
+        assert!(!rendered.contains("Workspace name: myproject█"));
         assert!(!rendered.contains("Default:"));
     }
 
@@ -3838,7 +3845,7 @@ mod tests {
     }
 
     #[test]
-    fn init_panel_esc_closes_overwrite_confirmation() {
+    fn init_panel_esc_returns_to_name_entry_from_overwrite_confirmation() {
         let (mut app, mut textarea) = make_app();
         app.open_init_panel("myproject".to_string(), true);
         let _ = app.handle_key(
@@ -3848,6 +3855,48 @@ mod tests {
 
         let action = app.handle_key(
             KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+            &mut textarea,
+        );
+
+        assert!(matches!(action, Action::Continue));
+        assert!(matches!(
+            app.panel,
+            PanelState::InitWorkspace {
+                confirm_overwrite: false,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn init_panel_enter_closes_overwrite_confirmation() {
+        let (mut app, mut textarea) = make_app();
+        app.open_init_panel("myproject".to_string(), true);
+        let _ = app.handle_key(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            &mut textarea,
+        );
+
+        let action = app.handle_key(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            &mut textarea,
+        );
+
+        assert!(matches!(action, Action::Continue));
+        assert!(matches!(app.panel, PanelState::None));
+    }
+
+    #[test]
+    fn init_panel_n_closes_overwrite_confirmation() {
+        let (mut app, mut textarea) = make_app();
+        app.open_init_panel("myproject".to_string(), true);
+        let _ = app.handle_key(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            &mut textarea,
+        );
+
+        let action = app.handle_key(
+            KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE),
             &mut textarea,
         );
 

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -72,10 +72,11 @@ const SKELETON_MAIN: &str = r#"{
 pub const MAX_WORKSPACE_NAME_CHARS: usize = 30;
 
 /// Default `config.toml` template (M7 format with registries and scope-based deps).
-const DEFAULT_CONFIG_TEMPLATE: &str = r#"[workspace]
-name = {name}
-namespace = {namespace}
-default-registry = "duumbi"
+/// Static remainder of `config.toml` after the `[workspace]` section.
+///
+/// The `[workspace]` block is rendered separately so user-supplied workspace
+/// names cannot collide with placeholder text via global string replacement.
+const DEFAULT_CONFIG_REST: &str = r#"default-registry = "duumbi"
 
 [registries]
 duumbi = "https://registry.duumbi.dev"
@@ -352,16 +353,21 @@ pub fn run_init_with_options(base: &Path, options: &InitOptions) -> Result<InitS
     )
     .context("Failed to write stdlib string module")?;
 
-    // Write config (includes stdlib deps by default)
+    // Write config (includes stdlib deps by default).
+    //
+    // The `[workspace]` block is built via formatting (not chained string
+    // replacement) so user-supplied names containing placeholder-like text
+    // cannot corrupt later substitutions.
     let workspace_name_toml = toml::Value::String(workspace_name.clone()).to_string();
     let namespace_toml = toml::Value::String(options.namespace.clone()).to_string();
-    fs::write(
-        duumbi_dir.join("config.toml"),
-        DEFAULT_CONFIG_TEMPLATE
-            .replace("{name}", workspace_name_toml.trim())
-            .replace("{namespace}", namespace_toml.trim()),
-    )
-    .context("Failed to write config.toml")?;
+    let config_content = format!(
+        "[workspace]\nname = {}\nnamespace = {}\n{}",
+        workspace_name_toml.trim(),
+        namespace_toml.trim(),
+        DEFAULT_CONFIG_REST,
+    );
+    fs::write(duumbi_dir.join("config.toml"), config_content)
+        .context("Failed to write config.toml")?;
 
     // Write skeleton main.jsonld
     fs::write(duumbi_dir.join("graph").join("main.jsonld"), SKELETON_MAIN)
@@ -553,6 +559,23 @@ mod tests {
         let ws = config.workspace.expect("workspace section must exist");
         assert_eq!(ws.name, "Human Project");
         assert_eq!(ws.namespace, "human-project");
+    }
+
+    #[test]
+    fn init_config_handles_placeholder_like_workspace_name() {
+        // Regression: chained .replace("{name}", ..).replace("{namespace}", ..)
+        // would corrupt the name field when it contained the literal text
+        // `{namespace}` (or `{name}`). The config writer must not collapse
+        // user-supplied content into placeholder substitutions.
+        let tmp = TempDir::new().expect("tempdir");
+        let options =
+            InitOptions::from_workspace_name("{namespace}", false).expect("valid options");
+        run_init_with_options(tmp.path(), &options).expect("init must succeed");
+
+        let config = crate::config::load_config(tmp.path()).expect("config must parse");
+        let ws = config.workspace.expect("workspace section must exist");
+        assert_eq!(ws.name, "{namespace}");
+        assert_eq!(ws.namespace, "namespace");
     }
 
     #[test]

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -5,7 +5,7 @@
 //! in the M5 cache layout (`.duumbi/cache/@duumbi/<name>@<version>/`).
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 
@@ -68,10 +68,13 @@ const SKELETON_MAIN: &str = r#"{
 }
 "#;
 
+/// Maximum user-facing workspace name length accepted by init.
+pub const MAX_WORKSPACE_NAME_CHARS: usize = 30;
+
 /// Default `config.toml` template (M7 format with registries and scope-based deps).
-const DEFAULT_CONFIG: &str = r#"[workspace]
-name = "myapp"
-namespace = "myapp"
+const DEFAULT_CONFIG_TEMPLATE: &str = r#"[workspace]
+name = {name}
+namespace = {namespace}
 default-registry = "duumbi"
 
 [registries]
@@ -84,20 +87,6 @@ duumbi = "https://registry.duumbi.dev"
 "@duumbi/stdlib-io" = "1.0.0"
 "@duumbi/stdlib-lang" = "1.0.0"
 "@duumbi/stdlib-string" = "1.0.0"
-
-# Uncomment and configure to enable AI commands (duumbi add, duumbi undo).
-# Supports: anthropic, openai, grok, openrouter, minimax.
-# Add multiple [[providers]] sections for fallback chains.
-#
-# [[providers]]
-# provider = "anthropic"
-# role = "primary"
-# api_key_env = "ANTHROPIC_API_KEY"
-#
-# [[providers]]
-# provider = "grok"
-# role = "fallback"
-# api_key_env = "XAI_API_KEY"
 "#;
 
 /// `.gitignore` template — excludes the auto-generated cache and build dirs.
@@ -109,17 +98,151 @@ const GITIGNORE: &str = "\
 .duumbi/telemetry/
 ";
 
+/// Result metadata for an initialized workspace.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InitSummary {
+    /// Workspace root where `.duumbi/` was created.
+    pub workspace_root: PathBuf,
+    /// Validated display name written into config.
+    pub workspace_name: String,
+    /// Namespace slug written into config.
+    pub namespace: String,
+}
+
+/// Options controlling workspace initialization.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InitOptions {
+    /// User-facing workspace name.
+    pub workspace_name: String,
+    /// Namespace slug used by config and resolvers.
+    pub namespace: String,
+    /// Whether an existing `.duumbi/` directory may be deleted first.
+    pub overwrite_existing: bool,
+}
+
+impl InitOptions {
+    /// Builds validated init options from a workspace name.
+    pub fn from_workspace_name(workspace_name: &str, overwrite_existing: bool) -> Result<Self> {
+        let workspace_name = validate_workspace_name(workspace_name)?;
+        let namespace = namespace_slug(&workspace_name);
+        Ok(Self {
+            workspace_name,
+            namespace,
+            overwrite_existing,
+        })
+    }
+}
+
+/// Returns the default workspace name for a path.
+#[must_use]
+pub fn default_workspace_name(base: &Path) -> String {
+    let name = path_file_name(base).or_else(|| {
+        base.canonicalize()
+            .ok()
+            .and_then(|canonical| path_file_name(&canonical))
+    });
+    name.unwrap_or_else(|| "workspace".to_string())
+        .chars()
+        .take(MAX_WORKSPACE_NAME_CHARS)
+        .collect()
+}
+
+fn path_file_name(path: &Path) -> Option<String> {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+/// Validates and normalizes a workspace display name.
+pub fn validate_workspace_name(name: &str) -> Result<String> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("Workspace name cannot be empty");
+    }
+    if trimmed.chars().count() > MAX_WORKSPACE_NAME_CHARS {
+        anyhow::bail!(
+            "Workspace name must be at most {} characters",
+            MAX_WORKSPACE_NAME_CHARS
+        );
+    }
+    Ok(trimmed.to_string())
+}
+
+/// Generates a portable namespace slug from a workspace name.
+#[must_use]
+pub fn namespace_slug(name: &str) -> String {
+    let mut slug = String::new();
+    let mut pending_separator = false;
+
+    for c in name.chars() {
+        if c.is_ascii_alphanumeric() {
+            if pending_separator && !slug.is_empty() {
+                slug.push('-');
+            }
+            slug.push(c.to_ascii_lowercase());
+            pending_separator = false;
+        } else {
+            pending_separator = true;
+        }
+    }
+
+    if slug.is_empty() {
+        slug.push_str("workspace");
+    }
+
+    if !slug
+        .chars()
+        .next()
+        .is_some_and(|first| first.is_ascii_alphabetic())
+    {
+        slug.insert_str(0, "w-");
+    }
+
+    slug
+}
+
+/// Returns whether an existing `.duumbi/` directory contains any entries.
+pub fn duumbi_dir_is_non_empty(base: &Path) -> Result<bool> {
+    let duumbi_dir = base.join(".duumbi");
+    if !duumbi_dir.exists() {
+        return Ok(false);
+    }
+    Ok(fs::read_dir(&duumbi_dir)
+        .with_context(|| format!("Failed to read '{}'", duumbi_dir.display()))?
+        .next()
+        .is_some())
+}
+
 /// Initializes a new duumbi workspace at the given base path.
 ///
 /// Creates `.duumbi/` with subdirectories for config, graph, schema, build,
 /// telemetry, and intents. Stdlib modules are written to the M5 cache layout:
 /// `.duumbi/cache/@duumbi/stdlib-{math,io,lang,string}@1.0.0/`.
-/// Fails if `.duumbi/` already exists.
-pub fn run_init(base: &Path) -> Result<()> {
+/// Fails if `.duumbi/` already exists and is non-empty.
+pub fn run_init(base: &Path) -> Result<InitSummary> {
+    let workspace_name = default_workspace_name(base);
+    let options = InitOptions::from_workspace_name(&workspace_name, false)?;
+    run_init_with_options(base, &options)
+}
+
+/// Initializes a new duumbi workspace using explicit options.
+pub fn run_init_with_options(base: &Path, options: &InitOptions) -> Result<InitSummary> {
+    let workspace_name = validate_workspace_name(&options.workspace_name)?;
+    if options.namespace.trim().is_empty() {
+        anyhow::bail!("Workspace namespace cannot be empty");
+    }
+
     let duumbi_dir = base.join(".duumbi");
 
     if duumbi_dir.exists() {
-        anyhow::bail!("Workspace already exists at '{}'", duumbi_dir.display());
+        if options.overwrite_existing {
+            fs::remove_dir_all(&duumbi_dir)
+                .with_context(|| format!("Failed to remove '{}'", duumbi_dir.display()))?;
+        } else if duumbi_dir_is_non_empty(base)? {
+            anyhow::bail!("Workspace already exists at '{}'", duumbi_dir.display());
+        }
     }
 
     // Core directory structure
@@ -230,8 +353,15 @@ pub fn run_init(base: &Path) -> Result<()> {
     .context("Failed to write stdlib string module")?;
 
     // Write config (includes stdlib deps by default)
-    fs::write(duumbi_dir.join("config.toml"), DEFAULT_CONFIG)
-        .context("Failed to write config.toml")?;
+    let workspace_name_toml = toml::Value::String(workspace_name.clone()).to_string();
+    let namespace_toml = toml::Value::String(options.namespace.clone()).to_string();
+    fs::write(
+        duumbi_dir.join("config.toml"),
+        DEFAULT_CONFIG_TEMPLATE
+            .replace("{name}", workspace_name_toml.trim())
+            .replace("{namespace}", namespace_toml.trim()),
+    )
+    .context("Failed to write config.toml")?;
 
     // Write skeleton main.jsonld
     fs::write(duumbi_dir.join("graph").join("main.jsonld"), SKELETON_MAIN)
@@ -243,43 +373,11 @@ pub fn run_init(base: &Path) -> Result<()> {
         fs::write(&gitignore, GITIGNORE).context("Failed to write .gitignore")?;
     }
 
-    eprintln!(
-        "{} Project initialized at {}",
-        super::theme::check_mark(),
-        duumbi_dir.display()
-    );
-    eprintln!();
-
-    // Post-init guidance: check for common API key env vars
-    let has_api_key = std::env::var("ANTHROPIC_API_KEY").is_ok()
-        || std::env::var("OPENAI_API_KEY").is_ok()
-        || std::env::var("XAI_API_KEY").is_ok();
-
-    if has_api_key {
-        eprintln!("{}", super::theme::bold("Next steps:"));
-        eprintln!("  1. Uncomment a [[providers]] section in .duumbi/config.toml");
-        eprintln!(
-            "  2. Run {} to start the REPL",
-            super::theme::command("duumbi")
-        );
-        eprintln!(
-            "  3. Try: {}",
-            super::theme::info("\"Add a function that adds two numbers\""),
-        );
-    } else {
-        eprintln!("{}", super::theme::bold("Next steps:"));
-        eprintln!(
-            "  1. Set an API key: {}",
-            super::theme::dim("export ANTHROPIC_API_KEY=sk-..."),
-        );
-        eprintln!("  2. Uncomment a [[providers]] section in .duumbi/config.toml");
-        eprintln!(
-            "  3. Run {} to start the REPL",
-            super::theme::command("duumbi")
-        );
-    }
-
-    Ok(())
+    Ok(InitSummary {
+        workspace_root: base.to_path_buf(),
+        workspace_name,
+        namespace: options.namespace.clone(),
+    })
 }
 
 /// Writes a single stdlib module into the cache layer.
@@ -403,6 +501,61 @@ mod tests {
     }
 
     #[test]
+    fn workspace_name_validation_trims_and_limits_length() {
+        assert_eq!(
+            validate_workspace_name("  My App  ").expect("valid"),
+            "My App"
+        );
+        assert!(validate_workspace_name("").is_err());
+        assert!(validate_workspace_name("   ").is_err());
+        assert!(
+            validate_workspace_name("a".repeat(MAX_WORKSPACE_NAME_CHARS + 1).as_str()).is_err()
+        );
+    }
+
+    #[test]
+    fn namespace_slug_is_portable() {
+        assert_eq!(namespace_slug("My App"), "my-app");
+        assert_eq!(namespace_slug("  My---App__v2  "), "my-app-v2");
+        assert_eq!(namespace_slug("123 App"), "w-123-app");
+        assert_eq!(namespace_slug("###"), "workspace");
+    }
+
+    #[test]
+    fn default_workspace_name_for_dot_uses_current_directory_name() {
+        let _lock = crate::cli::TEST_ENV_LOCK.lock().expect("env lock");
+        let tmp = TempDir::new().expect("tempdir");
+        let previous = std::env::current_dir().expect("current dir");
+        std::env::set_current_dir(tmp.path()).expect("set current dir");
+
+        let name = default_workspace_name(Path::new("."));
+
+        std::env::set_current_dir(previous).expect("restore current dir");
+        assert_eq!(
+            name,
+            tmp.path()
+                .file_name()
+                .and_then(|name| name.to_str())
+                .expect("temp basename")
+        );
+    }
+
+    #[test]
+    fn init_config_writes_workspace_identity() {
+        let tmp = TempDir::new().expect("tempdir");
+        let options =
+            InitOptions::from_workspace_name("Human Project", false).expect("valid options");
+        let summary = run_init_with_options(tmp.path(), &options).expect("init must succeed");
+
+        assert_eq!(summary.workspace_name, "Human Project");
+        assert_eq!(summary.namespace, "human-project");
+        let config = crate::config::load_config(tmp.path()).expect("config must parse");
+        let ws = config.workspace.expect("workspace section must exist");
+        assert_eq!(ws.name, "Human Project");
+        assert_eq!(ws.namespace, "human-project");
+    }
+
+    #[test]
     fn init_config_uses_scope_based_deps() {
         let tmp = TempDir::new().expect("tempdir");
         run_init(tmp.path()).expect("init must succeed");
@@ -443,5 +596,24 @@ mod tests {
         run_init(tmp.path()).expect("invariant: first init should succeed");
         let result = run_init(tmp.path());
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn init_overwrite_replaces_only_duumbi_directory() {
+        let tmp = TempDir::new().expect("invariant: temp dir must be created");
+        run_init(tmp.path()).expect("invariant: first init should succeed");
+        fs::write(tmp.path().join(".duumbi").join("old-marker"), "delete me").expect("write");
+        fs::write(tmp.path().join("root-marker"), "keep me").expect("write");
+
+        let options = InitOptions::from_workspace_name("Second App", true).expect("valid options");
+        run_init_with_options(tmp.path(), &options).expect("overwrite init must succeed");
+
+        assert!(!tmp.path().join(".duumbi").join("old-marker").exists());
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("root-marker")).expect("read root marker"),
+            "keep me"
+        );
+        let config = crate::config::load_config(tmp.path()).expect("config must parse");
+        assert_eq!(config.workspace.expect("workspace").namespace, "second-app");
     }
 }

--- a/src/cli/mode.rs
+++ b/src/cli/mode.rs
@@ -174,6 +174,13 @@ pub enum Action {
         /// If true, the key is a subscription/Bearer token.
         is_subscription: bool,
     },
+    /// Initialize a workspace from the interactive init panel.
+    InitWorkspaceSubmitted {
+        /// Validated workspace display name.
+        workspace_name: String,
+        /// Whether an existing `.duumbi/` directory may be deleted first.
+        overwrite_existing: bool,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -194,6 +201,19 @@ pub enum PanelState {
         /// Sub-mode for inline input within the panel.
         input_mode: Option<PanelInputMode>,
         /// Optional status message shown in the panel footer. Cleared on next key press.
+        status_msg: Option<(String, OutputStyle)>,
+    },
+    /// Workspace initialization panel.
+    InitWorkspace {
+        /// Editable workspace name buffer.
+        name_buf: String,
+        /// Default name offered from the current directory.
+        default_name: String,
+        /// Whether the current `.duumbi/` directory exists and contains entries.
+        existing_non_empty: bool,
+        /// Whether the panel is currently waiting for destructive re-init confirmation.
+        confirm_overwrite: bool,
+        /// Optional status message shown in the panel.
         status_msg: Option<(String, OutputStyle)>,
     },
 }

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -1982,8 +1982,7 @@ fn build_client(config: &DuumbiConfig, _workspace: &std::path::Path) -> Option<L
 
     // Load API keys from keychain for providers that use it.
     for p in &providers {
-        if matches!(p.key_storage, Some(crate::config::KeyStorage::File))
-            && std::env::var(&p.api_key_env).is_err()
+        if std::env::var(&p.api_key_env).is_err()
             && let Some(key) = super::keystore::load_api_key(&p.api_key_env)
         {
             // SAFETY: single-threaded CLI — no concurrent env access.
@@ -1992,7 +1991,6 @@ fn build_client(config: &DuumbiConfig, _workspace: &std::path::Path) -> Option<L
             }
         }
         if let Some(token_env) = &p.auth_token_env
-            && matches!(p.key_storage, Some(crate::config::KeyStorage::File))
             && std::env::var(token_env).is_err()
             && let Some(token) = super::keystore::load_api_key(token_env)
         {
@@ -2003,13 +2001,7 @@ fn build_client(config: &DuumbiConfig, _workspace: &std::path::Path) -> Option<L
         }
     }
 
-    match crate::agents::factory::create_provider_chain_for_global_access(&providers) {
-        Ok(client) => Some(client),
-        Err(e) => {
-            eprintln!("Warning: LLM provider not available ({e}). AI mutations disabled.");
-            None
-        }
-    }
+    crate::agents::factory::create_provider_chain_for_global_access(&providers).ok()
 }
 
 // ---------------------------------------------------------------------------
@@ -2099,8 +2091,47 @@ fn find_closest_command<'a>(input: &str, commands: &[&'a str]) -> Option<&'a str
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{ProviderConfig, ProviderKind, WorkspaceSection};
+    use crate::config::{KeyStorage, ProviderConfig, ProviderKind, ProviderRole, WorkspaceSection};
+    use std::ffi::OsString;
     use tempfile::TempDir;
+
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var_os(key);
+            // SAFETY: guarded test-only environment mutation.
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var_os(key);
+            // SAFETY: guarded test-only environment mutation.
+            unsafe {
+                std::env::remove_var(key);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: guarded test-only environment mutation.
+            unsafe {
+                if let Some(previous) = &self.previous {
+                    std::env::set_var(self.key, previous);
+                } else {
+                    std::env::remove_var(self.key);
+                }
+            }
+        }
+    }
 
     fn status_test_app(
         dir: &TempDir,
@@ -2190,6 +2221,35 @@ mod tests {
         assert_eq!(workspace.name, "New App");
         assert_eq!(workspace.namespace, "new-app");
         assert!(status_output(&app).contains("Workspace initialised: New App (new-app)"));
+    }
+
+    #[test]
+    fn build_client_loads_credentials_file_without_file_key_storage() {
+        let _lock = crate::cli::TEST_ENV_LOCK.lock().expect("env lock");
+        let home = TempDir::new().expect("home tempdir");
+        let _home = EnvGuard::set("HOME", home.path().to_str().expect("utf8 home"));
+        let _api_key = EnvGuard::remove("DUUMBI_TEST_REPL_KEYSTORE_API_KEY");
+        crate::cli::keystore::store_api_key("DUUMBI_TEST_REPL_KEYSTORE_API_KEY", "secret")
+            .expect("credential must store");
+        let mut config = DuumbiConfig::default();
+        config.providers.push(ProviderConfig {
+            provider: ProviderKind::MiniMax,
+            role: ProviderRole::Primary,
+            model: None,
+            api_key_env: "DUUMBI_TEST_REPL_KEYSTORE_API_KEY".to_string(),
+            base_url: None,
+            timeout_secs: None,
+            key_storage: Some(KeyStorage::Env),
+            auth_token_env: None,
+        });
+
+        let client = build_client(&config, Path::new("."));
+
+        assert!(client.is_some());
+        assert_eq!(
+            std::env::var("DUUMBI_TEST_REPL_KEYSTORE_API_KEY").as_deref(),
+            Ok("secret")
+        );
     }
 
     fn provider(kind: ProviderKind, role: ProviderRole) -> ProviderConfig {

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -238,6 +238,13 @@ async fn event_loop(
                         }
                         should_redraw = true;
                     }
+                    super::mode::Action::InitWorkspaceSubmitted {
+                        workspace_name,
+                        overwrite_existing,
+                    } => {
+                        complete_tui_init(app, workspace_name, overwrite_existing);
+                        should_redraw = true;
+                    }
                 },
                 Event::Paste(text) => {
                     app.handle_paste(&text, textarea);
@@ -485,40 +492,15 @@ async fn handle_slash(
         }
 
         "/init" => {
-            if app.has_workspace {
-                app.push_output("Workspace already initialised.", OutputStyle::Dim);
-            } else {
-                let workspace_root = app.workspace_root.clone();
-                let init_result = run_with_terminal_restore(terminal, app, textarea, || {
-                    super::init::run_init(&workspace_root)
-                });
-                match init_result {
-                    Ok(()) => {
-                        app.has_workspace = true;
-                        match crate::config::load_effective_config(&app.workspace_root) {
-                            Ok(effective) => {
-                                app.config = effective.config;
-                                app.system_config = effective.system_config;
-                                app.user_config = effective.user_config;
-                                app.workspace_config = effective.workspace_config;
-                                app.provider_config_source = effective.provider_source;
-                                app.client = build_client(&app.config, &app.workspace_root);
-                                app.session_mgr =
-                                    SessionManager::load_or_create(&app.workspace_root).ok();
-                                app.show_tip = true;
-                                app.push_output("Workspace initialised.", OutputStyle::Success);
-                            }
-                            Err(e) => {
-                                app.push_output(
-                                    format!("Workspace initialised, but config reload failed: {e}"),
-                                    OutputStyle::Error,
-                                );
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        app.push_output(format!("Init failed: {e:#}"), OutputStyle::Error);
-                    }
+            let default_name = super::init::default_workspace_name(&app.workspace_root);
+            match super::init::duumbi_dir_is_non_empty(&app.workspace_root) {
+                Ok(existing_non_empty) => {
+                    app.open_init_panel(default_name, existing_non_empty);
+                    textarea.move_cursor(ratatui_textarea::CursorMove::Head);
+                    textarea.delete_line_by_end();
+                }
+                Err(e) => {
+                    app.push_output(format!("Init failed: {e:#}"), OutputStyle::Error);
                 }
             }
         }
@@ -559,6 +541,50 @@ async fn handle_slash(
     }
 
     false
+}
+
+fn complete_tui_init(app: &mut ReplApp, workspace_name: String, overwrite_existing: bool) {
+    let options =
+        match super::init::InitOptions::from_workspace_name(&workspace_name, overwrite_existing) {
+            Ok(options) => options,
+            Err(e) => {
+                app.push_output(format!("Init failed: {e:#}"), OutputStyle::Error);
+                return;
+            }
+        };
+
+    match super::init::run_init_with_options(&app.workspace_root, &options) {
+        Ok(summary) => {
+            app.has_workspace = true;
+            match crate::config::load_effective_config(&app.workspace_root) {
+                Ok(effective) => {
+                    app.config = effective.config;
+                    app.system_config = effective.system_config;
+                    app.user_config = effective.user_config;
+                    app.workspace_config = effective.workspace_config;
+                    app.provider_config_source = effective.provider_source;
+                    app.session_mgr = SessionManager::load_or_create(&app.workspace_root).ok();
+                    app.show_tip = true;
+                    app.push_output(
+                        format!(
+                            "Workspace initialised: {} ({})",
+                            summary.workspace_name, summary.namespace
+                        ),
+                        OutputStyle::Success,
+                    );
+                }
+                Err(e) => {
+                    app.push_output(
+                        format!("Workspace initialised, but config reload failed: {e}"),
+                        OutputStyle::Error,
+                    );
+                }
+            }
+        }
+        Err(e) => {
+            app.push_output(format!("Init failed: {e:#}"), OutputStyle::Error);
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2134,6 +2160,36 @@ mod tests {
     }]
   }]
 }"#
+    }
+
+    #[test]
+    fn complete_tui_init_overwrites_only_duumbi_directory() {
+        let dir = TempDir::new().expect("tempdir");
+        fs::create_dir_all(dir.path().join(".duumbi")).expect("duumbi dir");
+        fs::write(dir.path().join(".duumbi/old-marker"), "delete").expect("old marker");
+        fs::write(dir.path().join("root-marker"), "keep").expect("root marker");
+        let mut app = ReplApp::new(
+            DuumbiConfig::default(),
+            dir.path().to_path_buf(),
+            None,
+            None,
+            true,
+            false,
+        );
+
+        complete_tui_init(&mut app, "New App".to_string(), true);
+
+        assert!(app.has_workspace);
+        assert!(!dir.path().join(".duumbi/old-marker").exists());
+        assert_eq!(
+            fs::read_to_string(dir.path().join("root-marker")).expect("root marker"),
+            "keep"
+        );
+        let config = crate::config::load_config(dir.path()).expect("config");
+        let workspace = config.workspace.expect("workspace");
+        assert_eq!(workspace.name, "New App");
+        assert_eq!(workspace.namespace, "new-app");
+        assert!(status_output(&app).contains("Workspace initialised: New App (new-app)"));
     }
 
     fn provider(kind: ProviderKind, role: ProviderRole) -> ProviderConfig {

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -563,6 +563,7 @@ fn complete_tui_init(app: &mut ReplApp, workspace_name: String, overwrite_existi
                     app.user_config = effective.user_config;
                     app.workspace_config = effective.workspace_config;
                     app.provider_config_source = effective.provider_source;
+                    app.rebuild_client_and_keychain_cache();
                     app.session_mgr = SessionManager::load_or_create(&app.workspace_root).ok();
                     app.show_tip = true;
                     app.push_output(
@@ -2195,6 +2196,14 @@ mod tests {
 
     #[test]
     fn complete_tui_init_overwrites_only_duumbi_directory() {
+        // `complete_tui_init` calls `load_effective_config`, which reads
+        // `$HOME/.duumbi/config.toml` (and may read `/etc/duumbi/config.toml`).
+        // Pin HOME to a fresh tempdir so the test stays hermetic regardless
+        // of the developer/CI machine's global config.
+        let _lock = crate::cli::TEST_ENV_LOCK.lock().expect("env lock");
+        let home = TempDir::new().expect("home tempdir");
+        let _home = EnvGuard::set("HOME", home.path().to_str().expect("utf8 home"));
+
         let dir = TempDir::new().expect("tempdir");
         fs::create_dir_all(dir.path().join(".duumbi")).expect("duumbi dir");
         fs::write(dir.path().join(".duumbi/old-marker"), "delete").expect("old marker");

--- a/src/cli/theme.rs
+++ b/src/cli/theme.rs
@@ -55,6 +55,7 @@ pub fn bold(text: &str) -> String {
 
 /// Renders a slash command name in bold cyan.
 #[must_use]
+#[allow(dead_code)]
 pub fn command(text: &str) -> String {
     format!("{}", text.cyan().bold())
 }

--- a/src/cli/theme.rs
+++ b/src/cli/theme.rs
@@ -54,8 +54,8 @@ pub fn bold(text: &str) -> String {
 }
 
 /// Renders a slash command name in bold cyan.
+#[cfg(test)]
 #[must_use]
-#[allow(dead_code)]
 pub fn command(text: &str) -> String {
     format!("{}", text.cyan().bold())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,7 +162,13 @@ async fn run(cli: Cli) -> Result<()> {
                 }
                 None => PathBuf::from("."),
             };
-            cli::init::run_init(&base)
+            let summary = cli::init::run_init(&base)?;
+            eprintln!(
+                "{} Project initialized at {}",
+                cli::theme::check_mark(),
+                summary.workspace_root.join(".duumbi").display()
+            );
+            Ok(())
         }
         Commands::Build {
             input,
@@ -709,9 +715,10 @@ async fn run_benchmark(
 
     let started_at = iso8601_now();
 
-    let results = bench::runner::run_benchmark(&config, cli::init::run_init)
-        .await
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let results =
+        bench::runner::run_benchmark(&config, |path| cli::init::run_init(path).map(|_| ()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
 
     let finished_at = iso8601_now();
 

--- a/tests/integration_phase1.rs
+++ b/tests/integration_phase1.rs
@@ -180,9 +180,19 @@ fn phase1_workspace_init_build_run() {
         "duumbi init failed: {}",
         String::from_utf8_lossy(&init_output.stderr)
     );
+    let init_stdout = String::from_utf8_lossy(&init_output.stdout);
+    let init_stderr = String::from_utf8_lossy(&init_output.stderr);
+    assert!(!init_stdout.contains("Next steps"));
+    assert!(!init_stderr.contains("Next steps"));
+    assert!(!init_stdout.contains("LLM provider not available"));
+    assert!(!init_stderr.contains("LLM provider not available"));
 
     assert!(tmp_dir.join(".duumbi/config.toml").exists());
     assert!(tmp_dir.join(".duumbi/graph/main.jsonld").exists());
+    let config = std::fs::read_to_string(tmp_dir.join(".duumbi/config.toml"))
+        .expect("invariant: config must be readable");
+    assert!(config.contains("name = \"duumbi_workspace_test\""));
+    assert!(config.contains("namespace = \"duumbi-workspace-test\""));
 
     // Build (workspace-aware — run duumbi from within the workspace dir)
     let build_output = Command::new(&duumbi_bin)


### PR DESCRIPTION
## Summary
- Add a TUI `/init` panel that asks for the workspace name, derives a namespace slug, and stays inside ratatui.
- Make init ignore provider validation and remove the old post-init provider/next-step guidance.
- Support confirmed re-initialization by deleting only `.duumbi` before recreating the workspace.

## Tests
- `cargo test --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- Manual TUI smoke in a temp directory with `/init`, default name acceptance, and `/exit`; verified no `Next steps` or `LLM provider not available` output.