### PR TITLE
Clean up TUI intent workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,6 +1210,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.11.0",
+ "shlex",
  "strsim",
  "tar",
  "target-lexicon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,7 +1181,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "duumbi"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -1256,7 +1256,7 @@ dependencies = [
 
 [[package]]
 name = "duumbi-studio"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/duumbi-studio"]
 
 [package]
 name = "duumbi"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 license = "MPL-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ indicatif = "0.18.4"
 comfy-table = "7.2.2"
 clap_complete = "4.6.3"
 strsim = "0.11.1"
+shlex = "1.3.0"
 
 [dev-dependencies]
 axum = "0.8.9"

--- a/crates/duumbi-studio/Cargo.toml
+++ b/crates/duumbi-studio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "duumbi-studio"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 license = "MPL-2.0"
 

--- a/src/agents/analyzer.rs
+++ b/src/agents/analyzer.rs
@@ -234,6 +234,7 @@ mod tests {
                 })
                 .collect(),
             dependencies: vec![],
+            context: None,
             created_at: None,
             execution: None,
         }

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -226,8 +226,8 @@ fn configured_provider_index(
 use super::completion::{SLASH_COMMANDS, SLASH_GROUPS, SlashGroup};
 use super::mode::{
     Action, ConversationAction, ConversationBlock, ConversationBlockKind, IntentDraft,
-    IntentPickerItem, OutputLine, OutputRenderMode, OutputStyle, PanelInputMode, PanelState,
-    ReplMode, SlashMatch, SlashMenuItem,
+    IntentPickerAction, IntentPickerItem, OutputLine, OutputRenderMode, OutputStyle,
+    PanelInputMode, PanelState, ReplMode, SlashMatch, SlashMenuItem,
 };
 use super::theme::tui as theme;
 
@@ -1167,6 +1167,7 @@ impl ReplApp {
     pub(crate) fn open_intent_picker(
         &mut self,
         intents: Vec<IntentPickerItem>,
+        requested_action: Option<IntentPickerAction>,
         status_msg: Option<(String, OutputStyle)>,
     ) {
         self.clear_slash_menu();
@@ -1178,6 +1179,7 @@ impl ReplApp {
         self.panel = PanelState::IntentPicker {
             intents,
             selected,
+            requested_action,
             status_msg,
         };
     }
@@ -1196,6 +1198,7 @@ impl ReplApp {
         let PanelState::IntentPicker {
             intents,
             mut selected,
+            requested_action,
             ..
         } = self.panel.clone()
         else {
@@ -1214,6 +1217,7 @@ impl ReplApp {
                 self.panel = PanelState::IntentPicker {
                     intents,
                     selected,
+                    requested_action,
                     status_msg: None,
                 };
             }
@@ -1222,22 +1226,29 @@ impl ReplApp {
                 self.panel = PanelState::IntentPicker {
                     intents,
                     selected,
+                    requested_action,
                     status_msg: None,
                 };
             }
             KeyCode::Enter => {
-                self.focused_intent = selected
+                let slug = selected
                     .checked_sub(1)
                     .and_then(|index| intents.get(index))
                     .map(|item| item.slug.clone());
+                self.focused_intent = slug.clone();
                 self.panel = PanelState::None;
                 textarea.move_cursor(CursorMove::Head);
                 textarea.delete_line_by_end();
+                return Action::IntentSelected {
+                    slug,
+                    requested_action,
+                };
             }
             _ => {
                 self.panel = PanelState::IntentPicker {
                     intents,
                     selected,
+                    requested_action,
                     status_msg: None,
                 };
             }
@@ -4385,6 +4396,7 @@ impl ReplApp {
             intents,
             selected,
             status_msg,
+            ..
         } = panel
         else {
             return;
@@ -5751,7 +5763,7 @@ mod tests {
     #[test]
     fn intent_picker_renders_empty_guidance() {
         let (mut app, textarea) = make_app();
-        app.open_intent_picker(Vec::new(), None);
+        app.open_intent_picker(Vec::new(), None, None);
 
         let (rendered, _rows) = render_app_to_string(&app, &textarea, 120, 30);
 
@@ -5771,6 +5783,7 @@ mod tests {
                 test_count: 2,
             }],
             None,
+            None,
         );
         app.handle_key(
             KeyEvent::new(KeyCode::Down, KeyModifiers::NONE),
@@ -5782,7 +5795,13 @@ mod tests {
             &mut textarea,
         );
 
-        assert!(matches!(action, Action::Continue));
+        assert!(matches!(
+            action,
+            Action::IntentSelected {
+                slug: Some(slug),
+                requested_action: None
+            } if slug == "build-calculator"
+        ));
         assert_eq!(app.focused_intent.as_deref(), Some("build-calculator"));
         assert!(matches!(app.panel, PanelState::None));
     }
@@ -5797,6 +5816,7 @@ mod tests {
                 description: "Build calculator".to_string(),
                 test_count: 4,
             }],
+            None,
             None,
         );
 

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -174,6 +174,18 @@ fn truncate_path(path: &str, max_chars: usize) -> String {
     format!("{head}\u{2026}{tail}")
 }
 
+fn truncate_for_width(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    if max_chars <= 3 {
+        return ".".repeat(max_chars);
+    }
+    let mut out: String = value.chars().take(max_chars - 3).collect();
+    out.push_str("...");
+    out
+}
+
 /// Parses a provider kind by wizard list index.
 fn parse_provider_kind_by_index(idx: usize) -> Option<crate::config::ProviderKind> {
     use crate::config::ProviderKind;
@@ -213,8 +225,9 @@ fn configured_provider_index(
 
 use super::completion::{SLASH_COMMANDS, SLASH_GROUPS, SlashGroup};
 use super::mode::{
-    Action, ConversationAction, ConversationBlock, ConversationBlockKind, OutputLine,
-    OutputRenderMode, OutputStyle, PanelInputMode, PanelState, ReplMode, SlashMatch, SlashMenuItem,
+    Action, ConversationAction, ConversationBlock, ConversationBlockKind, IntentDraft,
+    IntentPickerItem, OutputLine, OutputRenderMode, OutputStyle, PanelInputMode, PanelState,
+    ReplMode, SlashMatch, SlashMenuItem,
 };
 use super::theme::tui as theme;
 
@@ -753,6 +766,8 @@ pub struct ReplApp {
     pub mode: ReplMode,
     /// Intent slug that is currently focused, if any.
     pub focused_intent: Option<String>,
+    /// Pending intent creation clarification draft.
+    pub intent_draft: Option<IntentDraft>,
     /// Absolute path to the workspace root.
     pub workspace_root: PathBuf,
     /// Parsed workspace configuration.
@@ -869,6 +884,7 @@ impl ReplApp {
         Self {
             mode: ReplMode::default(),
             focused_intent: None,
+            intent_draft: None,
             workspace_root,
             config,
             system_config,
@@ -967,6 +983,12 @@ impl ReplApp {
         }
         if matches!(self.panel, PanelState::InitWorkspace { .. }) {
             return self.handle_init_panel_key(key);
+        }
+        if matches!(self.panel, PanelState::IntentPicker { .. }) {
+            return self.handle_intent_picker_key(key, textarea);
+        }
+        if matches!(self.panel, PanelState::ConfirmIntentDelete { .. }) {
+            return self.handle_confirm_intent_delete_key(key);
         }
 
         if self.conversation_action_menu.is_some() {
@@ -1117,6 +1139,12 @@ impl ReplApp {
             self.insert_text_into_init_panel(text);
             return;
         }
+        if matches!(
+            self.panel,
+            PanelState::IntentPicker { .. } | PanelState::ConfirmIntentDelete { .. }
+        ) {
+            return;
+        }
 
         textarea.insert_str(text);
         let current = textarea.lines().join("\n");
@@ -1133,6 +1161,106 @@ impl ReplApp {
             confirm_overwrite: false,
             status_msg: None,
         };
+    }
+
+    /// Opens the active intent picker panel.
+    pub(crate) fn open_intent_picker(
+        &mut self,
+        intents: Vec<IntentPickerItem>,
+        status_msg: Option<(String, OutputStyle)>,
+    ) {
+        self.clear_slash_menu();
+        let selected = self
+            .focused_intent
+            .as_deref()
+            .and_then(|slug| intents.iter().position(|item| item.slug == slug))
+            .map_or(0, |index| index + 1);
+        self.panel = PanelState::IntentPicker {
+            intents,
+            selected,
+            status_msg,
+        };
+    }
+
+    /// Opens a confirmation panel before removing an active intent.
+    pub(crate) fn confirm_intent_delete(&mut self, slug: String) {
+        self.clear_slash_menu();
+        self.panel = PanelState::ConfirmIntentDelete { slug };
+    }
+
+    fn handle_intent_picker_key(
+        &mut self,
+        key_event: KeyEvent,
+        textarea: &mut TextArea<'_>,
+    ) -> Action {
+        let PanelState::IntentPicker {
+            intents,
+            mut selected,
+            ..
+        } = self.panel.clone()
+        else {
+            return Action::Continue;
+        };
+        let max = intents.len();
+
+        match key_event.code {
+            KeyCode::Esc => {
+                self.panel = PanelState::None;
+                textarea.move_cursor(CursorMove::Head);
+                textarea.delete_line_by_end();
+            }
+            KeyCode::Up => {
+                selected = selected.saturating_sub(1);
+                self.panel = PanelState::IntentPicker {
+                    intents,
+                    selected,
+                    status_msg: None,
+                };
+            }
+            KeyCode::Down => {
+                selected = (selected + 1).min(max);
+                self.panel = PanelState::IntentPicker {
+                    intents,
+                    selected,
+                    status_msg: None,
+                };
+            }
+            KeyCode::Enter => {
+                self.focused_intent = selected
+                    .checked_sub(1)
+                    .and_then(|index| intents.get(index))
+                    .map(|item| item.slug.clone());
+                self.panel = PanelState::None;
+                textarea.move_cursor(CursorMove::Head);
+                textarea.delete_line_by_end();
+            }
+            _ => {
+                self.panel = PanelState::IntentPicker {
+                    intents,
+                    selected,
+                    status_msg: None,
+                };
+            }
+        }
+        Action::Continue
+    }
+
+    fn handle_confirm_intent_delete_key(&mut self, key_event: KeyEvent) -> Action {
+        let PanelState::ConfirmIntentDelete { slug } = self.panel.clone() else {
+            return Action::Continue;
+        };
+
+        match key_event.code {
+            KeyCode::Char('y' | 'Y') => {
+                self.panel = PanelState::None;
+                Action::IntentDeleteConfirmed { slug }
+            }
+            KeyCode::Esc | KeyCode::Enter | KeyCode::Char('n' | 'N') => {
+                self.panel = PanelState::None;
+                Action::Continue
+            }
+            _ => Action::Continue,
+        }
     }
 
     fn handle_init_panel_key(&mut self, key_event: KeyEvent) -> Action {
@@ -1325,7 +1453,10 @@ impl ReplApp {
                 input_mode,
                 ..
             } => (*selected, input_mode.clone()),
-            PanelState::None | PanelState::InitWorkspace { .. } => return Action::Continue,
+            PanelState::None
+            | PanelState::InitWorkspace { .. }
+            | PanelState::IntentPicker { .. }
+            | PanelState::ConfirmIntentDelete { .. } => return Action::Continue,
         };
         let mut new_status_msg: Option<(String, OutputStyle)> = None;
         let mut action = Action::Continue;
@@ -2730,6 +2861,22 @@ impl ReplApp {
                     self.render_init_panel(frame, overlay_area, &self.panel);
                 }
             }
+            PanelState::IntentPicker { .. } => {
+                if let Some(overlay_height) = self.overlay_height() {
+                    let overlay_width = page.width.saturating_sub(4).clamp(60, 112);
+                    let overlay_area =
+                        Self::centered_overlay_rect(page, overlay_width, overlay_height);
+                    self.render_intent_picker_panel(frame, overlay_area, &self.panel);
+                }
+            }
+            PanelState::ConfirmIntentDelete { .. } => {
+                if let Some(overlay_height) = self.overlay_height() {
+                    let overlay_width = page.width.saturating_sub(4).clamp(52, 90);
+                    let overlay_area =
+                        Self::centered_overlay_rect(page, overlay_width, overlay_height);
+                    self.render_intent_delete_panel(frame, overlay_area, &self.panel);
+                }
+            }
         }
     }
 
@@ -2787,6 +2934,20 @@ impl ReplApp {
             PanelState::InitWorkspace {
                 confirm_overwrite, ..
             } => Some(if *confirm_overwrite { 16 } else { 12 }),
+            PanelState::IntentPicker {
+                intents,
+                status_msg,
+                ..
+            } => {
+                let rows = intents.len().max(1) as u16;
+                let status = u16::from(status_msg.is_some()) * 2;
+                // The panel block has borders plus one row of vertical padding
+                // on each side, so the outer height needs four extra rows.
+                let base_rows = if intents.is_empty() { 7 } else { 7 + rows };
+                let content_rows = base_rows + status;
+                Some((content_rows + 4).min(24))
+            }
+            PanelState::ConfirmIntentDelete { .. } => Some(8),
         }
     }
 
@@ -2897,7 +3058,7 @@ impl ReplApp {
                 "TRY ONE OF THESE",
                 vec![
                     Line::from(vec![
-                        Span::styled("/intent create", theme::brand_word()),
+                        Span::styled("/mode intent", theme::brand_word()),
                         Span::raw("  "),
                         Span::styled(
                             "\"Build a calculator with add and multiply\"",
@@ -3821,7 +3982,7 @@ impl ReplApp {
         let placeholder = match self.mode {
             ReplMode::Query => "e.g. \"what modules exist?\" or /help",
             ReplMode::Agent => "e.g. \"create a module that parses CSV\" or /help",
-            ReplMode::Intent => "e.g. \"plan a calculator module\" or /intent create",
+            ReplMode::Intent => "describe a new intent, refine the active intent, or /intent",
         };
 
         if area.height >= 3 {
@@ -4212,6 +4373,140 @@ impl ReplApp {
                 theme::out_dim(),
             )));
         }
+
+        frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
+    }
+
+    /// Renders the active intent picker panel.
+    fn render_intent_picker_panel(&self, frame: &mut Frame, area: Rect, panel: &PanelState) {
+        use ratatui::widgets::{Block, Borders, Padding};
+
+        let PanelState::IntentPicker {
+            intents,
+            selected,
+            status_msg,
+        } = panel
+        else {
+            return;
+        };
+
+        frame.render_widget(Clear, area);
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(theme::panel_border())
+            .padding(Padding::new(1, 1, 1, 1))
+            .style(theme::panel_surface());
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        let inner_width = inner.width as usize;
+        let mut lines: Vec<Line<'_>> = Vec::new();
+        lines.push(Line::from(vec![
+            Span::styled("  Active Intents", theme::brand_word()),
+            Span::raw(" ".repeat(inner_width.saturating_sub(42))),
+            Span::styled("(Esc to close)", theme::out_dim()),
+        ]));
+        lines.push(Line::from(""));
+
+        let clear_style = if *selected == 0 {
+            theme::slash_selected()
+        } else {
+            theme::out_dim()
+        };
+        let clear_marker = if *selected == 0 { "\u{25cf}" } else { " " };
+        lines.push(Line::from(Span::styled(
+            format!("  {clear_marker} No active intent / new intent mode"),
+            clear_style,
+        )));
+
+        if intents.is_empty() {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "  No unfinished intents. Switch to Intent mode and describe what to build.",
+                theme::out_dim(),
+            )));
+        } else {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                format!(
+                    "  {:<28} {:<12} {:<6} {}",
+                    "Slug", "Status", "Tests", "Description"
+                ),
+                theme::out_dim(),
+            )));
+            for (index, item) in intents.iter().enumerate() {
+                let row = index + 1;
+                let is_selected = *selected == row;
+                let marker = if is_selected { "\u{25cf}" } else { " " };
+                let style = if is_selected {
+                    theme::slash_selected()
+                } else {
+                    theme::out_dim()
+                };
+                let description = truncate_for_width(&item.description, 44);
+                lines.push(Line::from(Span::styled(
+                    format!(
+                        "  {marker} {:<28} {:<12} {:<6} {}",
+                        truncate_for_width(&item.slug, 28),
+                        item.status,
+                        item.test_count,
+                        description
+                    ),
+                    style,
+                )));
+            }
+        }
+
+        if let Some((msg, style)) = status_msg {
+            let status_style = match style {
+                OutputStyle::Success => theme::out_success(),
+                OutputStyle::Error => theme::out_error(),
+                _ => theme::out_dim(),
+            };
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(format!("  {msg}"), status_style)));
+        }
+
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "  [\u{2191}/\u{2193}] Select  [Enter] Activate  [Esc] Close",
+            theme::out_dim(),
+        )));
+
+        frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
+    }
+
+    /// Renders the active intent delete confirmation panel.
+    fn render_intent_delete_panel(&self, frame: &mut Frame, area: Rect, panel: &PanelState) {
+        use ratatui::widgets::{Block, Borders, Padding};
+
+        let PanelState::ConfirmIntentDelete { slug } = panel else {
+            return;
+        };
+
+        frame.render_widget(Clear, area);
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(theme::panel_border())
+            .padding(Padding::new(1, 1, 1, 1))
+            .style(theme::panel_surface());
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        let lines = vec![
+            Line::from(Span::styled("  Delete Intent", theme::brand_word())),
+            Line::from(""),
+            Line::from(Span::styled(
+                format!("  Remove '{slug}' from active work?"),
+                theme::out_error(),
+            )),
+            Line::from(Span::styled(
+                "  The YAML will be moved to .duumbi/intents/deleted/.",
+                theme::out_dim(),
+            )),
+            Line::from(""),
+            Line::from(Span::styled("  Confirm? [y/N]", theme::out_dim())),
+        ];
 
         frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
     }
@@ -4790,7 +5085,7 @@ mod tests {
 
         assert!(rendered.contains(" empty workspace "));
         assert!(rendered.contains("TRY ONE OF THESE"));
-        assert!(rendered.contains("/intent create"));
+        assert!(rendered.contains("/mode intent"));
         assert!(rendered.contains("\"Build a calculator with add and multiply\""));
         assert!(!rendered.contains("Use the prompt"));
 
@@ -5430,7 +5725,7 @@ mod tests {
 
         assert!(rendered.contains("FILTER"));
         assert!(rendered.contains("/intent"));
-        assert!(rendered.contains("/intent create"));
+        assert!(rendered.contains("/intent review"));
         assert!(rendered.contains("/init"));
     }
 
@@ -5451,6 +5746,88 @@ mod tests {
         app.slash_selected = 1;
         let action = app.handle_key(enter, &mut textarea);
         assert!(matches!(action, Action::Submit(cmd) if cmd == "/build"));
+    }
+
+    #[test]
+    fn intent_picker_renders_empty_guidance() {
+        let (mut app, textarea) = make_app();
+        app.open_intent_picker(Vec::new(), None);
+
+        let (rendered, _rows) = render_app_to_string(&app, &textarea, 120, 30);
+
+        assert!(rendered.contains("Active Intents"));
+        assert!(rendered.contains("No active intent / new intent mode"));
+        assert!(rendered.contains("No unfinished intents"));
+    }
+
+    #[test]
+    fn intent_picker_enter_selects_intent() {
+        let (mut app, mut textarea) = make_app();
+        app.open_intent_picker(
+            vec![IntentPickerItem {
+                slug: "build-calculator".to_string(),
+                status: "pending".to_string(),
+                description: "Build calculator".to_string(),
+                test_count: 2,
+            }],
+            None,
+        );
+        app.handle_key(
+            KeyEvent::new(KeyCode::Down, KeyModifiers::NONE),
+            &mut textarea,
+        );
+
+        let action = app.handle_key(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            &mut textarea,
+        );
+
+        assert!(matches!(action, Action::Continue));
+        assert_eq!(app.focused_intent.as_deref(), Some("build-calculator"));
+        assert!(matches!(app.panel, PanelState::None));
+    }
+
+    #[test]
+    fn intent_picker_renders_first_intent_row() {
+        let (mut app, textarea) = make_app();
+        app.open_intent_picker(
+            vec![IntentPickerItem {
+                slug: "build-calculator".to_string(),
+                status: "pending".to_string(),
+                description: "Build calculator".to_string(),
+                test_count: 4,
+            }],
+            None,
+        );
+
+        let (rendered, _rows) = render_app_to_string(&app, &textarea, 120, 30);
+
+        assert!(rendered.contains("build-calculator"));
+        assert!(rendered.contains("pending"));
+        assert!(rendered.contains("Build calculator"));
+    }
+
+    #[test]
+    fn intent_delete_confirmation_requires_yes() {
+        let (mut app, mut textarea) = make_app();
+        app.confirm_intent_delete("build-calculator".to_string());
+
+        let action = app.handle_key(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            &mut textarea,
+        );
+        assert!(matches!(action, Action::Continue));
+        assert!(matches!(app.panel, PanelState::None));
+
+        app.confirm_intent_delete("build-calculator".to_string());
+        let action = app.handle_key(
+            KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE),
+            &mut textarea,
+        );
+        assert!(matches!(
+            action,
+            Action::IntentDeleteConfirmed { slug } if slug == "build-calculator"
+        ));
     }
 
     #[test]

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -89,37 +89,27 @@ pub const SLASH_COMMANDS: &[SlashCommand] = &[
     },
     SlashCommand {
         command: "/intent",
-        description: "Manage intent specs",
-        group: SlashGroup::Intent,
-    },
-    SlashCommand {
-        command: "/intent create",
-        description: "Generate a new intent spec",
+        description: "Select or clear the active intent",
         group: SlashGroup::Intent,
     },
     SlashCommand {
         command: "/intent review",
-        description: "Show intent details",
+        description: "Review the active intent",
         group: SlashGroup::Intent,
     },
     SlashCommand {
         command: "/intent execute",
-        description: "Execute an intent end-to-end",
+        description: "Execute the active intent",
         group: SlashGroup::Intent,
     },
     SlashCommand {
-        command: "/intent status",
-        description: "Show intent status",
+        command: "/intent edit",
+        description: "Edit the active intent YAML",
         group: SlashGroup::Intent,
     },
     SlashCommand {
-        command: "/intent focus",
-        description: "Focus an intent by slug",
-        group: SlashGroup::Intent,
-    },
-    SlashCommand {
-        command: "/intent unfocus",
-        description: "Clear the focused intent",
+        command: "/intent delete",
+        description: "Remove the active intent from active work",
         group: SlashGroup::Intent,
     },
     SlashCommand {
@@ -338,21 +328,31 @@ mod tests {
     #[test]
     fn intent_subcommands_found() {
         let results = match_commands("/intent ", 10);
-        assert!(results.iter().any(|(cmd, _)| *cmd == "/intent create"));
+        assert!(results.iter().any(|(cmd, _)| *cmd == "/intent review"));
+        assert!(results.iter().any(|(cmd, _)| *cmd == "/intent edit"));
+        assert!(!results.iter().any(|(cmd, _)| *cmd == "/intent create"));
     }
 
     #[test]
-    fn slash_commands_has_new_intent_commands() {
+    fn slash_commands_has_tui_intent_commands_only() {
         assert!(
             SLASH_COMMANDS
                 .iter()
-                .any(|entry| entry.command == "/intent focus")
+                .any(|entry| entry.command == "/intent")
         );
         assert!(
             SLASH_COMMANDS
                 .iter()
-                .any(|entry| entry.command == "/intent unfocus")
+                .any(|entry| entry.command == "/intent delete")
         );
+        for removed in [
+            "/intent create",
+            "/intent status",
+            "/intent focus",
+            "/intent unfocus",
+        ] {
+            assert!(!SLASH_COMMANDS.iter().any(|entry| entry.command == removed));
+        }
     }
 
     #[test]

--- a/src/cli/mode.rs
+++ b/src/cli/mode.rs
@@ -137,7 +137,7 @@ impl ConversationBlock {
 /// A slash command match for the inline menu.
 #[derive(Debug, Clone)]
 pub struct SlashMatch {
-    /// Full command string (e.g. "/intent create").
+    /// Full command string (e.g. "/intent review").
     pub command: String,
     /// Description text.
     pub description: String,
@@ -188,6 +188,11 @@ pub enum Action {
         /// Whether an existing `.duumbi/` directory may be deleted first.
         overwrite_existing: bool,
     },
+    /// Delete the active intent after confirmation.
+    IntentDeleteConfirmed {
+        /// Intent slug to remove from active work.
+        slug: String,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -223,6 +228,20 @@ pub enum PanelState {
         /// Optional status message shown in the panel.
         status_msg: Option<(String, OutputStyle)>,
     },
+    /// Active intent picker.
+    IntentPicker {
+        /// Loaded active intent rows. Row zero in the UI is always "new intent mode".
+        intents: Vec<IntentPickerItem>,
+        /// Highlighted row, including row zero.
+        selected: usize,
+        /// Optional status message shown in the panel.
+        status_msg: Option<(String, OutputStyle)>,
+    },
+    /// Confirmation panel for removing an active intent from the active list.
+    ConfirmIntentDelete {
+        /// Intent slug being deleted.
+        slug: String,
+    },
 }
 
 /// Sub-mode within an interactive panel for text input or confirmation.
@@ -247,6 +266,28 @@ pub enum PanelInputMode {
     },
     /// Waiting for y/N confirmation to delete the selected provider.
     ConfirmDelete,
+}
+
+/// One active intent row shown by the TUI intent picker.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntentPickerItem {
+    /// Intent slug.
+    pub slug: String,
+    /// Lifecycle status text.
+    pub status: String,
+    /// Short natural-language intent description.
+    pub description: String,
+    /// Number of test cases attached to the intent.
+    pub test_count: usize,
+}
+
+/// Pending TUI intent creation clarification state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntentDraft {
+    /// Original user request before clarification.
+    pub original_request: String,
+    /// Questions asked by the planner model.
+    pub questions: Vec<String>,
 }
 
 #[cfg(test)]

--- a/src/cli/mode.rs
+++ b/src/cli/mode.rs
@@ -193,6 +193,13 @@ pub enum Action {
         /// Intent slug to remove from active work.
         slug: String,
     },
+    /// Intent picker selected or cleared the active intent.
+    IntentSelected {
+        /// Selected intent slug, or none when the "new intent mode" row was selected.
+        slug: Option<String>,
+        /// Action requested before opening the picker.
+        requested_action: Option<IntentPickerAction>,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -234,6 +241,8 @@ pub enum PanelState {
         intents: Vec<IntentPickerItem>,
         /// Highlighted row, including row zero.
         selected: usize,
+        /// Action to run after a real intent row is selected.
+        requested_action: Option<IntentPickerAction>,
         /// Optional status message shown in the panel.
         status_msg: Option<(String, OutputStyle)>,
     },
@@ -279,6 +288,19 @@ pub struct IntentPickerItem {
     pub description: String,
     /// Number of test cases attached to the intent.
     pub test_count: usize,
+}
+
+/// Intent action requested before opening the picker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IntentPickerAction {
+    /// Review the selected intent.
+    Review,
+    /// Execute the selected intent.
+    Execute,
+    /// Edit the selected intent YAML.
+    Edit,
+    /// Delete the selected intent from the active list.
+    Delete,
 }
 
 /// Pending TUI intent creation clarification state.

--- a/src/cli/publish.rs
+++ b/src/cli/publish.rs
@@ -279,6 +279,7 @@ mod tests {
             vendor: None,
             cost: None,
             agent: None,
+            editor: None,
             mcp_clients: HashMap::new(),
         }
     }

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use std::process;
 use std::time::SystemTime;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use chrono::{DateTime, Local, Utc};
 use crossterm::event::{self, DisableBracketedPaste, EnableBracketedPaste, Event};
 use crossterm::execute;
@@ -39,6 +39,35 @@ const ENABLE_BALANCED_MOUSE_REPORTING: &str = "\x1b[?1000h\x1b[?1002h\x1b[?1006h
 const DISABLE_ALL_MOUSE_REPORTING: &str = "\x1b[?1006l\x1b[?1015l\x1b[?1003l\x1b[?1002l\x1b[?1000l";
 const NO_INTENT_SELECTED_MESSAGE: &str =
     "No intent selected. Describe the new intent you want to create.";
+
+/// Resolves the workspace root used by the interactive TUI.
+///
+/// If the current directory is already a DUUMBI workspace, it is used as-is.
+/// Otherwise, when there is exactly one direct child workspace, attach to that
+/// child. This matches the common `duumbi init myproject` flow followed by
+/// launching `duumbi` from the parent directory.
+#[must_use]
+pub fn resolve_repl_workspace_root(start: &Path) -> PathBuf {
+    if start.join(".duumbi").exists() {
+        return start.to_path_buf();
+    }
+
+    let Ok(entries) = fs::read_dir(start) else {
+        return start.to_path_buf();
+    };
+    let mut candidates = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.is_dir() && path.join(".duumbi").exists())
+        .collect::<Vec<_>>();
+    candidates.sort();
+
+    if candidates.len() == 1 {
+        candidates.remove(0)
+    } else {
+        start.to_path_buf()
+    }
+}
 
 struct PendingProviderProbe {
     provider: crate::config::ProviderKind,
@@ -253,6 +282,10 @@ async fn event_loop(
                         overwrite_existing,
                     } => {
                         complete_tui_init(app, workspace_name, overwrite_existing);
+                        should_redraw = true;
+                    }
+                    super::mode::Action::IntentDeleteConfirmed { slug } => {
+                        handle_confirmed_intent_delete(app, &slug);
                         should_redraw = true;
                     }
                 },
@@ -876,7 +909,7 @@ fn push_handoff(app: &mut ReplApp, handoff: &ModeHandoff) {
     let prefix = match handoff.mode {
         ReplMode::Query => "/query",
         ReplMode::Agent => "/agent",
-        ReplMode::Intent => "/intent create",
+        ReplMode::Intent => "/mode intent",
     };
     app.push_output(
         format!("{prefix} {}", handoff.suggested_request),
@@ -1089,8 +1122,9 @@ async fn handle_ai_request(
 /// Handles free-form text input when in Intent mode.
 ///
 /// - If no intent is focused, the input is treated as an intent description
-///   and forwarded to [`intent::create::run_create`].
-/// - If the input is "execute" or "run", delegates to intent execute.
+///   and starts the TUI clarification/create flow.
+/// - If the input is "review", "execute", "run", "edit", or "delete",
+///   delegates to the active intent action.
 /// - Otherwise, modifies the focused intent via LLM based on the input.
 async fn handle_intent_input(
     terminal: &mut ratatui::DefaultTerminal,
@@ -1099,54 +1133,51 @@ async fn handle_intent_input(
     input: &str,
 ) {
     let trimmed = input.trim();
+    if let Some(draft) = app.intent_draft.take() {
+        handle_intent_draft_answer(terminal, app, textarea, draft, trimmed).await;
+        return;
+    }
+
     if app.focused_intent.is_none() {
-        if is_intent_execute_alias(trimmed) {
+        if intent_prompt_action(trimmed).is_some() {
             push_no_intent_selected(app);
             return;
         }
 
-        // Treat as intent create.
-        let context = intent_create_model_context(trimmed);
-        let Some(client) = select_client_for_context(app, &context) else {
-            app.push_output(
-                "AI not available — use /provider in the REPL or `duumbi provider add ...` to configure a provider.",
-                OutputStyle::Error,
-            );
-            return;
-        };
-        let workspace = app.workspace_root.clone();
-        let mut log = Vec::new();
-        let pending_label =
-            pending_agent_label(AgentRole::Planner, client.as_ref(), "is creating an intent");
-        let result = run_with_pending_status(terminal, app, textarea, &pending_label, async {
-            // REPL always auto-confirms — interactive stdin is not available
-            // in ratatui raw mode.
-            intent::create::run_create(client.as_ref(), &workspace, trimmed, true, &mut log).await
-        })
-        .await;
-        for line in &log {
-            app.push_output(line, OutputStyle::Dim);
-        }
-        match result {
-            Ok(slug) => {
-                app.focused_intent = Some(slug.clone());
-            }
-            Err(e) => {
-                app.push_output(format!("Error: {e:#}"), OutputStyle::Error);
-            }
-        }
+        handle_tui_intent_create(terminal, app, textarea, trimmed).await;
         return;
     }
 
-    match trimmed {
-        value if is_intent_execute_alias(value) => {
+    match intent_prompt_action(trimmed) {
+        Some(IntentPromptAction::Review) => {
+            let slug = app
+                .focused_intent
+                .clone()
+                .expect("invariant: focused_intent checked above");
+            handle_intent_review(app, &slug);
+        }
+        Some(IntentPromptAction::Execute) => {
             let slug = app
                 .focused_intent
                 .clone()
                 .expect("invariant: focused_intent checked above");
             handle_intent_execute(terminal, app, textarea, &slug).await;
         }
-        _ => {
+        Some(IntentPromptAction::Edit) => {
+            let slug = app
+                .focused_intent
+                .clone()
+                .expect("invariant: focused_intent checked above");
+            handle_intent_edit(terminal, app, textarea, &slug);
+        }
+        Some(IntentPromptAction::Delete) => {
+            let slug = app
+                .focused_intent
+                .clone()
+                .expect("invariant: focused_intent checked above");
+            app.confirm_intent_delete(slug);
+        }
+        None => {
             // Modify the focused intent via LLM.
             let slug = app
                 .focused_intent
@@ -1183,8 +1214,11 @@ async fn handle_intent_input(
             match result {
                 Ok(modified) => {
                     // Show the modified spec.
-                    let yaml = serde_yaml::to_string(&modified).unwrap_or_default();
-                    app.push_output(yaml, OutputStyle::Ai);
+                    let mut log = Vec::new();
+                    intent::review::format_spec_detail(&slug, &modified, &mut log);
+                    for line in log {
+                        app.push_output(line, OutputStyle::Normal);
+                    }
 
                     // Save (auto-save in intent mode for now).
                     match intent::save_intent(&workspace, &slug, &modified) {
@@ -1213,8 +1247,7 @@ async fn handle_intent_input(
 
 /// Handles `/intent <subcommand> [args]` within the REPL.
 ///
-/// Supported subcommands: `list`, `create`, `review`, `execute`, `status`,
-/// `focus`, `unfocus`.
+/// Supported TUI subcommands: `review`, `execute`, `edit`, `delete`.
 async fn handle_intent_slash(
     terminal: &mut ratatui::DefaultTerminal,
     app: &mut ReplApp,
@@ -1227,135 +1260,337 @@ async fn handle_intent_slash(
 
     match subcmd {
         "" | "list" => {
-            let workspace = app.workspace_root.clone();
-            match collect_intent_list(&workspace) {
-                Ok(lines) => {
-                    for line in lines {
-                        app.push_output(line, OutputStyle::Normal);
-                    }
-                }
-                Err(e) => {
-                    app.push_output(format!("Error: {e}"), OutputStyle::Error);
-                }
-            }
+            open_intent_picker(app, None);
         }
 
         "create" => {
-            if rest.is_empty() {
-                app.push_output("Usage: /intent create <description>", OutputStyle::Dim);
-                return;
-            }
-            let context = intent_create_model_context(rest);
-            let Some(client) = select_client_for_context(app, &context) else {
+            app.push_output(
+                "In the TUI, switch to Intent mode and describe the new intent in the prompt.",
+                OutputStyle::Dim,
+            );
+            if !rest.is_empty() {
                 app.push_output(
-                    "AI not available — use /provider in the REPL or `duumbi provider add ...` to configure a provider.",
-                    OutputStyle::Error,
+                    format!("Suggested intent description: {rest}"),
+                    OutputStyle::Dim,
                 );
-                return;
-            };
-            let workspace = app.workspace_root.clone();
-            let mut log = Vec::new();
-            let pending_label =
-                pending_agent_label(AgentRole::Planner, client.as_ref(), "is creating an intent");
-            let result = run_with_pending_status(terminal, app, textarea, &pending_label, async {
-                // REPL always auto-confirms (no interactive stdin in ratatui).
-                intent::create::run_create(client.as_ref(), &workspace, rest, true, &mut log).await
-            })
-            .await;
-            for line in &log {
-                app.push_output(line, OutputStyle::Dim);
-            }
-            if let Err(e) = result {
-                app.push_output(format!("Error: {e:#}"), OutputStyle::Error);
             }
         }
 
         "review" => {
-            let workspace = app.workspace_root.clone();
-            if rest.is_empty() {
-                match collect_intent_list(&workspace) {
-                    Ok(lines) => {
-                        for line in lines {
-                            app.push_output(line, OutputStyle::Normal);
-                        }
-                    }
-                    Err(e) => {
-                        app.push_output(format!("Error: {e}"), OutputStyle::Error);
-                    }
-                }
+            if let Some(slug) = active_intent_slug(app) {
+                handle_intent_review(app, &slug);
             } else {
-                match collect_intent_detail(&workspace, rest) {
-                    Ok(lines) => {
-                        for line in lines {
-                            app.push_output(line, OutputStyle::Normal);
-                        }
-                    }
-                    Err(e) => {
-                        app.push_output(format!("Error: {e}"), OutputStyle::Error);
-                    }
-                }
+                open_intent_picker(
+                    app,
+                    Some(("Select an intent to review.".to_string(), OutputStyle::Dim)),
+                );
             }
         }
 
         "execute" => {
-            if rest.is_empty() {
-                app.push_output("Usage: /intent execute <name>", OutputStyle::Dim);
-                return;
-            }
-            handle_intent_execute(terminal, app, textarea, rest).await;
-        }
-
-        "status" => {
-            let workspace = app.workspace_root.clone();
-            if rest.is_empty() {
-                match collect_intent_status_list(&workspace) {
-                    Ok(lines) => {
-                        for line in lines {
-                            app.push_output(line, OutputStyle::Normal);
-                        }
-                    }
-                    Err(e) => {
-                        app.push_output(format!("Error: {e}"), OutputStyle::Error);
-                    }
-                }
+            if let Some(slug) = active_intent_slug(app) {
+                handle_intent_execute(terminal, app, textarea, &slug).await;
             } else {
-                match collect_intent_status_detail(&workspace, rest) {
-                    Ok(lines) => {
-                        for line in lines {
-                            app.push_output(line, OutputStyle::Normal);
-                        }
-                    }
-                    Err(e) => {
-                        app.push_output(format!("Error: {e}"), OutputStyle::Error);
-                    }
-                }
+                open_intent_picker(
+                    app,
+                    Some(("Select an intent to execute.".to_string(), OutputStyle::Dim)),
+                );
             }
         }
 
-        "focus" => {
-            if rest.is_empty() {
-                app.push_output("Usage: /intent focus <slug>", OutputStyle::Dim);
+        "edit" => {
+            if let Some(slug) = active_intent_slug(app) {
+                handle_intent_edit(terminal, app, textarea, &slug);
             } else {
-                app.focused_intent = Some(rest.to_string());
-                app.push_output(format!("Focused intent: {rest}"), OutputStyle::Success);
+                open_intent_picker(
+                    app,
+                    Some(("Select an intent to edit.".to_string(), OutputStyle::Dim)),
+                );
             }
         }
 
-        "unfocus" => {
-            app.focused_intent = None;
-            app.push_output("Intent focus cleared.", OutputStyle::Dim);
+        "delete" => {
+            if let Some(slug) = active_intent_slug(app) {
+                app.confirm_intent_delete(slug);
+            } else {
+                open_intent_picker(
+                    app,
+                    Some(("Select an intent to delete.".to_string(), OutputStyle::Dim)),
+                );
+            }
         }
 
+        "status" | "focus" | "unfocus" => {
+            app.push_output(
+                "This TUI command is no longer used. Use /intent to switch the active intent.",
+                OutputStyle::Dim,
+            );
+        }
         _ => {
             app.push_output(
                 format!("Unknown intent subcommand: {subcmd}"),
                 OutputStyle::Error,
             );
             app.push_output(
-                "Available: list, create <desc>, review [name], execute <name>, \
-                 status [name], focus <slug>, unfocus",
+                "Available: /intent, /intent review, /intent execute, /intent edit, /intent delete",
                 OutputStyle::Dim,
             );
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IntentPromptAction {
+    Review,
+    Execute,
+    Edit,
+    Delete,
+}
+
+fn intent_prompt_action(input: &str) -> Option<IntentPromptAction> {
+    match input.trim() {
+        "review" => Some(IntentPromptAction::Review),
+        value if is_intent_execute_alias(value) => Some(IntentPromptAction::Execute),
+        "edit" => Some(IntentPromptAction::Edit),
+        "delete" | "remove" => Some(IntentPromptAction::Delete),
+        _ => None,
+    }
+}
+
+fn active_intent_slug(app: &ReplApp) -> Option<String> {
+    app.focused_intent.clone()
+}
+
+fn open_intent_picker(app: &mut ReplApp, status_msg: Option<(String, OutputStyle)>) {
+    match collect_intent_picker_items(&app.workspace_root) {
+        Ok(items) => app.open_intent_picker(items, status_msg),
+        Err(e) => app.push_output(format!("Failed to load intents: {e}"), OutputStyle::Error),
+    }
+}
+
+fn collect_intent_picker_items(workspace: &Path) -> Result<Vec<super::mode::IntentPickerItem>> {
+    let slugs = intent::list_intents(workspace).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let mut items = Vec::new();
+    for slug in slugs {
+        match intent::load_intent(workspace, &slug) {
+            Ok(spec) => items.push(super::mode::IntentPickerItem {
+                slug,
+                status: spec.status.to_string(),
+                description: spec.intent,
+                test_count: spec.test_cases.len(),
+            }),
+            Err(e) => items.push(super::mode::IntentPickerItem {
+                slug,
+                status: "error".to_string(),
+                description: e.to_string(),
+                test_count: 0,
+            }),
+        }
+    }
+    Ok(items)
+}
+
+fn handle_intent_review(app: &mut ReplApp, slug: &str) {
+    match intent::load_intent(&app.workspace_root, slug) {
+        Ok(spec) => {
+            let mut log = Vec::new();
+            intent::review::format_spec_detail(slug, &spec, &mut log);
+            for line in log {
+                app.push_output(line, OutputStyle::Normal);
+            }
+        }
+        Err(e) => {
+            if matches!(e, intent::IntentError::NotFound { .. }) {
+                clear_focused_intent_if_matches(app, slug);
+                push_no_intent_selected(app);
+            } else {
+                app.push_output(format!("Failed to load intent: {e}"), OutputStyle::Error);
+            }
+        }
+    }
+}
+
+fn handle_intent_edit(
+    terminal: &mut ratatui::DefaultTerminal,
+    app: &mut ReplApp,
+    textarea: &mut TextArea<'_>,
+    slug: &str,
+) {
+    let workspace = app.workspace_root.clone();
+    let editor = app.config.editor.clone();
+    let result = run_with_terminal_restore(terminal, app, textarea, || {
+        intent::review::edit_intent_with_editor(&workspace, slug, editor.as_deref())
+    });
+    match result {
+        Ok(()) => {
+            app.push_output(
+                format!("Intent '{slug}' saved and validated."),
+                OutputStyle::Success,
+            );
+            handle_intent_review(app, slug);
+        }
+        Err(e) => app.push_output(format!("Intent edit failed: {e}"), OutputStyle::Error),
+    }
+}
+
+fn handle_confirmed_intent_delete(app: &mut ReplApp, slug: &str) {
+    match intent::delete_intent(&app.workspace_root, slug) {
+        Ok(path) => {
+            clear_focused_intent_if_matches(app, slug);
+            app.push_output(
+                format!("Intent '{slug}' moved to '{}'.", path.display()),
+                OutputStyle::Success,
+            );
+        }
+        Err(e) => {
+            if matches!(e, intent::IntentError::NotFound { .. }) {
+                clear_focused_intent_if_matches(app, slug);
+                push_no_intent_selected(app);
+            } else {
+                app.push_output(format!("Intent delete failed: {e}"), OutputStyle::Error);
+            }
+        }
+    }
+}
+
+async fn handle_tui_intent_create(
+    terminal: &mut ratatui::DefaultTerminal,
+    app: &mut ReplApp,
+    textarea: &mut TextArea<'_>,
+    description: &str,
+) {
+    let context = intent_create_model_context(description);
+    let Some(client) = select_client_for_context(app, &context) else {
+        app.push_output(
+            "AI not available — use /provider in the REPL or `duumbi provider add ...` to configure a provider.",
+            OutputStyle::Error,
+        );
+        return;
+    };
+    let workspace = app.workspace_root.clone();
+    let pending_label = pending_agent_label(
+        AgentRole::Planner,
+        client.as_ref(),
+        "is clarifying the intent",
+    );
+    let plan = run_with_pending_status(terminal, app, textarea, &pending_label, async {
+        intent::create::plan_tui_create(client.as_ref(), &workspace, description).await
+    })
+    .await;
+
+    match plan {
+        Ok(intent::create::TuiIntentCreatePlan::NeedsClarification { questions }) => {
+            app.intent_draft = Some(super::mode::IntentDraft {
+                original_request: description.to_string(),
+                questions: questions.clone(),
+            });
+            app.push_output(
+                "Clarification needed before creating the intent:",
+                OutputStyle::Normal,
+            );
+            for (index, question) in questions.iter().enumerate() {
+                app.push_output(format!("  {}. {question}", index + 1), OutputStyle::Normal);
+            }
+        }
+        Ok(intent::create::TuiIntentCreatePlan::Ready {
+            description,
+            context,
+        }) => {
+            handle_tui_intent_create_ready(terminal, app, textarea, &description, context).await;
+        }
+        Err(e) => app.push_output(
+            format!("Intent clarification failed: {e:#}"),
+            OutputStyle::Error,
+        ),
+    }
+}
+
+async fn handle_intent_draft_answer(
+    terminal: &mut ratatui::DefaultTerminal,
+    app: &mut ReplApp,
+    textarea: &mut TextArea<'_>,
+    draft: super::mode::IntentDraft,
+    answer: &str,
+) {
+    if matches!(answer.trim(), "cancel" | "abort") {
+        app.push_output("Intent creation cancelled.", OutputStyle::Dim);
+        return;
+    }
+
+    let mut context = crate::intent::spec::IntentContext {
+        clarification_log: vec![format!("Original request: {}", draft.original_request)],
+        ..crate::intent::spec::IntentContext::default()
+    };
+    for (index, question) in draft.questions.iter().enumerate() {
+        context
+            .clarification_log
+            .push(format!("Question {}: {question}", index + 1));
+    }
+    context.clarification_log.push(format!("Answer: {answer}"));
+
+    let clarified_description = format!(
+        "{}\n\nClarification questions:\n{}\n\nUser clarification answer:\n{}",
+        draft.original_request,
+        draft
+            .questions
+            .iter()
+            .enumerate()
+            .map(|(index, question)| format!("{}. {question}", index + 1))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        answer
+    );
+    handle_tui_intent_create_ready(
+        terminal,
+        app,
+        textarea,
+        &clarified_description,
+        Some(context),
+    )
+    .await;
+}
+
+async fn handle_tui_intent_create_ready(
+    terminal: &mut ratatui::DefaultTerminal,
+    app: &mut ReplApp,
+    textarea: &mut TextArea<'_>,
+    description: &str,
+    context: Option<crate::intent::spec::IntentContext>,
+) {
+    let model_context = intent_create_model_context(description);
+    let Some(client) = select_client_for_context(app, &model_context) else {
+        app.push_output(
+            "AI not available — use /provider in the REPL or `duumbi provider add ...` to configure a provider.",
+            OutputStyle::Error,
+        );
+        return;
+    };
+    let workspace = app.workspace_root.clone();
+    let mut log = Vec::new();
+    let pending_label =
+        pending_agent_label(AgentRole::Planner, client.as_ref(), "is creating an intent");
+    let result = run_with_pending_status(terminal, app, textarea, &pending_label, async {
+        intent::create::run_create_with_context(
+            client.as_ref(),
+            &workspace,
+            description,
+            context,
+            true,
+            &mut log,
+        )
+        .await
+    })
+    .await;
+    for line in &log {
+        app.push_output(line, OutputStyle::Normal);
+    }
+    match result {
+        Ok(slug) => {
+            app.focused_intent = Some(slug.clone());
+            app.push_output(format!("Active intent: {slug}"), OutputStyle::Success);
+        }
+        Err(e) => {
+            app.push_output(format!("Error: {e:#}"), OutputStyle::Error);
         }
     }
 }
@@ -1438,67 +1673,6 @@ fn is_missing_intent_error(error: &anyhow::Error, slug: &str) -> bool {
 
     let rendered = format!("{error:#}");
     rendered.contains(&format!("Intent '{slug}' not found in .duumbi/intents/"))
-}
-
-// ---------------------------------------------------------------------------
-// Intent output helpers (capture-to-string wrappers)
-// ---------------------------------------------------------------------------
-
-/// Captures [`intent::review::print_intent_list`] output as lines.
-fn collect_intent_list(workspace: &Path) -> Result<Vec<String>> {
-    // The underlying function prints to stderr; we can't easily redirect it.
-    // Instead, re-implement a lightweight version that returns strings.
-    let intents_dir = workspace.join(".duumbi/intents");
-    let mut lines = Vec::new();
-    if !intents_dir.exists() {
-        lines.push("No active intents.".to_string());
-        return Ok(lines);
-    }
-    let entries: Vec<_> = std::fs::read_dir(&intents_dir)
-        .context("read intents dir")?
-        .flatten()
-        .filter(|e| {
-            e.path()
-                .extension()
-                .is_some_and(|ext| ext == "yaml" || ext == "yml")
-        })
-        .collect();
-    if entries.is_empty() {
-        lines.push("No active intents.".to_string());
-    } else {
-        lines.push(format!("Active intents ({}):", entries.len()));
-        for entry in &entries {
-            let name = entry
-                .path()
-                .file_stem()
-                .map(|s| s.to_string_lossy().to_string())
-                .unwrap_or_default();
-            lines.push(format!("  {name}"));
-        }
-    }
-    Ok(lines)
-}
-
-/// Captures [`intent::review::print_intent_detail`] output as lines.
-fn collect_intent_detail(workspace: &Path, name: &str) -> Result<Vec<String>> {
-    let path = workspace.join(format!(".duumbi/intents/{name}.yaml"));
-    if !path.exists() {
-        anyhow::bail!("Intent '{name}' not found.");
-    }
-    let content =
-        std::fs::read_to_string(&path).with_context(|| format!("reading intent '{name}'"))?;
-    Ok(content.lines().map(|l| l.to_string()).collect())
-}
-
-/// Captures intent status list as lines.
-fn collect_intent_status_list(workspace: &Path) -> Result<Vec<String>> {
-    // Delegate to the list for now — status details live in the YAML.
-    collect_intent_list(workspace)
-}
-
-/// Captures intent status detail as lines.
-fn collect_intent_status_detail(workspace: &Path, name: &str) -> Result<Vec<String>> {
-    collect_intent_detail(workspace, name)
 }
 
 // ---------------------------------------------------------------------------
@@ -2582,6 +2756,39 @@ mod tests {
         }
     }
 
+    #[test]
+    fn repl_workspace_root_uses_current_workspace_first() {
+        let dir = TempDir::new().expect("tempdir");
+        fs::create_dir_all(dir.path().join(".duumbi")).expect("workspace");
+        fs::create_dir_all(dir.path().join("child/.duumbi")).expect("child workspace");
+
+        let resolved = resolve_repl_workspace_root(dir.path());
+
+        assert_eq!(resolved, dir.path());
+    }
+
+    #[test]
+    fn repl_workspace_root_uses_single_direct_child_workspace() {
+        let dir = TempDir::new().expect("tempdir");
+        let child = dir.path().join("myproject");
+        fs::create_dir_all(child.join(".duumbi/intents")).expect("child workspace");
+
+        let resolved = resolve_repl_workspace_root(dir.path());
+
+        assert_eq!(resolved, child);
+    }
+
+    #[test]
+    fn repl_workspace_root_keeps_parent_when_child_workspace_is_ambiguous() {
+        let dir = TempDir::new().expect("tempdir");
+        fs::create_dir_all(dir.path().join("one/.duumbi")).expect("first workspace");
+        fs::create_dir_all(dir.path().join("two/.duumbi")).expect("second workspace");
+
+        let resolved = resolve_repl_workspace_root(dir.path());
+
+        assert_eq!(resolved, dir.path());
+    }
+
     struct EnvGuard {
         key: &'static str,
         previous: Option<OsString>,
@@ -2910,6 +3117,28 @@ mod tests {
 
         assert_eq!(app.focused_intent, None);
         assert!(status_output(&app).contains(NO_INTENT_SELECTED_MESSAGE));
+    }
+
+    #[test]
+    fn intent_prompt_action_maps_active_intent_commands() {
+        assert_eq!(
+            intent_prompt_action("review"),
+            Some(IntentPromptAction::Review)
+        );
+        assert_eq!(
+            intent_prompt_action("execute"),
+            Some(IntentPromptAction::Execute)
+        );
+        assert_eq!(
+            intent_prompt_action("run"),
+            Some(IntentPromptAction::Execute)
+        );
+        assert_eq!(intent_prompt_action("edit"), Some(IntentPromptAction::Edit));
+        assert_eq!(
+            intent_prompt_action("delete"),
+            Some(IntentPromptAction::Delete)
+        );
+        assert_eq!(intent_prompt_action("add another test"), None);
     }
 
     #[test]

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -33,7 +33,7 @@ use crate::snapshot;
 
 use super::app::{ReplApp, Turn};
 use super::commands;
-use super::mode::{OutputStyle, ReplMode};
+use super::mode::{IntentPickerAction, OutputStyle, ReplMode};
 
 const ENABLE_BALANCED_MOUSE_REPORTING: &str = "\x1b[?1000h\x1b[?1002h\x1b[?1006h";
 const DISABLE_ALL_MOUSE_REPORTING: &str = "\x1b[?1006l\x1b[?1015l\x1b[?1003l\x1b[?1002l\x1b[?1000l";
@@ -286,6 +286,22 @@ async fn event_loop(
                     }
                     super::mode::Action::IntentDeleteConfirmed { slug } => {
                         handle_confirmed_intent_delete(app, &slug);
+                        should_redraw = true;
+                    }
+                    super::mode::Action::IntentSelected {
+                        slug,
+                        requested_action,
+                    } => {
+                        if let (Some(slug), Some(action)) = (slug, requested_action) {
+                            app.working = matches!(action, IntentPickerAction::Execute);
+                            terminal.draw(|frame| app.render(frame, textarea))?;
+                            last_draw = Instant::now();
+                            handle_intent_picker_action(terminal, app, textarea, &slug, action)
+                                .await;
+                            app.working = false;
+                        } else if requested_action.is_some() {
+                            push_no_intent_selected(app);
+                        }
                         should_redraw = true;
                     }
                 },
@@ -1260,7 +1276,7 @@ async fn handle_intent_slash(
 
     match subcmd {
         "" | "list" => {
-            open_intent_picker(app, None);
+            open_intent_picker(app, None, None);
         }
 
         "create" => {
@@ -1282,6 +1298,7 @@ async fn handle_intent_slash(
             } else {
                 open_intent_picker(
                     app,
+                    Some(IntentPickerAction::Review),
                     Some(("Select an intent to review.".to_string(), OutputStyle::Dim)),
                 );
             }
@@ -1293,6 +1310,7 @@ async fn handle_intent_slash(
             } else {
                 open_intent_picker(
                     app,
+                    Some(IntentPickerAction::Execute),
                     Some(("Select an intent to execute.".to_string(), OutputStyle::Dim)),
                 );
             }
@@ -1304,6 +1322,7 @@ async fn handle_intent_slash(
             } else {
                 open_intent_picker(
                     app,
+                    Some(IntentPickerAction::Edit),
                     Some(("Select an intent to edit.".to_string(), OutputStyle::Dim)),
                 );
             }
@@ -1315,6 +1334,7 @@ async fn handle_intent_slash(
             } else {
                 open_intent_picker(
                     app,
+                    Some(IntentPickerAction::Delete),
                     Some(("Select an intent to delete.".to_string(), OutputStyle::Dim)),
                 );
             }
@@ -1361,9 +1381,13 @@ fn active_intent_slug(app: &ReplApp) -> Option<String> {
     app.focused_intent.clone()
 }
 
-fn open_intent_picker(app: &mut ReplApp, status_msg: Option<(String, OutputStyle)>) {
+fn open_intent_picker(
+    app: &mut ReplApp,
+    requested_action: Option<IntentPickerAction>,
+    status_msg: Option<(String, OutputStyle)>,
+) {
     match collect_intent_picker_items(&app.workspace_root) {
-        Ok(items) => app.open_intent_picker(items, status_msg),
+        Ok(items) => app.open_intent_picker(items, requested_action, status_msg),
         Err(e) => app.push_output(format!("Failed to load intents: {e}"), OutputStyle::Error),
     }
 }
@@ -1656,6 +1680,21 @@ fn is_intent_execute_alias(input: &str) -> bool {
 
 fn push_no_intent_selected(app: &mut ReplApp) {
     app.push_output(NO_INTENT_SELECTED_MESSAGE, OutputStyle::Normal);
+}
+
+async fn handle_intent_picker_action(
+    terminal: &mut ratatui::DefaultTerminal,
+    app: &mut ReplApp,
+    textarea: &mut TextArea<'_>,
+    slug: &str,
+    action: IntentPickerAction,
+) {
+    match action {
+        IntentPickerAction::Review => handle_intent_review(app, slug),
+        IntentPickerAction::Execute => handle_intent_execute(terminal, app, textarea, slug).await,
+        IntentPickerAction::Edit => handle_intent_edit(terminal, app, textarea, slug),
+        IntentPickerAction::Delete => app.confirm_intent_delete(slug.to_string()),
+    }
 }
 
 fn clear_focused_intent_if_matches(app: &mut ReplApp, slug: &str) {

--- a/src/cli/yank.rs
+++ b/src/cli/yank.rs
@@ -177,6 +177,7 @@ mod tests {
             vendor: None,
             cost: None,
             agent: None,
+            editor: None,
             mcp_clients: HashMap::new(),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -710,22 +710,41 @@ pub fn discover_editor_command() -> Option<String> {
 }
 
 fn editor_command_is_available(command: &str) -> bool {
-    command
-        .split_whitespace()
-        .next()
-        .is_some_and(program_is_available)
+    parse_editor_command(command)
+        .and_then(|parts| parts.into_iter().next())
+        .is_some_and(|program| program_is_available(&program))
+}
+
+/// Parses an editor command into program and argument parts.
+#[must_use]
+pub(crate) fn parse_editor_command(command: &str) -> Option<Vec<String>> {
+    shlex::split(command).filter(|parts| !parts.is_empty())
 }
 
 fn program_is_available(program: &str) -> bool {
     let path = Path::new(program);
     if path.is_absolute() || program.contains(std::path::MAIN_SEPARATOR) {
-        return path.is_file();
+        return is_executable_file(path);
     }
 
     let Some(paths) = std::env::var_os("PATH") else {
         return false;
     };
-    std::env::split_paths(&paths).any(|dir| dir.join(program).is_file())
+    std::env::split_paths(&paths).any(|dir| is_executable_file(&dir.join(program)))
+}
+
+#[cfg(unix)]
+fn is_executable_file(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    path.metadata()
+        .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable_file(path: &Path) -> bool {
+    path.is_file()
 }
 
 /// Loads system, user, and workspace config layers and returns the effective runtime config.

--- a/src/config.rs
+++ b/src/config.rs
@@ -487,6 +487,10 @@ pub struct DuumbiConfig {
     /// Workspace identity settings (name, namespace, default-registry).
     pub workspace: Option<WorkspaceSection>,
 
+    /// Command used to edit files from the TUI, for example `"code --wait"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub editor: Option<String>,
+
     /// External MCP server configurations for agent tool access.
     ///
     /// Keys are short server names used in logs and error messages.
@@ -675,6 +679,55 @@ pub fn save_user_config(config: &DuumbiConfig) -> Result<(), ConfigError> {
     save_config_file(&user_config_path(), config)
 }
 
+/// Detects a suitable editor command for TUI file editing.
+#[must_use]
+pub fn discover_editor_command() -> Option<String> {
+    for env_var in ["DUUMBI_EDITOR", "VISUAL", "EDITOR"] {
+        if let Ok(value) = std::env::var(env_var) {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() && editor_command_is_available(trimmed) {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
+
+    for (program, command) in [
+        ("code", "code --wait"),
+        ("cursor", "cursor --wait"),
+        ("zed", "zed --wait"),
+        ("subl", "subl -w"),
+        ("mate", "mate -w"),
+        ("nvim", "nvim"),
+        ("vim", "vim"),
+        ("vi", "vi"),
+    ] {
+        if program_is_available(program) {
+            return Some(command.to_string());
+        }
+    }
+
+    None
+}
+
+fn editor_command_is_available(command: &str) -> bool {
+    command
+        .split_whitespace()
+        .next()
+        .is_some_and(program_is_available)
+}
+
+fn program_is_available(program: &str) -> bool {
+    let path = Path::new(program);
+    if path.is_absolute() || program.contains(std::path::MAIN_SEPARATOR) {
+        return path.is_file();
+    }
+
+    let Some(paths) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&paths).any(|dir| dir.join(program).is_file())
+}
+
 /// Loads system, user, and workspace config layers and returns the effective runtime config.
 pub fn load_effective_config(workspace_root: &Path) -> Result<EffectiveConfig, ConfigError> {
     let system_config = match load_config_file(Path::new("/etc/duumbi/config.toml")) {
@@ -752,6 +805,9 @@ pub fn merge_config_layers(
 fn merge_non_provider_fields(base: &mut DuumbiConfig, overlay: &DuumbiConfig) {
     if overlay.workspace.is_some() {
         base.workspace = overlay.workspace.clone();
+    }
+    if overlay.editor.is_some() {
+        base.editor = overlay.editor.clone();
     }
     if !overlay.mcp_clients.is_empty() {
         base.mcp_clients = overlay.mcp_clients.clone();
@@ -1006,6 +1062,36 @@ output_dir = "build"
 
         let cfg = load_config(tmp.path()).expect("config without llm must parse");
         assert!(cfg.llm.is_none());
+    }
+
+    #[test]
+    fn load_config_editor_field() {
+        let tmp = TempDir::new().expect("invariant: temp dir creation must succeed");
+        write_config(
+            &tmp,
+            r#"
+editor = "code --wait"
+"#,
+        );
+
+        let cfg = load_config(tmp.path()).expect("config with editor must parse");
+        assert_eq!(cfg.editor.as_deref(), Some("code --wait"));
+    }
+
+    #[test]
+    fn workspace_editor_overrides_user_editor() {
+        let user = DuumbiConfig {
+            editor: Some("code --wait".to_string()),
+            ..DuumbiConfig::default()
+        };
+        let workspace = DuumbiConfig {
+            editor: Some("zed --wait".to_string()),
+            ..DuumbiConfig::default()
+        };
+
+        let effective = merge_config_layers(DuumbiConfig::default(), user, workspace);
+
+        assert_eq!(effective.config.editor.as_deref(), Some("zed --wait"));
     }
 
     #[test]

--- a/src/intent/benchmarks.rs
+++ b/src/intent/benchmarks.rs
@@ -105,6 +105,7 @@ mod tests {
             },
             test_cases: Vec::new(),
             dependencies: Vec::new(),
+            context: None,
             created_at: None,
             execution: None,
         }

--- a/src/intent/coordinator.rs
+++ b/src/intent/coordinator.rs
@@ -327,6 +327,7 @@ mod tests {
                 expected_return: 8,
             }],
             dependencies: vec![],
+            context: None,
             created_at: None,
             execution: None,
         }
@@ -421,6 +422,7 @@ mod tests {
                 expected_return: 14,
             }],
             dependencies: vec![],
+            context: None,
             created_at: None,
             execution: None,
         };
@@ -465,6 +467,7 @@ mod tests {
                 },
             ],
             dependencies: vec![],
+            context: None,
             created_at: None,
             execution: None,
         };
@@ -495,6 +498,7 @@ mod tests {
             modules: IntentModules::default(),
             test_cases: vec![],
             dependencies: vec![],
+            context: None,
             created_at: None,
             execution: None,
         };

--- a/src/intent/create.rs
+++ b/src/intent/create.rs
@@ -190,6 +190,7 @@ fn workspace_context_summary(workspace: &Path) -> String {
     let graph_dir = workspace.join(".duumbi/graph");
     let mut modules = Vec::new();
     collect_jsonld_module_paths(&graph_dir, &mut modules);
+    modules.sort();
     if modules.is_empty() {
         return "No graph modules found.".to_string();
     }
@@ -214,7 +215,6 @@ fn collect_jsonld_module_paths(dir: &Path, out: &mut Vec<std::path::PathBuf>) {
             out.push(path);
         }
     }
-    out.sort();
 }
 
 pub(crate) fn parse_clarification_response(

--- a/src/intent/create.rs
+++ b/src/intent/create.rs
@@ -8,8 +8,8 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
-use crate::agents::LlmProvider;
-use crate::intent::spec::{IntentModules, IntentSpec, IntentStatus, TestCase};
+use crate::agents::{AgentError, LlmProvider};
+use crate::intent::spec::{IntentContext, IntentModules, IntentSpec, IntentStatus, TestCase};
 use crate::intent::{IntentError, save_intent, slugify, unique_slug};
 
 // ---------------------------------------------------------------------------
@@ -103,6 +103,50 @@ User: \"Build a math library with double, square, and cube\"
   \"dependencies\": []
 }";
 
+const INTENT_CLARIFY_PROMPT: &str = "\
+You are preparing a DUUMBI intent before structured spec generation. Decide whether the \
+request has enough product and integration context to execute well.
+
+Ask clarification questions only when they materially affect implementation. Focus on:
+- target surface: function, command, TUI flow, REST endpoint, whole application, or module
+- entrypoint/caller and where the behavior is wired
+- runtime environment and constraints
+- acceptance behavior that should be verified
+
+DUUMBI currently verifies integer graph behavior best. Capture broader product context, but keep \
+generated executable tests within DUUMBI's current i64 graph capabilities.
+
+Respond ONLY with valid JSON:
+{
+  \"needs_clarification\": true|false,
+  \"questions\": [\"...\"],
+  \"enhanced_description\": \"...\",
+  \"context\": {
+    \"scope\": \"...\",
+    \"entrypoint\": \"...\",
+    \"runtime_surface\": \"...\",
+    \"integration_points\": [\"...\"],
+    \"constraints\": [\"...\"]
+  }
+}";
+
+/// TUI intent creation planning result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TuiIntentCreatePlan {
+    /// The request can be converted into an intent immediately.
+    Ready {
+        /// Description to pass to structured spec generation.
+        description: String,
+        /// Clarified context to persist with the spec.
+        context: Option<IntentContext>,
+    },
+    /// The user should answer material clarification questions first.
+    NeedsClarification {
+        /// Questions to show in the chat.
+        questions: Vec<String>,
+    },
+}
+
 // ---------------------------------------------------------------------------
 // LLM-based spec generation
 // ---------------------------------------------------------------------------
@@ -125,6 +169,134 @@ pub async fn generate_spec_with_llm(
     let mut spec = parse_llm_response(description, &raw)?;
     let _ = crate::intent::benchmarks::apply_known_benchmark(description, &mut spec);
     Ok(spec)
+}
+
+/// Uses an LLM to decide whether a TUI intent request needs clarification first.
+pub async fn plan_tui_create(
+    client: &dyn LlmProvider,
+    workspace: &Path,
+    description: &str,
+) -> Result<TuiIntentCreatePlan> {
+    let user_message = format!(
+        "Workspace context:\n{}\n\nUser request:\n{}",
+        workspace_context_summary(workspace),
+        description
+    );
+    let raw = call_plain_completion(client, INTENT_CLARIFY_PROMPT, &user_message).await?;
+    parse_clarification_response(description, &raw)
+}
+
+fn workspace_context_summary(workspace: &Path) -> String {
+    let graph_dir = workspace.join(".duumbi/graph");
+    let mut modules = Vec::new();
+    collect_jsonld_module_paths(&graph_dir, &mut modules);
+    if modules.is_empty() {
+        return "No graph modules found.".to_string();
+    }
+    let mut lines = vec!["Existing graph modules:".to_string()];
+    for path in modules.into_iter().take(20) {
+        if let Ok(relative) = path.strip_prefix(&graph_dir) {
+            lines.push(format!("- {}", relative.display()));
+        }
+    }
+    lines.join("\n")
+}
+
+fn collect_jsonld_module_paths(dir: &Path, out: &mut Vec<std::path::PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_jsonld_module_paths(&path, out);
+        } else if path.extension().and_then(|ext| ext.to_str()) == Some("jsonld") {
+            out.push(path);
+        }
+    }
+    out.sort();
+}
+
+pub(crate) fn parse_clarification_response(
+    original_description: &str,
+    raw: &str,
+) -> Result<TuiIntentCreatePlan> {
+    let Some(json_str) = extract_json(raw) else {
+        return Ok(TuiIntentCreatePlan::Ready {
+            description: original_description.to_string(),
+            context: None,
+        });
+    };
+    let value: serde_json::Value =
+        serde_json::from_str(json_str).context("Failed to parse clarification JSON")?;
+
+    let questions: Vec<String> = value["questions"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|item| item.as_str().map(str::trim))
+                .filter(|item| !item.is_empty())
+                .map(ToString::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    let needs_clarification = value["needs_clarification"].as_bool().unwrap_or(false);
+    if needs_clarification && !questions.is_empty() {
+        return Ok(TuiIntentCreatePlan::NeedsClarification { questions });
+    }
+
+    let description = value["enhanced_description"]
+        .as_str()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(original_description)
+        .to_string();
+    let context = parse_intent_context(&value["context"]);
+    Ok(TuiIntentCreatePlan::Ready {
+        description,
+        context,
+    })
+}
+
+fn parse_intent_context(value: &serde_json::Value) -> Option<IntentContext> {
+    if !value.is_object() {
+        return None;
+    }
+    let context = IntentContext {
+        scope: string_field(value, "scope"),
+        entrypoint: string_field(value, "entrypoint"),
+        runtime_surface: string_field(value, "runtime_surface"),
+        integration_points: string_array_field(value, "integration_points"),
+        constraints: string_array_field(value, "constraints"),
+        clarification_log: Vec::new(),
+    };
+    let has_data = context.scope.is_some()
+        || context.entrypoint.is_some()
+        || context.runtime_surface.is_some()
+        || !context.integration_points.is_empty()
+        || !context.constraints.is_empty();
+    has_data.then_some(context)
+}
+
+fn string_field(value: &serde_json::Value, key: &str) -> Option<String> {
+    value[key]
+        .as_str()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToString::to_string)
+}
+
+fn string_array_field(value: &serde_json::Value, key: &str) -> Vec<String> {
+    value[key]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|item| item.as_str().map(str::trim))
+                .filter(|item| !item.is_empty())
+                .map(ToString::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// Extracts the first valid JSON object from an LLM response.
@@ -267,6 +439,7 @@ pub(crate) fn parse_llm_response(description: &str, raw: &str) -> Result<IntentS
         },
         test_cases,
         dependencies,
+        context: None,
         created_at: Some(now),
         execution: None,
     })
@@ -307,6 +480,12 @@ pub(crate) async fn call_plain_completion(
     system: &str,
     user: &str,
 ) -> Result<String> {
+    match client.answer(system, user).await {
+        Ok(text) if !text.trim().is_empty() => return Ok(text),
+        Ok(_) | Err(AgentError::NoToolCalls | AgentError::Parse(_)) => {}
+        Err(e) => return Err(anyhow::anyhow!("LLM call failed: {e}")),
+    }
+
     // Mutex lets the closure satisfy Fn + Send + Sync while accumulating chunks.
     let response = std::sync::Mutex::new(String::new());
 
@@ -331,10 +510,10 @@ pub(crate) async fn call_plain_completion(
     let text = response
         .into_inner()
         .expect("invariant: mutex not poisoned");
-    if text.is_empty() {
+    if text.trim().is_empty() {
         anyhow::bail!(
-            "The selected model did not generate an intent spec.\n\
-             This usually means the active provider could not satisfy structured output for this task.\n\
+            "The selected model did not generate a text response.\n\
+             This usually means the active provider could not satisfy plain completion for this task.\n\
              Configure another supported provider or retry when provider health improves."
         );
     }
@@ -361,11 +540,24 @@ pub async fn run_create(
     yes: bool,
     log: &mut Vec<String>,
 ) -> Result<String> {
+    run_create_with_context(client, workspace, description, None, yes, log).await
+}
+
+/// Full create flow with optional clarified context, used by the TUI.
+pub async fn run_create_with_context(
+    client: &dyn LlmProvider,
+    workspace: &Path,
+    description: &str,
+    context: Option<IntentContext>,
+    yes: bool,
+    log: &mut Vec<String>,
+) -> Result<String> {
     log.push(format!("Generating intent spec for: \"{description}\"…"));
 
-    let spec = generate_spec_with_llm(client, description)
+    let mut spec = generate_spec_with_llm(client, description)
         .await
         .context("Failed to generate intent spec")?;
+    spec.context = context;
 
     // Show preview
     crate::intent::review::format_spec_detail("(preview)", &spec, log);
@@ -400,6 +592,55 @@ pub async fn run_create(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::future::Future;
+    use std::pin::Pin;
+
+    use crate::patch::PatchOp;
+
+    struct PlainMockProvider {
+        answer_text: Option<&'static str>,
+        tool_text: &'static str,
+    }
+
+    impl LlmProvider for PlainMockProvider {
+        fn name(&self) -> &str {
+            "mock"
+        }
+
+        fn call_with_tools<'a>(
+            &'a self,
+            _system_prompt: &'a str,
+            _user_message: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<Vec<PatchOp>, AgentError>> + Send + 'a>> {
+            Box::pin(async { Err(AgentError::NoToolCalls) })
+        }
+
+        fn call_with_tools_streaming<'a>(
+            &'a self,
+            _system_prompt: &'a str,
+            _user_message: &'a str,
+            on_text: &'a (dyn Fn(&str) + Send + Sync),
+        ) -> Pin<Box<dyn Future<Output = Result<Vec<PatchOp>, AgentError>> + Send + 'a>> {
+            Box::pin(async move {
+                if !self.tool_text.is_empty() {
+                    on_text(self.tool_text);
+                }
+                Err(AgentError::NoToolCalls)
+            })
+        }
+
+        fn answer<'a>(
+            &'a self,
+            _system_prompt: &'a str,
+            _user_message: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<String, AgentError>> + Send + 'a>> {
+            Box::pin(async move {
+                self.answer_text
+                    .map(ToString::to_string)
+                    .ok_or(AgentError::NoToolCalls)
+            })
+        }
+    }
 
     #[test]
     fn parse_valid_llm_response() {
@@ -444,6 +685,99 @@ This intent creates an addition function that..."#;
         let spec =
             parse_llm_response("Test trailing", raw).expect("must parse despite trailing text");
         assert_eq!(spec.acceptance_criteria, vec!["add works"]);
+    }
+
+    #[test]
+    fn parse_clarification_response_ready_with_context() {
+        let raw = r#"{
+  "needs_clarification": false,
+  "questions": [],
+  "enhanced_description": "Add add(a,b) to calculator/ops and call it from app/main",
+  "context": {
+    "scope": "function",
+    "entrypoint": "app/main",
+    "runtime_surface": "CLI",
+    "integration_points": ["calculator/ops", "app/main"],
+    "constraints": ["i64 only"]
+  }
+}"#;
+
+        let plan = parse_clarification_response("Add", raw).expect("parse");
+
+        match plan {
+            TuiIntentCreatePlan::Ready {
+                description,
+                context: Some(context),
+            } => {
+                assert!(description.contains("calculator/ops"));
+                assert_eq!(context.scope.as_deref(), Some("function"));
+                assert_eq!(
+                    context.integration_points,
+                    vec!["calculator/ops", "app/main"]
+                );
+            }
+            other => panic!("unexpected plan: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_clarification_response_questions() {
+        let raw = r#"{
+  "needs_clarification": true,
+  "questions": ["Where should this be wired?", "Which function should call it?"],
+  "enhanced_description": "",
+  "context": {}
+}"#;
+
+        let plan = parse_clarification_response("Do a thing", raw).expect("parse");
+
+        assert!(matches!(
+            plan,
+            TuiIntentCreatePlan::NeedsClarification { questions } if questions.len() == 2
+        ));
+    }
+
+    #[test]
+    fn parse_clarification_response_without_json_falls_back_to_ready() {
+        let plan = parse_clarification_response(
+            "Build a calculator with i64 arithmetic functions",
+            "This is clear enough to implement.",
+        )
+        .expect("fallback");
+
+        assert!(matches!(
+            plan,
+            TuiIntentCreatePlan::Ready { description, context: None }
+                if description == "Build a calculator with i64 arithmetic functions"
+        ));
+    }
+
+    #[tokio::test]
+    async fn call_plain_completion_prefers_plain_answer() {
+        let provider = PlainMockProvider {
+            answer_text: Some("{\"ok\":true}"),
+            tool_text: "",
+        };
+
+        let text = call_plain_completion(&provider, "system", "user")
+            .await
+            .expect("plain answer");
+
+        assert_eq!(text, "{\"ok\":true}");
+    }
+
+    #[tokio::test]
+    async fn call_plain_completion_falls_back_to_tool_text() {
+        let provider = PlainMockProvider {
+            answer_text: None,
+            tool_text: "{\"fallback\":true}",
+        };
+
+        let text = call_plain_completion(&provider, "system", "user")
+            .await
+            .expect("tool fallback");
+
+        assert_eq!(text, "{\"fallback\":true}");
     }
 
     #[test]

--- a/src/intent/execute.rs
+++ b/src/intent/execute.rs
@@ -887,11 +887,40 @@ fn build_task_prompt(spec: &IntentSpec, task_prompt: &str) -> String {
         .map(|(i, c)| format!("  {}. {c}", i + 1))
         .collect::<Vec<_>>()
         .join("\n");
+    let context = spec
+        .context
+        .as_ref()
+        .map(format_intent_context)
+        .unwrap_or_else(|| "No additional clarified context.".to_string());
 
     format!(
-        "Intent: \"{}\"\n\nAcceptance criteria:\n{}\n\nCurrent task:\n{}",
-        spec.intent, criteria, task_prompt
+        "Intent: \"{}\"\n\nClarified context:\n{}\n\nAcceptance criteria:\n{}\n\nCurrent task:\n{}",
+        spec.intent, context, criteria, task_prompt
     )
+}
+
+fn format_intent_context(context: &crate::intent::spec::IntentContext) -> String {
+    let mut lines = Vec::new();
+    if let Some(scope) = &context.scope {
+        lines.push(format!("- Scope: {scope}"));
+    }
+    if let Some(entrypoint) = &context.entrypoint {
+        lines.push(format!("- Entrypoint: {entrypoint}"));
+    }
+    if let Some(surface) = &context.runtime_surface {
+        lines.push(format!("- Runtime surface: {surface}"));
+    }
+    for point in &context.integration_points {
+        lines.push(format!("- Integration point: {point}"));
+    }
+    for constraint in &context.constraints {
+        lines.push(format!("- Constraint: {constraint}"));
+    }
+    if lines.is_empty() {
+        "No additional clarified context.".to_string()
+    } else {
+        lines.join("\n")
+    }
 }
 
 /// Archives a successfully completed intent.
@@ -978,6 +1007,7 @@ mod tests {
             modules: IntentModules::default(),
             test_cases: vec![],
             dependencies: vec![],
+            context: None,
             created_at: None,
             execution: None,
         };

--- a/src/intent/mod.rs
+++ b/src/intent/mod.rs
@@ -61,6 +61,16 @@ pub enum IntentError {
         source: std::io::Error,
     },
 
+    /// Editor command failed before the file could be opened.
+    #[error("Editor '{editor}' failed: {source}")]
+    EditorIo {
+        /// Editor command.
+        editor: String,
+        /// Underlying error.
+        #[source]
+        source: std::io::Error,
+    },
+
     /// YAML parse error.
     #[error("Failed to parse intent YAML at '{path}': {source}")]
     Parse {
@@ -88,6 +98,11 @@ pub fn intents_dir(workspace: &Path) -> PathBuf {
 /// Returns the `.duumbi/intents/history/` directory for a workspace.
 pub fn history_dir(workspace: &Path) -> PathBuf {
     intents_dir(workspace).join("history")
+}
+
+/// Returns the `.duumbi/intents/deleted/` directory for removed active intents.
+pub fn deleted_dir(workspace: &Path) -> PathBuf {
+    intents_dir(workspace).join("deleted")
 }
 
 /// Returns the path to an active intent YAML file.
@@ -128,6 +143,36 @@ pub fn save_intent(workspace: &Path, slug: &str, spec: &IntentSpec) -> Result<()
         path: path.display().to_string(),
         source,
     })
+}
+
+/// Moves an active intent to `.duumbi/intents/deleted/` instead of removing it permanently.
+#[must_use = "intent delete errors should be handled"]
+pub fn delete_intent(workspace: &Path, slug: &str) -> Result<PathBuf, IntentError> {
+    let active_path = intent_path(workspace, slug);
+    if !active_path.exists() {
+        return Err(IntentError::NotFound {
+            name: slug.to_string(),
+        });
+    }
+
+    let dir = deleted_dir(workspace);
+    fs::create_dir_all(&dir).map_err(|source| IntentError::Io {
+        path: dir.display().to_string(),
+        source,
+    })?;
+
+    let mut deleted_path = dir.join(format!("{slug}-{}.yaml", timestamp_suffix()));
+    let mut counter = 2;
+    while deleted_path.exists() {
+        deleted_path = dir.join(format!("{slug}-{}-{counter}.yaml", timestamp_suffix()));
+        counter += 1;
+    }
+
+    fs::rename(&active_path, &deleted_path).map_err(|source| IntentError::Io {
+        path: active_path.display().to_string(),
+        source,
+    })?;
+    Ok(deleted_path)
 }
 
 /// Lists all active intent slugs in `.duumbi/intents/` (excludes `history/`).
@@ -209,6 +254,10 @@ fn uuid_suffix() -> u64 {
         .unwrap_or(0)
 }
 
+fn timestamp_suffix() -> u64 {
+    uuid_suffix()
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -247,6 +296,7 @@ mod tests {
             },
             test_cases: vec![],
             dependencies: vec![],
+            context: None,
             created_at: Some("2026-01-01T00:00:00Z".to_string()),
             execution: None,
         };
@@ -282,6 +332,7 @@ mod tests {
             modules: spec::IntentModules::default(),
             test_cases: vec![],
             dependencies: vec![],
+            context: None,
             created_at: None,
             execution: None,
         };
@@ -290,6 +341,31 @@ mod tests {
 
         let slugs = list_intents(tmp.path()).expect("list");
         assert_eq!(slugs, vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn delete_intent_moves_to_deleted_dir() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let spec = IntentSpec {
+            intent: "Delete me".to_string(),
+            version: 1,
+            status: spec::IntentStatus::Pending,
+            acceptance_criteria: vec![],
+            modules: spec::IntentModules::default(),
+            test_cases: vec![],
+            dependencies: vec![],
+            context: None,
+            created_at: None,
+            execution: None,
+        };
+        save_intent(tmp.path(), "delete-me", &spec).expect("save");
+
+        let deleted_path = delete_intent(tmp.path(), "delete-me").expect("delete");
+
+        assert!(!intent_path(tmp.path(), "delete-me").exists());
+        assert!(deleted_path.starts_with(deleted_dir(tmp.path())));
+        assert!(deleted_path.exists());
+        assert!(list_intents(tmp.path()).expect("list").is_empty());
     }
 
     #[test]

--- a/src/intent/mod.rs
+++ b/src/intent/mod.rs
@@ -71,6 +71,22 @@ pub enum IntentError {
         source: std::io::Error,
     },
 
+    /// Editor command could not be parsed into a program and arguments.
+    #[error("Failed to parse editor command '{editor}'")]
+    EditorCommandParse {
+        /// Editor command.
+        editor: String,
+    },
+
+    /// Editor process exited unsuccessfully.
+    #[error("Editor '{editor}' exited with {status}")]
+    EditorExit {
+        /// Editor command.
+        editor: String,
+        /// Exit status.
+        status: String,
+    },
+
     /// YAML parse error.
     #[error("Failed to parse intent YAML at '{path}': {source}")]
     Parse {
@@ -244,18 +260,14 @@ pub fn unique_slug(workspace: &Path, base_slug: &str) -> String {
             return candidate;
         }
     }
-    format!("{base_slug}-{}", uuid_suffix())
+    format!("{base_slug}-{}", timestamp_suffix())
 }
 
-fn uuid_suffix() -> u64 {
+fn timestamp_suffix() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
-}
-
-fn timestamp_suffix() -> u64 {
-    uuid_suffix()
 }
 
 // ---------------------------------------------------------------------------

--- a/src/intent/modify.rs
+++ b/src/intent/modify.rs
@@ -68,6 +68,7 @@ pub async fn modify_intent_with_llm(
     modified.created_at = current_spec.created_at.clone();
     modified.status = current_spec.status.clone();
     modified.execution = current_spec.execution.clone();
+    modified.context = current_spec.context.clone();
 
     Ok(modified)
 }
@@ -98,6 +99,7 @@ mod tests {
                 expected_return: 8,
             }],
             dependencies: vec![],
+            context: None,
             created_at: Some("2026-01-01T00:00:00Z".to_string()),
             execution: None,
         }

--- a/src/intent/review.rs
+++ b/src/intent/review.rs
@@ -4,6 +4,8 @@
 
 use std::path::Path;
 
+use crate::config::parse_editor_command;
+
 use super::spec::{IntentSpec, IntentStatus};
 use super::{IntentError, list_intents, load_intent};
 
@@ -230,9 +232,12 @@ pub fn edit_intent_with_editor(
         .filter(|value| !value.is_empty())
         .map(ToString::to_string)
         .unwrap_or_else(default_editor_command);
-    let mut parts = editor.split_whitespace();
-    let program = parts.next().unwrap_or("vi");
-    let args = parts.collect::<Vec<_>>();
+    let parts = parse_editor_command(&editor).ok_or_else(|| IntentError::EditorCommandParse {
+        editor: editor.clone(),
+    })?;
+    let (program, args) = parts
+        .split_first()
+        .expect("invariant: parse_editor_command rejects empty commands");
 
     let status = std::process::Command::new(program)
         .args(args)
@@ -244,7 +249,10 @@ pub fn edit_intent_with_editor(
         })?;
 
     if !status.success() {
-        eprintln!("Editor exited with {status}");
+        return Err(IntentError::EditorExit {
+            editor,
+            status: status.to_string(),
+        });
     }
 
     // Re-validate by loading

--- a/src/intent/review.rs
+++ b/src/intent/review.rs
@@ -68,6 +68,26 @@ pub fn print_spec_detail(slug: &str, spec: &IntentSpec) {
         }
     }
 
+    if let Some(ref context) = spec.context {
+        eprintln!();
+        eprintln!("Context:");
+        if let Some(scope) = &context.scope {
+            eprintln!("  Scope: {scope}");
+        }
+        if let Some(entrypoint) = &context.entrypoint {
+            eprintln!("  Entrypoint: {entrypoint}");
+        }
+        if let Some(surface) = &context.runtime_surface {
+            eprintln!("  Runtime surface: {surface}");
+        }
+        for point in &context.integration_points {
+            eprintln!("  Integration: {point}");
+        }
+        for constraint in &context.constraints {
+            eprintln!("  Constraint: {constraint}");
+        }
+    }
+
     if !spec.modules.create.is_empty() || !spec.modules.modify.is_empty() {
         eprintln!();
         eprintln!("Modules:");
@@ -131,6 +151,25 @@ pub fn format_spec_detail(slug: &str, spec: &IntentSpec, log: &mut Vec<String>) 
         }
     }
 
+    if let Some(ref context) = spec.context {
+        log.push("Context:".to_string());
+        if let Some(scope) = &context.scope {
+            log.push(format!("  Scope: {scope}"));
+        }
+        if let Some(entrypoint) = &context.entrypoint {
+            log.push(format!("  Entrypoint: {entrypoint}"));
+        }
+        if let Some(surface) = &context.runtime_surface {
+            log.push(format!("  Runtime surface: {surface}"));
+        }
+        for point in &context.integration_points {
+            log.push(format!("  Integration: {point}"));
+        }
+        for constraint in &context.constraints {
+            log.push(format!("  Constraint: {constraint}"));
+        }
+    }
+
     if !spec.modules.create.is_empty() || !spec.modules.modify.is_empty() {
         log.push("Modules:".to_string());
         for m in &spec.modules.create {
@@ -158,19 +197,49 @@ pub fn format_spec_detail(slug: &str, spec: &IntentSpec, log: &mut Vec<String>) 
     }
 }
 
-/// Opens the intent YAML in `$EDITOR` (falls back to `vi`) and re-validates.
+/// Opens the intent YAML in the configured editor and re-validates.
 ///
 /// Returns `Ok(())` if the file was saved with valid YAML, or an error if
 /// the editor fails or the resulting YAML is invalid.
 pub fn edit_intent(workspace: &Path, slug: &str) -> Result<(), IntentError> {
-    let path = super::intent_path(workspace, slug);
+    edit_intent_with_editor(workspace, slug, None)
+}
 
-    let editor = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
-    let status = std::process::Command::new(&editor)
+/// Opens the intent YAML in `editor_command` and re-validates.
+///
+/// When `editor_command` is not provided, falls back to `$DUUMBI_EDITOR`,
+/// `$VISUAL`, `$EDITOR`, then `vi` for CLI compatibility.
+pub fn edit_intent_with_editor(
+    workspace: &Path,
+    slug: &str,
+    editor_command: Option<&str>,
+) -> Result<(), IntentError> {
+    let path = super::intent_path(workspace, slug);
+    if !path.exists() {
+        return Err(IntentError::NotFound {
+            name: slug.to_string(),
+        });
+    }
+    let path = path.canonicalize().map_err(|source| IntentError::Io {
+        path: path.display().to_string(),
+        source,
+    })?;
+
+    let editor = editor_command
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+        .unwrap_or_else(default_editor_command);
+    let mut parts = editor.split_whitespace();
+    let program = parts.next().unwrap_or("vi");
+    let args = parts.collect::<Vec<_>>();
+
+    let status = std::process::Command::new(program)
+        .args(args)
         .arg(&path)
         .status()
-        .map_err(|source| IntentError::Io {
-            path: path.display().to_string(),
+        .map_err(|source| IntentError::EditorIo {
+            editor: editor.clone(),
             source,
         })?;
 
@@ -182,4 +251,66 @@ pub fn edit_intent(workspace: &Path, slug: &str) -> Result<(), IntentError> {
     load_intent(workspace, slug)?;
     eprintln!("Intent '{slug}' saved and validated.");
     Ok(())
+}
+
+fn default_editor_command() -> String {
+    std::env::var("DUUMBI_EDITOR")
+        .or_else(|_| std::env::var("VISUAL"))
+        .or_else(|_| std::env::var("EDITOR"))
+        .unwrap_or_else(|_| "vi".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::intent::save_intent;
+    use crate::intent::spec::{IntentModules, IntentSpec, IntentStatus};
+    use std::fs;
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    fn minimal_spec() -> IntentSpec {
+        IntentSpec {
+            intent: "Build calculator".to_string(),
+            version: 1,
+            status: IntentStatus::Pending,
+            acceptance_criteria: vec!["works".to_string()],
+            modules: IntentModules::default(),
+            test_cases: Vec::new(),
+            dependencies: Vec::new(),
+            context: None,
+            created_at: None,
+            execution: None,
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn edit_intent_with_editor_passes_absolute_yaml_path() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        save_intent(tmp.path(), "calculator", &minimal_spec()).expect("save intent");
+
+        let opened = tmp.path().join("opened.txt");
+        let script = tmp.path().join("fake-editor.sh");
+        fs::write(
+            &script,
+            format!("#!/bin/sh\nprintf '%s' \"$1\" > '{}'\n", opened.display()),
+        )
+        .expect("write script");
+        let mut perms = fs::metadata(&script).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script, perms).expect("chmod");
+
+        edit_intent_with_editor(
+            tmp.path(),
+            "calculator",
+            Some(&script.display().to_string()),
+        )
+        .expect("edit");
+
+        let opened_path = fs::read_to_string(&opened).expect("opened path");
+        assert!(Path::new(&opened_path).is_absolute());
+        assert!(opened_path.ends_with(".duumbi/intents/calculator.yaml"));
+    }
 }

--- a/src/intent/spec.rs
+++ b/src/intent/spec.rs
@@ -173,6 +173,34 @@ pub struct IntentModules {
     pub modify: Vec<String>,
 }
 
+/// Additional product and integration context clarified before intent execution.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct IntentContext {
+    /// Scope of the request, such as whole app, module, function, or command.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+
+    /// Entry point or caller that should invoke the behavior.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entrypoint: Option<String>,
+
+    /// Runtime surface, such as CLI, TUI, REST, library function, or internal graph.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_surface: Option<String>,
+
+    /// Existing modules, commands, screens, or functions where the change should be wired.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub integration_points: Vec<String>,
+
+    /// Important constraints for implementation and verification.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub constraints: Vec<String>,
+
+    /// Clarification questions and answers captured before spec generation.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub clarification_log: Vec<String>,
+}
+
 // ---------------------------------------------------------------------------
 // Execution metadata (appended on completion)
 // ---------------------------------------------------------------------------
@@ -223,6 +251,10 @@ pub struct IntentSpec {
     /// Names of external dependencies required by this intent.
     #[serde(default)]
     pub dependencies: Vec<String>,
+
+    /// Clarified product, integration, and execution context for this intent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context: Option<IntentContext>,
 
     /// ISO-8601 creation timestamp.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -279,6 +311,7 @@ created_at: "2026-03-06T10:00:00Z"
         assert_eq!(spec.modules.create, vec!["calculator/ops"]);
         assert_eq!(spec.test_cases.len(), 2);
         assert_eq!(spec.test_cases[0].expected_return, 8);
+        assert_eq!(spec.context, None);
     }
 
     #[test]

--- a/src/intent/status.rs
+++ b/src/intent/status.rs
@@ -138,6 +138,7 @@ mod tests {
             modules: IntentModules::default(),
             test_cases: vec![],
             dependencies: vec![],
+            context: None,
             created_at: Some("2026-01-01T00:00:00Z".to_string()),
             execution: None,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ fn auto_configure_startup_editor(
     workspace_root: &Path,
     effective_config: config::EffectiveConfig,
 ) -> Result<config::EffectiveConfig> {
-    if effective_config.user_config.editor.is_some() {
+    if effective_config.config.editor.is_some() {
         return Ok(effective_config);
     }
 
@@ -111,11 +111,22 @@ fn auto_configure_startup_editor(
         return Ok(effective_config);
     };
 
-    let mut user_config = effective_config.user_config;
-    user_config.editor = Some(editor);
-    config::save_user_config(&user_config).context("Failed to save startup editor config")?;
-    config::load_effective_config(workspace_root)
-        .context("Failed to reload config after startup editor setup")
+    let mut updated_config = effective_config;
+    updated_config.user_config.editor = Some(editor.clone());
+    updated_config.config.editor = Some(editor);
+
+    if let Err(e) = config::save_user_config(&updated_config.user_config) {
+        eprintln!("warning: failed to save startup editor config: {e}");
+        return Ok(updated_config);
+    }
+
+    match config::load_effective_config(workspace_root) {
+        Ok(reloaded) => Ok(reloaded),
+        Err(e) => {
+            eprintln!("warning: failed to reload config after startup editor setup: {e}");
+            Ok(updated_config)
+        }
+    }
 }
 
 async fn auto_configure_startup_providers(

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,11 +63,18 @@ async fn main() {
     // If invoked with no arguments and stdin is a terminal, enter the
     // interactive REPL — even without an initialised workspace.
     if std::env::args().len() == 1 && io::stdin().is_terminal() {
-        let workspace_root = PathBuf::from(".");
+        let workspace_root = cli::repl::resolve_repl_workspace_root(&PathBuf::from("."));
         let config = match config::load_effective_config(&workspace_root) {
             Ok(config) => config,
             Err(e) => {
                 eprintln!("error: {e}");
+                process::exit(1);
+            }
+        };
+        let config = match auto_configure_startup_editor(&workspace_root, config) {
+            Ok(config) => config,
+            Err(e) => {
+                eprintln!("error: {e:#}");
                 process::exit(1);
             }
         };
@@ -90,6 +97,25 @@ async fn main() {
         eprintln!("error: {e:#}");
         process::exit(1);
     }
+}
+
+fn auto_configure_startup_editor(
+    workspace_root: &Path,
+    effective_config: config::EffectiveConfig,
+) -> Result<config::EffectiveConfig> {
+    if effective_config.user_config.editor.is_some() {
+        return Ok(effective_config);
+    }
+
+    let Some(editor) = config::discover_editor_command() else {
+        return Ok(effective_config);
+    };
+
+    let mut user_config = effective_config.user_config;
+    user_config.editor = Some(editor);
+    config::save_user_config(&user_config).context("Failed to save startup editor config")?;
+    config::load_effective_config(workspace_root)
+        .context("Failed to reload config after startup editor setup")
 }
 
 async fn auto_configure_startup_providers(

--- a/tests/integration_phase12.rs
+++ b/tests/integration_phase12.rs
@@ -206,6 +206,7 @@ fn kill_criterion_2_dynamic_assembly_multi_module() {
             },
         ],
         dependencies: vec![],
+        context: None,
         created_at: None,
         execution: None,
     };

--- a/tests/integration_phase5.rs
+++ b/tests/integration_phase5.rs
@@ -32,6 +32,7 @@ fn minimal_spec(intent: &str) -> IntentSpec {
         modules: IntentModules::default(),
         test_cases: vec![],
         dependencies: vec![],
+        context: None,
         created_at: Some("2026-01-01T00:00:00Z".to_string()),
         execution: None,
     }
@@ -144,6 +145,7 @@ fn phase5_coordinator_creates_before_modifies() {
         },
         test_cases: vec![],
         dependencies: vec![],
+        context: None,
         created_at: None,
         execution: None,
     };
@@ -180,6 +182,7 @@ fn phase5_coordinator_modifymain_is_last() {
         },
         test_cases: vec![],
         dependencies: vec![],
+        context: None,
         created_at: None,
         execution: None,
     };
@@ -208,6 +211,7 @@ fn phase5_coordinator_task_ids_are_sequential() {
         },
         test_cases: vec![],
         dependencies: vec![],
+        context: None,
         created_at: None,
         execution: None,
     };
@@ -239,6 +243,7 @@ fn phase5_verifier_double_21_returns_42() {
             expected_return: 42,
         }],
         dependencies: vec![],
+        context: None,
         created_at: None,
         execution: None,
     };
@@ -270,6 +275,7 @@ fn phase5_verifier_double_0_returns_0() {
             expected_return: 0,
         }],
         dependencies: vec![],
+        context: None,
         created_at: None,
         execution: None,
     };
@@ -299,6 +305,7 @@ fn phase5_verifier_wrong_expected_fails() {
             expected_return: 99, // wrong: double(5) = 10
         }],
         dependencies: vec![],
+        context: None,
         created_at: None,
         execution: None,
     };
@@ -320,6 +327,7 @@ fn phase5_verifier_empty_test_cases_passes() {
         modules: IntentModules::default(),
         test_cases: vec![],
         dependencies: vec![],
+        context: None,
         created_at: None,
         execution: None,
     };
@@ -365,6 +373,7 @@ fn phase5_m5_kill_criterion_verifier_validates_real_function() {
             },
         ],
         dependencies: vec![],
+        context: None,
         created_at: None,
         execution: None,
     };


### PR DESCRIPTION
## Summary
- Rework TUI intent commands around an active intent picker and prompt-driven actions
- Add intent clarification context, modification, delete/archive, editor support, and workspace-root handling
- Keep CLI intent behavior compatible while simplifying TUI completion/help
- Bump DUUMBI workspace and Studio crate versions from 0.3.2 to 0.3.3

## Verification
- cargo fmt --check
- cargo test --all
- cargo clippy --all-targets -- -D warnings