### PR TITLE
[codex] add logging configuration

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,8 +84,10 @@ Phase 5 (implemented):
 | `core.schema.json` | JSON Schema for Op node validation | `.duumbi/schema/` |
 | `.o` | Cranelift object file output | `.duumbi/build/` |
 | `traces.jsonl` | Runtime traceId → nodeId mapping | `.duumbi/telemetry/` |
-| `config.toml` | Workspace, LLM, registries, dependencies, vendor | `.duumbi/` |
+| `config.toml` | Workspace, LLM, registries, dependencies, vendor, logging | `.duumbi/` |
 | `deps.lock` | Lockfile v1 with integrity hashes | `.duumbi/` |
+| `duumbi.log` | General internal diagnostic log | `.duumbi/logs/` |
+| `performance.jsonl` | Command performance timing events | `.duumbi/logs/` |
 | `manifest.toml` | Module metadata (name, version, exports) | cache/vendor entries |
 | `{N:06}.jsonld` | Undo history snapshots | `.duumbi/history/` |
 | `<slug>.yaml` | Active intent specs | `.duumbi/intents/` |

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -1550,18 +1550,24 @@ impl ReplApp {
             .get_or_insert_with(LoggingSection::default);
         match selected {
             0 => {
-                let next = cycle_log_level(logging.general.level, forward);
-                logging.general.level = next;
-                logging.general.enabled = next != LogLevel::Off;
+                let current = if logging.general.effective_enabled() {
+                    logging.general.effective_level()
+                } else {
+                    LogLevel::Off
+                };
+                let next = cycle_log_level(current, forward);
+                logging.general.level = Some(next);
+                logging.general.enabled = Some(next != LogLevel::Off);
             }
             1 => {
-                logging.general.mode = cycle_log_mode(logging.general.mode);
+                logging.general.mode = Some(cycle_log_mode(logging.general.effective_mode()));
             }
             2 => {
-                logging.performance.enabled = !logging.performance.enabled;
+                logging.performance.enabled = Some(!logging.performance.effective_enabled());
             }
             3 => {
-                logging.performance.mode = cycle_log_mode(logging.performance.mode);
+                logging.performance.mode =
+                    Some(cycle_log_mode(logging.performance.effective_mode()));
             }
             _ => {}
         }
@@ -3069,7 +3075,7 @@ impl ReplApp {
                 }
             }),
             PanelState::UserConfig { status_msg, .. } => {
-                Some(Self::USER_CONFIG_ROWS as u16 + 8 + u16::from(status_msg.is_some()))
+                Some(Self::USER_CONFIG_ROWS as u16 + 10 + 2 * u16::from(status_msg.is_some()))
             }
             PanelState::InitWorkspace {
                 confirm_overwrite, ..
@@ -4452,21 +4458,24 @@ impl ReplApp {
         frame.render_widget(block, area);
 
         let logging = self.user_config.logging.clone().unwrap_or_default();
-        let general_level = if logging.general.enabled {
-            logging.general.level
+        let general_level = if logging.general.effective_enabled() {
+            logging.general.effective_level()
         } else {
             LogLevel::Off
         };
-        let performance = if logging.performance.enabled {
+        let performance = if logging.performance.effective_enabled() {
             "enabled"
         } else {
             "disabled"
         };
         let rows = [
             ("General level", general_level.to_string()),
-            ("General mode", logging.general.mode.to_string()),
+            ("General mode", logging.general.effective_mode().to_string()),
             ("Performance log", performance.to_string()),
-            ("Performance mode", logging.performance.mode.to_string()),
+            (
+                "Performance mode",
+                logging.performance.effective_mode().to_string(),
+            ),
         ];
 
         let mut lines: Vec<Line<'_>> = Vec::new();
@@ -6163,8 +6172,8 @@ mod tests {
         );
 
         let logging = app.user_config.logging.expect("logging settings");
-        assert_eq!(logging.general.level, LogLevel::Warn);
-        assert!(logging.general.enabled);
+        assert_eq!(logging.general.level, Some(LogLevel::Warn));
+        assert_eq!(logging.general.enabled, Some(true));
         assert!(matches!(
             app.panel,
             PanelState::UserConfig {
@@ -6195,7 +6204,10 @@ mod tests {
         );
 
         let saved = crate::config::load_user_config().expect("user config must save");
-        assert!(saved.logging.expect("logging settings").performance.enabled);
+        assert_eq!(
+            saved.logging.expect("logging settings").performance.enabled,
+            Some(true)
+        );
     }
 
     #[test]

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -19,7 +19,7 @@ use ratatui::widgets::{Block, Clear, Paragraph, Wrap};
 use ratatui_textarea::{CursorMove, TextArea};
 
 use crate::agents::LlmClient;
-use crate::config::{DuumbiConfig, ProviderConfigSource};
+use crate::config::{DuumbiConfig, LogLevel, LogMode, LoggingSection, ProviderConfigSource};
 use crate::session::SessionManager;
 
 // ---------------------------------------------------------------------------
@@ -387,6 +387,34 @@ fn animated_provider_status_message(msg: &str) -> String {
 
     let dots = (ReplApp::animation_now_ms() / 360 % 4) as usize;
     format!("{PROVIDER_TESTING_STATUS_PREFIX}{:<3}", ".".repeat(dots))
+}
+
+fn cycle_log_level(level: LogLevel, forward: bool) -> LogLevel {
+    const LEVELS: &[LogLevel] = &[
+        LogLevel::Off,
+        LogLevel::Error,
+        LogLevel::Warn,
+        LogLevel::Info,
+        LogLevel::Debug,
+        LogLevel::Trace,
+    ];
+    let index = LEVELS
+        .iter()
+        .position(|candidate| *candidate == level)
+        .unwrap_or(1);
+    let next = if forward {
+        (index + 1) % LEVELS.len()
+    } else {
+        (index + LEVELS.len() - 1) % LEVELS.len()
+    };
+    LEVELS[next]
+}
+
+fn cycle_log_mode(mode: LogMode) -> LogMode {
+    match mode {
+        LogMode::Append => LogMode::Rewrite,
+        LogMode::Rewrite => LogMode::Append,
+    }
 }
 
 pub(crate) async fn probe_provider_config_with_key(
@@ -978,17 +1006,23 @@ impl ReplApp {
     /// mode toggles, slash-menu navigation, and output buffer updates.
     pub fn handle_key(&mut self, key: KeyEvent, textarea: &mut TextArea<'_>) -> Action {
         // Interactive panel gets priority over normal key handling.
-        if matches!(self.panel, PanelState::ProviderManager { .. }) {
-            return self.handle_provider_panel_key(key, textarea);
-        }
-        if matches!(self.panel, PanelState::InitWorkspace { .. }) {
-            return self.handle_init_panel_key(key);
-        }
-        if matches!(self.panel, PanelState::IntentPicker { .. }) {
-            return self.handle_intent_picker_key(key, textarea);
-        }
-        if matches!(self.panel, PanelState::ConfirmIntentDelete { .. }) {
-            return self.handle_confirm_intent_delete_key(key);
+        match self.panel {
+            PanelState::ProviderManager { .. } => {
+                return self.handle_provider_panel_key(key, textarea);
+            }
+            PanelState::UserConfig { .. } => {
+                return self.handle_user_config_panel_key(key, textarea);
+            }
+            PanelState::InitWorkspace { .. } => {
+                return self.handle_init_panel_key(key);
+            }
+            PanelState::IntentPicker { .. } => {
+                return self.handle_intent_picker_key(key, textarea);
+            }
+            PanelState::ConfirmIntentDelete { .. } => {
+                return self.handle_confirm_intent_delete_key(key);
+            }
+            PanelState::None => {}
         }
 
         if self.conversation_action_menu.is_some() {
@@ -1141,7 +1175,9 @@ impl ReplApp {
         }
         if matches!(
             self.panel,
-            PanelState::IntentPicker { .. } | PanelState::ConfirmIntentDelete { .. }
+            PanelState::IntentPicker { .. }
+                | PanelState::ConfirmIntentDelete { .. }
+                | PanelState::UserConfig { .. }
         ) {
             return;
         }
@@ -1450,6 +1486,88 @@ impl ReplApp {
         Action::Continue
     }
 
+    const USER_CONFIG_ROWS: usize = 4;
+
+    /// Handles key events when the user configuration panel is active.
+    fn handle_user_config_panel_key(
+        &mut self,
+        key_event: KeyEvent,
+        textarea: &mut TextArea<'_>,
+    ) -> Action {
+        let mut selected = match &self.panel {
+            PanelState::UserConfig { selected, .. } => *selected,
+            _ => return Action::Continue,
+        };
+        let mut status_msg = None;
+
+        match key_event.code {
+            KeyCode::Esc => {
+                self.panel = PanelState::None;
+                textarea.move_cursor(CursorMove::Head);
+                textarea.delete_line_by_end();
+                return Action::Continue;
+            }
+            KeyCode::Up => {
+                selected = selected.saturating_sub(1);
+            }
+            KeyCode::Down => {
+                selected = (selected + 1).min(Self::USER_CONFIG_ROWS - 1);
+            }
+            KeyCode::Left => {
+                self.adjust_user_config_setting(selected, false);
+                status_msg = Some(("Changed. Press S to save.".to_string(), OutputStyle::Dim));
+            }
+            KeyCode::Right | KeyCode::Enter | KeyCode::Char(' ') => {
+                self.adjust_user_config_setting(selected, true);
+                status_msg = Some(("Changed. Press S to save.".to_string(), OutputStyle::Dim));
+            }
+            KeyCode::Char('s') | KeyCode::Char('S') => {
+                match crate::config::save_user_config(&self.user_config) {
+                    Ok(()) => {
+                        self.refresh_effective_config();
+                        status_msg =
+                            Some(("Logging defaults saved.".to_string(), OutputStyle::Success));
+                    }
+                    Err(e) => {
+                        status_msg = Some((format!("Save failed: {e}"), OutputStyle::Error));
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        self.panel = PanelState::UserConfig {
+            selected,
+            status_msg,
+        };
+        Action::Continue
+    }
+
+    fn adjust_user_config_setting(&mut self, selected: usize, forward: bool) {
+        let logging = self
+            .user_config
+            .logging
+            .get_or_insert_with(LoggingSection::default);
+        match selected {
+            0 => {
+                let next = cycle_log_level(logging.general.level, forward);
+                logging.general.level = next;
+                logging.general.enabled = next != LogLevel::Off;
+            }
+            1 => {
+                logging.general.mode = cycle_log_mode(logging.general.mode);
+            }
+            2 => {
+                logging.performance.enabled = !logging.performance.enabled;
+            }
+            3 => {
+                logging.performance.mode = cycle_log_mode(logging.performance.mode);
+            }
+            _ => {}
+        }
+        self.refresh_effective_config();
+    }
+
     /// Handles key events when the provider manager panel is active.
     ///
     /// Extracts panel state by value, processes the key, then writes back.
@@ -1464,10 +1582,7 @@ impl ReplApp {
                 input_mode,
                 ..
             } => (*selected, input_mode.clone()),
-            PanelState::None
-            | PanelState::InitWorkspace { .. }
-            | PanelState::IntentPicker { .. }
-            | PanelState::ConfirmIntentDelete { .. } => return Action::Continue,
+            _ => return Action::Continue,
         };
         let mut new_status_msg: Option<(String, OutputStyle)> = None;
         let mut action = Action::Continue;
@@ -2864,6 +2979,17 @@ impl ReplApp {
                     )
                 }
             }
+            PanelState::UserConfig {
+                selected,
+                status_msg,
+            } => {
+                if let Some(overlay_height) = self.overlay_height() {
+                    let overlay_width = page.width.saturating_sub(4).clamp(52, 96);
+                    let overlay_area =
+                        Self::centered_overlay_rect(page, overlay_width, overlay_height);
+                    self.render_user_config_panel(frame, overlay_area, *selected, status_msg);
+                }
+            }
             PanelState::InitWorkspace { .. } => {
                 if let Some(overlay_height) = self.overlay_height() {
                     let overlay_width = page.width.saturating_sub(4).clamp(52, 96);
@@ -2942,6 +3068,9 @@ impl ReplApp {
                     (provider_count as u16) + 9 + status_line
                 }
             }),
+            PanelState::UserConfig { status_msg, .. } => {
+                Some(Self::USER_CONFIG_ROWS as u16 + 8 + u16::from(status_msg.is_some()))
+            }
             PanelState::InitWorkspace {
                 confirm_overwrite, ..
             } => Some(if *confirm_overwrite { 16 } else { 12 }),
@@ -4301,6 +4430,89 @@ impl ReplApp {
             Span::styled(matched, theme::slash_match()),
             Span::styled(rest, theme::slash_command()),
         ])
+    }
+
+    /// Renders the interactive user configuration panel.
+    fn render_user_config_panel(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        selected: usize,
+        status_msg: &Option<(String, OutputStyle)>,
+    ) {
+        use ratatui::widgets::{Block, Borders, Padding};
+
+        frame.render_widget(Clear, area);
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(theme::panel_border())
+            .padding(Padding::new(1, 1, 1, 1))
+            .style(theme::panel_surface());
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        let logging = self.user_config.logging.clone().unwrap_or_default();
+        let general_level = if logging.general.enabled {
+            logging.general.level
+        } else {
+            LogLevel::Off
+        };
+        let performance = if logging.performance.enabled {
+            "enabled"
+        } else {
+            "disabled"
+        };
+        let rows = [
+            ("General level", general_level.to_string()),
+            ("General mode", logging.general.mode.to_string()),
+            ("Performance log", performance.to_string()),
+            ("Performance mode", logging.performance.mode.to_string()),
+        ];
+
+        let mut lines: Vec<Line<'_>> = Vec::new();
+        let inner_width = inner.width as usize;
+        lines.push(Line::from(vec![
+            Span::styled("  User Config", theme::brand_word()),
+            Span::raw(" ".repeat(inner_width.saturating_sub(38))),
+            Span::styled("(Esc to close)", theme::out_dim()),
+        ]));
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "  Logging defaults saved to ~/.duumbi/config.toml",
+            theme::out_dim(),
+        )));
+        lines.push(Line::from(""));
+
+        for (index, (label, value)) in rows.iter().enumerate() {
+            let is_sel = index == selected;
+            let prefix = if is_sel { "  \u{25cf} " } else { "    " };
+            let style = if is_sel {
+                theme::slash_selected()
+            } else {
+                theme::out_dim()
+            };
+            lines.push(Line::from(Span::styled(
+                format!("{prefix}{label:<18} {value}"),
+                style,
+            )));
+        }
+
+        if let Some((msg, style)) = status_msg {
+            let style = match style {
+                OutputStyle::Success => theme::out_success(),
+                OutputStyle::Error => theme::out_error(),
+                _ => theme::out_dim(),
+            };
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(format!("  {msg}"), style)));
+        }
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "  [\u{2191}/\u{2193}] Select  [\u{2190}/\u{2192}] Change  [S] Save",
+            theme::out_dim(),
+        )));
+
+        frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
     }
 
     /// Renders the workspace initialization panel.
@@ -5935,6 +6147,55 @@ mod tests {
         let key = KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL);
         let action = app.handle_key(key, &mut textarea);
         assert!(matches!(action, Action::Exit));
+    }
+
+    #[test]
+    fn user_config_panel_cycles_general_log_level() {
+        let (mut app, mut textarea) = make_app();
+        app.panel = PanelState::UserConfig {
+            selected: 0,
+            status_msg: None,
+        };
+
+        app.handle_key(
+            KeyEvent::new(KeyCode::Right, KeyModifiers::NONE),
+            &mut textarea,
+        );
+
+        let logging = app.user_config.logging.expect("logging settings");
+        assert_eq!(logging.general.level, LogLevel::Warn);
+        assert!(logging.general.enabled);
+        assert!(matches!(
+            app.panel,
+            PanelState::UserConfig {
+                status_msg: Some(_),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn user_config_panel_saves_logging_defaults() {
+        let _guard = crate::cli::TEST_ENV_LOCK.lock().expect("env lock");
+        let home = tempfile::TempDir::new().expect("invariant: temp dir");
+        let _home = HomeEnvGuard::set(home.path());
+        let (mut app, mut textarea) = make_app();
+        app.panel = PanelState::UserConfig {
+            selected: 2,
+            status_msg: None,
+        };
+
+        app.handle_key(
+            KeyEvent::new(KeyCode::Right, KeyModifiers::NONE),
+            &mut textarea,
+        );
+        app.handle_key(
+            KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE),
+            &mut textarea,
+        );
+
+        let saved = crate::config::load_user_config().expect("user config must save");
+        assert!(saved.logging.expect("logging settings").performance.enabled);
     }
 
     #[test]

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -190,7 +190,7 @@ pub(crate) fn describe_to_string(input: &Path) -> Result<String> {
 }
 
 /// If `input` is `<workspace>/.duumbi/graph/*.jsonld`, returns `<workspace>`.
-fn workspace_root_for_graph_input(input: &Path) -> Option<std::path::PathBuf> {
+pub(crate) fn workspace_root_for_graph_input(input: &Path) -> Option<std::path::PathBuf> {
     let parent = input.parent()?;
     if parent.file_name().and_then(|s| s.to_str()) != Some("graph") {
         return None;

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -263,6 +263,16 @@ pub const SLASH_COMMANDS: &[SlashCommand] = &[
         group: SlashGroup::WorkspaceConfig,
     },
     SlashCommand {
+        command: "/settings",
+        description: "Manage user configuration defaults",
+        group: SlashGroup::WorkspaceConfig,
+    },
+    SlashCommand {
+        command: "/config",
+        description: "Manage user configuration defaults",
+        group: SlashGroup::WorkspaceConfig,
+    },
+    SlashCommand {
         command: "/help",
         description: "Show available commands",
         group: SlashGroup::System,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -23,7 +23,7 @@ pub mod yank;
 
 use std::path::PathBuf;
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 #[cfg(test)]
 pub(crate) static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -32,9 +32,81 @@ pub(crate) static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(()
 #[derive(Parser, Debug)]
 #[command(name = "duumbi", version, about)]
 pub struct Cli {
+    /// General diagnostic log level for this invocation.
+    #[arg(long, value_enum, global = true)]
+    pub log_level: Option<CliLogLevel>,
+
+    /// General diagnostic log file path for this invocation.
+    #[arg(long, global = true)]
+    pub log_file: Option<PathBuf>,
+
+    /// General diagnostic log write mode for this invocation.
+    #[arg(long, value_enum, global = true)]
+    pub log_mode: Option<CliLogMode>,
+
+    /// Enable command performance JSONL logging for this invocation.
+    #[arg(long, global = true)]
+    pub perf_log: bool,
+
+    /// Performance JSONL log file path for this invocation.
+    #[arg(long, global = true)]
+    pub perf_log_file: Option<PathBuf>,
+
+    /// Performance JSONL log write mode for this invocation.
+    #[arg(long, value_enum, global = true)]
+    pub perf_log_mode: Option<CliLogMode>,
+
     /// Subcommand to execute.
     #[command(subcommand)]
     pub command: Commands,
+}
+
+/// CLI values for the general diagnostic log level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum CliLogLevel {
+    /// Disable general diagnostic logging.
+    Off,
+    /// Log errors only.
+    Error,
+    /// Log warnings and errors.
+    Warn,
+    /// Log informational messages and above.
+    Info,
+    /// Log debug messages and above.
+    Debug,
+    /// Log all tracing events.
+    Trace,
+}
+
+impl From<CliLogLevel> for crate::config::LogLevel {
+    fn from(value: CliLogLevel) -> Self {
+        match value {
+            CliLogLevel::Off => Self::Off,
+            CliLogLevel::Error => Self::Error,
+            CliLogLevel::Warn => Self::Warn,
+            CliLogLevel::Info => Self::Info,
+            CliLogLevel::Debug => Self::Debug,
+            CliLogLevel::Trace => Self::Trace,
+        }
+    }
+}
+
+/// CLI values for log file write mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum CliLogMode {
+    /// Append to an existing file.
+    Append,
+    /// Rewrite the file when logging starts.
+    Rewrite,
+}
+
+impl From<CliLogMode> for crate::config::LogMode {
+    fn from(value: CliLogMode) -> Self {
+        match value {
+            CliLogMode::Append => Self::Append,
+            CliLogMode::Rewrite => Self::Rewrite,
+        }
+    }
 }
 
 /// Available CLI commands.
@@ -466,4 +538,52 @@ pub enum IntentSubcommand {
         /// Intent name/slug to show details for. Omit to list all.
         name: Option<String>,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn global_logging_flags_parse_before_subcommand() {
+        let cli = Cli::try_parse_from([
+            "duumbi",
+            "--log-level",
+            "debug",
+            "--log-file",
+            "duumbi.log",
+            "--log-mode",
+            "rewrite",
+            "--perf-log",
+            "--perf-log-file",
+            "perf.jsonl",
+            "--perf-log-mode",
+            "append",
+            "build",
+        ])
+        .expect("CLI must parse");
+
+        assert_eq!(cli.log_level, Some(CliLogLevel::Debug));
+        assert_eq!(
+            cli.log_file.as_deref(),
+            Some(std::path::Path::new("duumbi.log"))
+        );
+        assert_eq!(cli.log_mode, Some(CliLogMode::Rewrite));
+        assert!(cli.perf_log);
+        assert_eq!(
+            cli.perf_log_file.as_deref(),
+            Some(std::path::Path::new("perf.jsonl"))
+        );
+        assert_eq!(cli.perf_log_mode, Some(CliLogMode::Append));
+        assert!(matches!(cli.command, Commands::Build { .. }));
+    }
+
+    #[test]
+    fn global_logging_flags_parse_after_subcommand() {
+        let cli =
+            Cli::try_parse_from(["duumbi", "check", "--log-level", "off"]).expect("CLI must parse");
+
+        assert_eq!(cli.log_level, Some(CliLogLevel::Off));
+        assert!(matches!(cli.command, Commands::Check { .. }));
+    }
 }

--- a/src/cli/mode.rs
+++ b/src/cli/mode.rs
@@ -213,6 +213,13 @@ pub enum PanelState {
     /// No panel open — normal REPL mode.
     #[default]
     None,
+    /// User configuration panel.
+    UserConfig {
+        /// Index of highlighted setting row.
+        selected: usize,
+        /// Optional status message shown in the panel footer. Cleared on next key press.
+        status_msg: Option<(String, OutputStyle)>,
+    },
     /// Provider connection manager panel.
     ProviderManager {
         /// Index of highlighted provider kind (0-based).

--- a/src/cli/publish.rs
+++ b/src/cli/publish.rs
@@ -280,6 +280,7 @@ mod tests {
             cost: None,
             agent: None,
             editor: None,
+            logging: None,
             mcp_clients: HashMap::new(),
         }
     }

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -627,6 +627,15 @@ async fn handle_slash(
             textarea.delete_line_by_end();
         }
 
+        "/settings" | "/config" => {
+            app.panel = super::mode::PanelState::UserConfig {
+                selected: 0,
+                status_msg: None,
+            };
+            textarea.move_cursor(ratatui_textarea::CursorMove::Head);
+            textarea.delete_line_by_end();
+        }
+
         "/help" => {
             print_help_to_buffer(app);
         }

--- a/src/cli/yank.rs
+++ b/src/cli/yank.rs
@@ -178,6 +178,7 @@ mod tests {
             cost: None,
             agent: None,
             editor: None,
+            logging: None,
             mcp_clients: HashMap::new(),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -468,6 +468,122 @@ impl Default for AgentSection {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Logging configuration
+// ---------------------------------------------------------------------------
+
+/// General diagnostic log level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    /// Disable general diagnostic logging.
+    Off,
+    /// Log errors only.
+    #[default]
+    Error,
+    /// Log warnings and errors.
+    Warn,
+    /// Log informational messages and above.
+    Info,
+    /// Log debug messages and above.
+    Debug,
+    /// Log all tracing events.
+    Trace,
+}
+
+impl fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Off => f.write_str("off"),
+            Self::Error => f.write_str("error"),
+            Self::Warn => f.write_str("warn"),
+            Self::Info => f.write_str("info"),
+            Self::Debug => f.write_str("debug"),
+            Self::Trace => f.write_str("trace"),
+        }
+    }
+}
+
+/// File write mode for a log.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum LogMode {
+    /// Append to an existing file.
+    #[default]
+    Append,
+    /// Truncate the file when logging starts.
+    Rewrite,
+}
+
+impl fmt::Display for LogMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Append => f.write_str("append"),
+            Self::Rewrite => f.write_str("rewrite"),
+        }
+    }
+}
+
+fn default_general_logging_enabled() -> bool {
+    true
+}
+
+/// General diagnostic logging configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct GeneralLoggingSection {
+    /// Whether general diagnostic logging is enabled.
+    #[serde(default = "default_general_logging_enabled")]
+    pub enabled: bool,
+    /// Minimum diagnostic level to write.
+    #[serde(default)]
+    pub level: LogLevel,
+    /// Append or rewrite the log file.
+    #[serde(default)]
+    pub mode: LogMode,
+    /// Optional path override. Relative paths are resolved by the process.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<PathBuf>,
+}
+
+impl Default for GeneralLoggingSection {
+    fn default() -> Self {
+        Self {
+            enabled: default_general_logging_enabled(),
+            level: LogLevel::Error,
+            mode: LogMode::Append,
+            path: None,
+        }
+    }
+}
+
+/// Performance logging configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct PerformanceLoggingSection {
+    /// Whether command performance logging is enabled.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Append or rewrite the performance log file.
+    #[serde(default)]
+    pub mode: LogMode,
+    /// Optional path override. Relative paths are resolved by the process.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<PathBuf>,
+}
+
+/// Logging configuration for workspace diagnostics and command timings.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct LoggingSection {
+    /// General diagnostic tracing log.
+    #[serde(default)]
+    pub general: GeneralLoggingSection,
+    /// Command performance JSONL log.
+    #[serde(default)]
+    pub performance: PerformanceLoggingSection,
+}
+
 /// Optional `[vendor]` section in `config.toml`.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct VendorSection {
@@ -563,6 +679,10 @@ pub struct DuumbiConfig {
     /// Agent mutation retry/repair policy.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent: Option<AgentSection>,
+
+    /// Logging settings for diagnostics and command performance events.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub logging: Option<LoggingSection>,
 }
 
 impl DuumbiConfig {
@@ -846,6 +966,9 @@ fn merge_non_provider_fields(base: &mut DuumbiConfig, overlay: &DuumbiConfig) {
     if overlay.agent.is_some() {
         base.agent = overlay.agent.clone();
     }
+    if overlay.logging.is_some() {
+        base.logging = overlay.logging.clone();
+    }
 }
 
 /// Saves a [`DuumbiConfig`] to `<workspace_root>/.duumbi/config.toml`.
@@ -903,6 +1026,7 @@ fn load_config_file(path: &Path) -> Result<DuumbiConfig, ConfigError> {
 mod tests {
     use super::*;
     use std::fs;
+    use std::path::Path;
     use tempfile::TempDir;
 
     fn write_config(dir: &TempDir, contents: &str) {
@@ -1111,6 +1235,82 @@ editor = "code --wait"
         let effective = merge_config_layers(DuumbiConfig::default(), user, workspace);
 
         assert_eq!(effective.config.editor.as_deref(), Some("zed --wait"));
+    }
+
+    #[test]
+    fn logging_config_defaults_match_user_config_policy() {
+        let logging = LoggingSection::default();
+
+        assert!(logging.general.enabled);
+        assert_eq!(logging.general.level, LogLevel::Error);
+        assert_eq!(logging.general.mode, LogMode::Append);
+        assert!(!logging.performance.enabled);
+        assert_eq!(logging.performance.mode, LogMode::Append);
+    }
+
+    #[test]
+    fn logging_config_roundtrip() {
+        let tmp = TempDir::new().expect("invariant: temp dir creation must succeed");
+        write_config(
+            &tmp,
+            r#"
+[logging.general]
+enabled = true
+level = "debug"
+mode = "rewrite"
+path = "custom-general.log"
+
+[logging.performance]
+enabled = true
+mode = "append"
+path = "custom-performance.jsonl"
+"#,
+        );
+
+        let cfg = load_config(tmp.path()).expect("config must parse");
+        let logging = cfg.logging.expect("logging section");
+        assert_eq!(logging.general.level, LogLevel::Debug);
+        assert_eq!(logging.general.mode, LogMode::Rewrite);
+        assert_eq!(
+            logging.general.path.as_deref(),
+            Some(Path::new("custom-general.log"))
+        );
+        assert!(logging.performance.enabled);
+        assert_eq!(
+            logging.performance.path.as_deref(),
+            Some(Path::new("custom-performance.jsonl"))
+        );
+    }
+
+    #[test]
+    fn effective_config_workspace_logging_overrides_user_logging() {
+        let user = DuumbiConfig {
+            logging: Some(LoggingSection {
+                general: GeneralLoggingSection {
+                    level: LogLevel::Warn,
+                    ..GeneralLoggingSection::default()
+                },
+                ..LoggingSection::default()
+            }),
+            ..DuumbiConfig::default()
+        };
+        let workspace = DuumbiConfig {
+            logging: Some(LoggingSection {
+                general: GeneralLoggingSection {
+                    level: LogLevel::Info,
+                    ..GeneralLoggingSection::default()
+                },
+                ..LoggingSection::default()
+            }),
+            ..DuumbiConfig::default()
+        };
+
+        let effective = merge_config_layers(DuumbiConfig::default(), user, workspace);
+
+        assert_eq!(
+            effective.config.logging.expect("logging").general.level,
+            LogLevel::Info
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -529,31 +529,40 @@ fn default_general_logging_enabled() -> bool {
 }
 
 /// General diagnostic logging configuration.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct GeneralLoggingSection {
     /// Whether general diagnostic logging is enabled.
-    #[serde(default = "default_general_logging_enabled")]
-    pub enabled: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
     /// Minimum diagnostic level to write.
-    #[serde(default)]
-    pub level: LogLevel,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub level: Option<LogLevel>,
     /// Append or rewrite the log file.
-    #[serde(default)]
-    pub mode: LogMode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<LogMode>,
     /// Optional path override. Relative paths are resolved by the process.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<PathBuf>,
 }
 
-impl Default for GeneralLoggingSection {
-    fn default() -> Self {
-        Self {
-            enabled: default_general_logging_enabled(),
-            level: LogLevel::Error,
-            mode: LogMode::Append,
-            path: None,
-        }
+impl GeneralLoggingSection {
+    /// Returns whether diagnostic logging is enabled after defaults.
+    #[must_use]
+    pub fn effective_enabled(&self) -> bool {
+        self.enabled.unwrap_or_else(default_general_logging_enabled)
+    }
+
+    /// Returns the effective diagnostic log level.
+    #[must_use]
+    pub fn effective_level(&self) -> LogLevel {
+        self.level.unwrap_or_default()
+    }
+
+    /// Returns the effective diagnostic log write mode.
+    #[must_use]
+    pub fn effective_mode(&self) -> LogMode {
+        self.mode.unwrap_or_default()
     }
 }
 
@@ -562,14 +571,28 @@ impl Default for GeneralLoggingSection {
 #[serde(rename_all = "kebab-case")]
 pub struct PerformanceLoggingSection {
     /// Whether command performance logging is enabled.
-    #[serde(default)]
-    pub enabled: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
     /// Append or rewrite the performance log file.
-    #[serde(default)]
-    pub mode: LogMode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<LogMode>,
     /// Optional path override. Relative paths are resolved by the process.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<PathBuf>,
+}
+
+impl PerformanceLoggingSection {
+    /// Returns whether performance logging is enabled after defaults.
+    #[must_use]
+    pub fn effective_enabled(&self) -> bool {
+        self.enabled.unwrap_or(false)
+    }
+
+    /// Returns the effective performance log write mode.
+    #[must_use]
+    pub fn effective_mode(&self) -> LogMode {
+        self.mode.unwrap_or_default()
+    }
 }
 
 /// Logging configuration for workspace diagnostics and command timings.
@@ -966,8 +989,35 @@ fn merge_non_provider_fields(base: &mut DuumbiConfig, overlay: &DuumbiConfig) {
     if overlay.agent.is_some() {
         base.agent = overlay.agent.clone();
     }
-    if overlay.logging.is_some() {
-        base.logging = overlay.logging.clone();
+    if let Some(logging) = overlay.logging.as_ref() {
+        merge_logging_fields(&mut base.logging, logging);
+    }
+}
+
+fn merge_logging_fields(base: &mut Option<LoggingSection>, overlay: &LoggingSection) {
+    let base = base.get_or_insert_with(LoggingSection::default);
+
+    if overlay.general.enabled.is_some() {
+        base.general.enabled = overlay.general.enabled;
+    }
+    if overlay.general.level.is_some() {
+        base.general.level = overlay.general.level;
+    }
+    if overlay.general.mode.is_some() {
+        base.general.mode = overlay.general.mode;
+    }
+    if overlay.general.path.is_some() {
+        base.general.path = overlay.general.path.clone();
+    }
+
+    if overlay.performance.enabled.is_some() {
+        base.performance.enabled = overlay.performance.enabled;
+    }
+    if overlay.performance.mode.is_some() {
+        base.performance.mode = overlay.performance.mode;
+    }
+    if overlay.performance.path.is_some() {
+        base.performance.path = overlay.performance.path.clone();
     }
 }
 
@@ -1241,11 +1291,11 @@ editor = "code --wait"
     fn logging_config_defaults_match_user_config_policy() {
         let logging = LoggingSection::default();
 
-        assert!(logging.general.enabled);
-        assert_eq!(logging.general.level, LogLevel::Error);
-        assert_eq!(logging.general.mode, LogMode::Append);
-        assert!(!logging.performance.enabled);
-        assert_eq!(logging.performance.mode, LogMode::Append);
+        assert!(logging.general.effective_enabled());
+        assert_eq!(logging.general.effective_level(), LogLevel::Error);
+        assert_eq!(logging.general.effective_mode(), LogMode::Append);
+        assert!(!logging.performance.effective_enabled());
+        assert_eq!(logging.performance.effective_mode(), LogMode::Append);
     }
 
     #[test]
@@ -1269,13 +1319,13 @@ path = "custom-performance.jsonl"
 
         let cfg = load_config(tmp.path()).expect("config must parse");
         let logging = cfg.logging.expect("logging section");
-        assert_eq!(logging.general.level, LogLevel::Debug);
-        assert_eq!(logging.general.mode, LogMode::Rewrite);
+        assert_eq!(logging.general.level, Some(LogLevel::Debug));
+        assert_eq!(logging.general.mode, Some(LogMode::Rewrite));
         assert_eq!(
             logging.general.path.as_deref(),
             Some(Path::new("custom-general.log"))
         );
-        assert!(logging.performance.enabled);
+        assert_eq!(logging.performance.enabled, Some(true));
         assert_eq!(
             logging.performance.path.as_deref(),
             Some(Path::new("custom-performance.jsonl"))
@@ -1287,7 +1337,7 @@ path = "custom-performance.jsonl"
         let user = DuumbiConfig {
             logging: Some(LoggingSection {
                 general: GeneralLoggingSection {
-                    level: LogLevel::Warn,
+                    level: Some(LogLevel::Warn),
                     ..GeneralLoggingSection::default()
                 },
                 ..LoggingSection::default()
@@ -1297,7 +1347,7 @@ path = "custom-performance.jsonl"
         let workspace = DuumbiConfig {
             logging: Some(LoggingSection {
                 general: GeneralLoggingSection {
-                    level: LogLevel::Info,
+                    level: Some(LogLevel::Info),
                     ..GeneralLoggingSection::default()
                 },
                 ..LoggingSection::default()
@@ -1309,8 +1359,43 @@ path = "custom-performance.jsonl"
 
         assert_eq!(
             effective.config.logging.expect("logging").general.level,
-            LogLevel::Info
+            Some(LogLevel::Info)
         );
+    }
+
+    #[test]
+    fn effective_config_workspace_logging_preserves_unset_user_fields() {
+        let user = DuumbiConfig {
+            logging: Some(LoggingSection {
+                general: GeneralLoggingSection {
+                    level: Some(LogLevel::Debug),
+                    path: Some(PathBuf::from("user-general.log")),
+                    ..GeneralLoggingSection::default()
+                },
+                ..LoggingSection::default()
+            }),
+            ..DuumbiConfig::default()
+        };
+        let workspace = DuumbiConfig {
+            logging: Some(LoggingSection {
+                performance: PerformanceLoggingSection {
+                    enabled: Some(true),
+                    ..PerformanceLoggingSection::default()
+                },
+                ..LoggingSection::default()
+            }),
+            ..DuumbiConfig::default()
+        };
+
+        let effective = merge_config_layers(DuumbiConfig::default(), user, workspace);
+        let logging = effective.config.logging.expect("logging");
+
+        assert_eq!(logging.general.level, Some(LogLevel::Debug));
+        assert_eq!(
+            logging.general.path.as_deref(),
+            Some(Path::new("user-general.log"))
+        );
+        assert_eq!(logging.performance.enabled, Some(true));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod hash;
 pub mod intent;
 pub mod interaction;
 pub mod knowledge;
+pub mod logging;
 pub mod manifest;
 pub mod mcp;
 pub mod parser;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,415 @@
+//! File logging and command performance event support.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::fmt::writer::MakeWriter;
+use tracing_subscriber::util::SubscriberInitExt;
+
+use crate::config::{DuumbiConfig, LogLevel, LogMode, PerformanceLoggingSection};
+
+const DEFAULT_GENERAL_LOG: &str = ".duumbi/logs/duumbi.log";
+const DEFAULT_PERFORMANCE_LOG: &str = ".duumbi/logs/performance.jsonl";
+
+/// CLI-provided logging overrides.
+#[derive(Debug, Clone, Default)]
+pub struct LoggingOverrides {
+    /// General log level override.
+    pub general_level: Option<LogLevel>,
+    /// General log path override.
+    pub general_path: Option<PathBuf>,
+    /// General log write mode override.
+    pub general_mode: Option<LogMode>,
+    /// Performance log enabled override.
+    pub performance_enabled: Option<bool>,
+    /// Performance log path override.
+    pub performance_path: Option<PathBuf>,
+    /// Performance log write mode override.
+    pub performance_mode: Option<LogMode>,
+}
+
+/// Fully resolved logging settings for a process invocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedLogging {
+    /// General tracing log level, if enabled and writable.
+    pub general_level: Option<LogLevel>,
+    /// General tracing log path, if enabled and resolved.
+    pub general_path: Option<PathBuf>,
+    /// General tracing log write mode.
+    pub general_mode: LogMode,
+    /// Performance JSONL log path, if enabled and resolved.
+    pub performance_path: Option<PathBuf>,
+    /// Performance JSONL log write mode.
+    pub performance_mode: LogMode,
+}
+
+/// Runtime logging handles.
+#[derive(Debug, Clone)]
+pub struct RuntimeLogging {
+    performance: Option<PerformanceLogger>,
+}
+
+impl RuntimeLogging {
+    /// Returns the active performance logger, if command timing is enabled.
+    #[must_use]
+    pub fn performance(&self) -> Option<&PerformanceLogger> {
+        self.performance.as_ref()
+    }
+}
+
+/// Append-only command performance event logger.
+#[derive(Debug, Clone)]
+pub struct PerformanceLogger {
+    path: PathBuf,
+    lock: Arc<Mutex<()>>,
+}
+
+impl PerformanceLogger {
+    /// Creates a performance logger at `path`.
+    pub fn new(path: PathBuf, mode: LogMode) -> io::Result<Self> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        if mode == LogMode::Rewrite {
+            OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(&path)?;
+        }
+        Ok(Self {
+            path,
+            lock: Arc::new(Mutex::new(())),
+        })
+    }
+
+    /// Records a command start event and returns the start instant.
+    #[must_use]
+    pub fn record_start(&self, command: &str) -> Instant {
+        let started = Instant::now();
+        let _ = self.write_event(PerformanceEvent {
+            timestamp: Utc::now(),
+            command,
+            phase: "command_start",
+            elapsed_ms: 0,
+            status: "started",
+            error: None,
+        });
+        started
+    }
+
+    /// Records a successful command end event.
+    pub fn record_success(&self, command: &str, started: Instant) {
+        let _ = self.write_end(command, started.elapsed(), "success", None);
+    }
+
+    /// Records a failed command end event.
+    pub fn record_error(&self, command: &str, started: Instant, error: &str) {
+        let _ = self.write_end(command, started.elapsed(), "error", Some(error));
+    }
+
+    fn write_end(
+        &self,
+        command: &str,
+        elapsed: Duration,
+        status: &'static str,
+        error: Option<&str>,
+    ) -> io::Result<()> {
+        self.write_event(PerformanceEvent {
+            timestamp: Utc::now(),
+            command,
+            phase: "command_end",
+            elapsed_ms: elapsed.as_millis() as u64,
+            status,
+            error: error.map(ToOwned::to_owned),
+        })
+    }
+
+    fn write_event(&self, event: PerformanceEvent<'_>) -> io::Result<()> {
+        let _guard = self
+            .lock
+            .lock()
+            .map_err(|_| io::Error::other("performance log lock poisoned"))?;
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)?;
+        let line = serde_json::to_string(&event).map_err(io::Error::other)?;
+        writeln!(file, "{line}")
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PerformanceEvent<'a> {
+    timestamp: DateTime<Utc>,
+    command: &'a str,
+    phase: &'a str,
+    elapsed_ms: u64,
+    status: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+#[derive(Clone)]
+struct SharedMakeWriter {
+    file: Arc<Mutex<File>>,
+}
+
+struct SharedFileWriter {
+    file: Arc<Mutex<File>>,
+}
+
+impl Write for SharedFileWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut file = self
+            .file
+            .lock()
+            .map_err(|_| io::Error::other("log file lock poisoned"))?;
+        file.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let mut file = self
+            .file
+            .lock()
+            .map_err(|_| io::Error::other("log file lock poisoned"))?;
+        file.flush()
+    }
+}
+
+impl<'a> MakeWriter<'a> for SharedMakeWriter {
+    type Writer = SharedFileWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        SharedFileWriter {
+            file: Arc::clone(&self.file),
+        }
+    }
+}
+
+/// Resolves logging settings from config plus CLI overrides.
+#[must_use]
+pub fn resolve_logging(
+    workspace_root: &Path,
+    config: &DuumbiConfig,
+    overrides: &LoggingOverrides,
+) -> ResolvedLogging {
+    let logging = config.logging.clone().unwrap_or_default();
+    let general = logging.general;
+    let performance = logging.performance;
+
+    let mut general_level = if general.enabled {
+        Some(general.level)
+    } else {
+        None
+    };
+    if let Some(level) = overrides.general_level {
+        general_level = (level != LogLevel::Off).then_some(level);
+    }
+    let general_path = overrides
+        .general_path
+        .clone()
+        .or(general.path)
+        .or_else(|| default_log_path(workspace_root, DEFAULT_GENERAL_LOG));
+    let general_mode = overrides.general_mode.unwrap_or(general.mode);
+    if general_level == Some(LogLevel::Off) {
+        general_level = None;
+    }
+
+    let performance_enabled = resolve_performance_enabled(&performance, overrides);
+    let performance_path = performance_enabled
+        .then(|| {
+            overrides
+                .performance_path
+                .clone()
+                .or(performance.path)
+                .or_else(|| default_log_path(workspace_root, DEFAULT_PERFORMANCE_LOG))
+        })
+        .flatten();
+    let performance_mode = overrides.performance_mode.unwrap_or(performance.mode);
+
+    ResolvedLogging {
+        general_level: general_path.as_ref().and(general_level),
+        general_path,
+        general_mode,
+        performance_path,
+        performance_mode,
+    }
+}
+
+fn resolve_performance_enabled(
+    performance: &PerformanceLoggingSection,
+    overrides: &LoggingOverrides,
+) -> bool {
+    overrides
+        .performance_enabled
+        .unwrap_or(performance.enabled || overrides.performance_path.is_some())
+}
+
+fn default_log_path(workspace_root: &Path, relative: &str) -> Option<PathBuf> {
+    workspace_root
+        .join(".duumbi")
+        .exists()
+        .then(|| workspace_root.join(relative))
+}
+
+/// Initializes general tracing and performance logging.
+pub fn initialize(
+    workspace_root: &Path,
+    config: &DuumbiConfig,
+    overrides: &LoggingOverrides,
+) -> io::Result<RuntimeLogging> {
+    let resolved = resolve_logging(workspace_root, config, overrides);
+    if let (Some(level), Some(path)) = (resolved.general_level, resolved.general_path.as_ref()) {
+        init_general_logging(path, resolved.general_mode, level)?;
+    }
+    let performance = resolved
+        .performance_path
+        .map(|path| PerformanceLogger::new(path, resolved.performance_mode))
+        .transpose()?;
+    Ok(RuntimeLogging { performance })
+}
+
+fn init_general_logging(path: &Path, mode: LogMode, level: LogLevel) -> io::Result<()> {
+    let file = open_log_file(path, mode)?;
+    let writer = SharedMakeWriter {
+        file: Arc::new(Mutex::new(file)),
+    };
+    let filter = EnvFilter::new(level.to_string());
+    let subscriber = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_ansi(false)
+        .with_writer(writer)
+        .finish();
+    let _ = subscriber.try_init();
+    Ok(())
+}
+
+fn open_log_file(path: &Path, mode: LogMode) -> io::Result<File> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut options = OpenOptions::new();
+    options.create(true).write(true);
+    match mode {
+        LogMode::Append => {
+            options.append(true);
+        }
+        LogMode::Rewrite => {
+            options.truncate(true);
+        }
+    }
+    options.open(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{GeneralLoggingSection, LoggingSection};
+    use tempfile::TempDir;
+
+    #[test]
+    fn default_paths_require_workspace() {
+        let tmp = TempDir::new().expect("invariant: temp dir");
+        let resolved = resolve_logging(
+            tmp.path(),
+            &DuumbiConfig::default(),
+            &LoggingOverrides::default(),
+        );
+
+        assert_eq!(resolved.general_level, None);
+        assert_eq!(resolved.general_path, None);
+        assert_eq!(resolved.performance_path, None);
+    }
+
+    #[test]
+    fn default_general_log_uses_workspace_logs_dir() {
+        let tmp = TempDir::new().expect("invariant: temp dir");
+        fs::create_dir_all(tmp.path().join(".duumbi")).expect("mkdir");
+
+        let resolved = resolve_logging(
+            tmp.path(),
+            &DuumbiConfig::default(),
+            &LoggingOverrides::default(),
+        );
+
+        assert_eq!(resolved.general_level, Some(LogLevel::Error));
+        assert_eq!(
+            resolved.general_path,
+            Some(tmp.path().join(DEFAULT_GENERAL_LOG))
+        );
+    }
+
+    #[test]
+    fn cli_level_off_disables_general_logging() {
+        let tmp = TempDir::new().expect("invariant: temp dir");
+        fs::create_dir_all(tmp.path().join(".duumbi")).expect("mkdir");
+        let overrides = LoggingOverrides {
+            general_level: Some(LogLevel::Off),
+            ..LoggingOverrides::default()
+        };
+
+        let resolved = resolve_logging(tmp.path(), &DuumbiConfig::default(), &overrides);
+
+        assert_eq!(resolved.general_level, None);
+    }
+
+    #[test]
+    fn explicit_paths_do_not_require_workspace() {
+        let tmp = TempDir::new().expect("invariant: temp dir");
+        let path = tmp.path().join("custom.log");
+        let overrides = LoggingOverrides {
+            general_path: Some(path.clone()),
+            ..LoggingOverrides::default()
+        };
+
+        let resolved = resolve_logging(tmp.path(), &DuumbiConfig::default(), &overrides);
+
+        assert_eq!(resolved.general_level, Some(LogLevel::Error));
+        assert_eq!(resolved.general_path, Some(path));
+    }
+
+    #[test]
+    fn user_config_can_disable_general_logging() {
+        let tmp = TempDir::new().expect("invariant: temp dir");
+        fs::create_dir_all(tmp.path().join(".duumbi")).expect("mkdir");
+        let config = DuumbiConfig {
+            logging: Some(LoggingSection {
+                general: GeneralLoggingSection {
+                    enabled: false,
+                    ..GeneralLoggingSection::default()
+                },
+                ..LoggingSection::default()
+            }),
+            ..DuumbiConfig::default()
+        };
+
+        let resolved = resolve_logging(tmp.path(), &config, &LoggingOverrides::default());
+
+        assert_eq!(resolved.general_level, None);
+    }
+
+    #[test]
+    fn performance_logger_rewrite_truncates_once_then_appends() {
+        let tmp = TempDir::new().expect("invariant: temp dir");
+        let path = tmp.path().join("performance.jsonl");
+        fs::write(&path, "old\n").expect("write old log");
+        let logger = PerformanceLogger::new(path.clone(), LogMode::Rewrite).expect("logger");
+
+        let started = logger.record_start("build");
+        logger.record_success("build", started);
+
+        let log = fs::read_to_string(path).expect("read performance log");
+        assert!(!log.contains("old"));
+        assert_eq!(log.lines().count(), 2);
+        assert!(log.contains("\"phase\":\"command_start\""));
+        assert!(log.contains("\"status\":\"success\""));
+    }
+}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -56,6 +56,12 @@ pub struct RuntimeLogging {
 }
 
 impl RuntimeLogging {
+    /// Returns a runtime logging handle with file and performance logging disabled.
+    #[must_use]
+    pub fn disabled() -> Self {
+        Self { performance: None }
+    }
+
     /// Returns the active performance logger, if command timing is enabled.
     #[must_use]
     pub fn performance(&self) -> Option<&PerformanceLogger> {
@@ -205,8 +211,8 @@ pub fn resolve_logging(
     let general = logging.general;
     let performance = logging.performance;
 
-    let mut general_level = if general.enabled {
-        Some(general.level)
+    let mut general_level = if general.effective_enabled() {
+        Some(general.effective_level())
     } else {
         None
     };
@@ -216,9 +222,11 @@ pub fn resolve_logging(
     let general_path = overrides
         .general_path
         .clone()
-        .or(general.path)
+        .or_else(|| general.path.clone())
         .or_else(|| default_log_path(workspace_root, DEFAULT_GENERAL_LOG));
-    let general_mode = overrides.general_mode.unwrap_or(general.mode);
+    let general_mode = overrides
+        .general_mode
+        .unwrap_or_else(|| general.effective_mode());
     if general_level == Some(LogLevel::Off) {
         general_level = None;
     }
@@ -229,11 +237,13 @@ pub fn resolve_logging(
             overrides
                 .performance_path
                 .clone()
-                .or(performance.path)
+                .or_else(|| performance.path.clone())
                 .or_else(|| default_log_path(workspace_root, DEFAULT_PERFORMANCE_LOG))
         })
         .flatten();
-    let performance_mode = overrides.performance_mode.unwrap_or(performance.mode);
+    let performance_mode = overrides
+        .performance_mode
+        .unwrap_or_else(|| performance.effective_mode());
 
     ResolvedLogging {
         general_level: general_path.as_ref().and(general_level),
@@ -250,7 +260,7 @@ fn resolve_performance_enabled(
 ) -> bool {
     overrides
         .performance_enabled
-        .unwrap_or(performance.enabled || overrides.performance_path.is_some())
+        .unwrap_or(performance.effective_enabled() || overrides.performance_path.is_some())
 }
 
 fn default_log_path(workspace_root: &Path, relative: &str) -> Option<PathBuf> {
@@ -288,8 +298,7 @@ fn init_general_logging(path: &Path, mode: LogMode, level: LogLevel) -> io::Resu
         .with_ansi(false)
         .with_writer(writer)
         .finish();
-    let _ = subscriber.try_init();
-    Ok(())
+    subscriber.try_init().map_err(io::Error::other)
 }
 
 fn open_log_file(path: &Path, mode: LogMode) -> io::Result<File> {
@@ -383,7 +392,7 @@ mod tests {
         let config = DuumbiConfig {
             logging: Some(LoggingSection {
                 general: GeneralLoggingSection {
-                    enabled: false,
+                    enabled: Some(false),
                     ..GeneralLoggingSection::default()
                 },
                 ..LoggingSection::default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,9 @@ use clap::Parser;
 use agents::orchestrator;
 use cli::{Cli, Commands};
 
+const EXIT_SUCCESS: i32 = 0;
+const EXIT_FAILURE: i32 = 1;
+
 #[tokio::main]
 async fn main() {
     // If invoked with no arguments and stdin is a terminal, enter the
@@ -121,19 +124,40 @@ async fn main() {
         .performance()
         .map(|performance| performance.record_start(command_name));
     tracing::info!(command = command_name, "duumbi command started");
-    if let Err(e) = run(cli).await {
-        if let (Some(performance), Some(started)) = (logging_runtime.performance(), command_started)
-        {
-            performance.record_error(command_name, started, &format!("{e:#}"));
+    let exit_code = match run(cli).await {
+        Ok(exit_code) => exit_code,
+        Err(e) => {
+            if let (Some(performance), Some(started)) =
+                (logging_runtime.performance(), command_started)
+            {
+                performance.record_error(command_name, started, &format!("{e:#}"));
+            }
+            tracing::error!(command = command_name, error = %e, "duumbi command failed");
+            eprintln!("error: {e:#}");
+            process::exit(EXIT_FAILURE);
         }
-        tracing::error!(command = command_name, error = %e, "duumbi command failed");
-        eprintln!("error: {e:#}");
-        process::exit(1);
-    }
+    };
     if let (Some(performance), Some(started)) = (logging_runtime.performance(), command_started) {
-        performance.record_success(command_name, started);
+        if exit_code == EXIT_SUCCESS {
+            performance.record_success(command_name, started);
+        } else {
+            performance.record_error(
+                command_name,
+                started,
+                &format!("command exited with status {exit_code}"),
+            );
+        }
     }
-    tracing::info!(command = command_name, "duumbi command finished");
+    if exit_code == EXIT_SUCCESS {
+        tracing::info!(command = command_name, "duumbi command finished");
+    } else {
+        tracing::error!(
+            command = command_name,
+            exit_code,
+            "duumbi command exited with non-zero status"
+        );
+        process::exit(exit_code);
+    }
 }
 
 fn logging_overrides(cli: &Cli) -> logging::LoggingOverrides {
@@ -163,6 +187,7 @@ fn initialize_logging(
 
 fn logging_workspace_root(command: &Commands) -> PathBuf {
     match command {
+        Commands::Init { name: Some(name) } => PathBuf::from(name),
         Commands::Build {
             input: Some(input), ..
         }
@@ -297,7 +322,7 @@ async fn run_provider_startup_spinner(
     }
 }
 
-async fn run(cli: Cli) -> Result<()> {
+async fn run(cli: Cli) -> Result<i32> {
     match cli.command {
         Commands::Init { name } => {
             let base = match name {
@@ -315,7 +340,7 @@ async fn run(cli: Cli) -> Result<()> {
                 cli::theme::check_mark(),
                 summary.workspace_root.join(".duumbi").display()
             );
-            Ok(())
+            Ok(EXIT_SUCCESS)
         }
         Commands::Build {
             input,
@@ -327,7 +352,11 @@ async fn run(cli: Cli) -> Result<()> {
             }
             let input_path = resolve_input(input.as_deref())?;
             let output_path = resolve_output(output.as_deref())?;
-            cli::commands::build_with_opts(&input_path, &output_path, offline)
+            success_exit(cli::commands::build_with_opts(
+                &input_path,
+                &output_path,
+                offline,
+            ))
         }
         Commands::Run { args } => {
             let workspace = PathBuf::from(".");
@@ -335,7 +364,7 @@ async fn run(cli: Cli) -> Result<()> {
                 let output = workspace::run_workspace_binary(&workspace, &args)?;
                 print!("{}", output.stdout);
                 eprint!("{}", output.stderr);
-                process::exit(output.exit_code);
+                Ok(output.exit_code)
             } else {
                 let binary = resolve_output(None)?;
                 if !binary.exists() {
@@ -348,26 +377,26 @@ async fn run(cli: Cli) -> Result<()> {
                     .args(&args)
                     .status()
                     .with_context(|| format!("Failed to execute '{}'", binary.display()))?;
-                process::exit(status.code().unwrap_or(1));
+                Ok(status.code().unwrap_or(EXIT_FAILURE))
             }
         }
         Commands::Check { input } => {
             let input_path = resolve_input(input.as_deref())?;
-            cli::commands::check(&input_path)
+            success_exit(cli::commands::check(&input_path))
         }
         Commands::Describe { input } => {
             let input_path = resolve_input(input.as_deref())?;
-            cli::commands::describe(&input_path)
+            success_exit(cli::commands::describe(&input_path))
         }
-        Commands::Add { request, yes } => add(&request, yes).await,
-        Commands::Undo => undo(),
+        Commands::Add { request, yes } => success_exit(add(&request, yes).await),
+        Commands::Undo => success_exit(undo()),
         Commands::Search { query, registry } => {
             let workspace = PathBuf::from(".");
-            cli::deps::run_search(&workspace, &query, registry.as_deref()).await
+            success_exit(cli::deps::run_search(&workspace, &query, registry.as_deref()).await)
         }
         Commands::Deps { subcommand } => {
             let workspace = PathBuf::from(".");
-            match subcommand {
+            success_exit(match subcommand {
                 cli::DepsSubcommand::List => cli::deps::run_deps_list(&workspace),
                 cli::DepsSubcommand::Add {
                     name,
@@ -391,7 +420,7 @@ async fn run(cli: Cli) -> Result<()> {
                 cli::DepsSubcommand::Vendor { all, include } => {
                     cli::deps::run_deps_vendor(&workspace, all, include.as_deref())
                 }
-            }
+            })
         }
         Commands::Publish {
             registry,
@@ -399,11 +428,13 @@ async fn run(cli: Cli) -> Result<()> {
             yes,
         } => {
             let workspace = PathBuf::from(".");
-            cli::publish::run_publish(&workspace, registry.as_deref(), dry_run, yes).await
+            success_exit(
+                cli::publish::run_publish(&workspace, registry.as_deref(), dry_run, yes).await,
+            )
         }
         Commands::Registry { subcommand } => {
             let workspace = PathBuf::from(".");
-            run_registry(subcommand, &workspace).await
+            success_exit(run_registry(subcommand, &workspace).await)
         }
         Commands::Intent { subcommand } => {
             let workspace = PathBuf::from(".");
@@ -415,12 +446,14 @@ async fn run(cli: Cli) -> Result<()> {
             yes,
         } => {
             let workspace = PathBuf::from(".");
-            cli::yank::run_yank(&workspace, &specifier, registry.as_deref(), yes).await
+            success_exit(
+                cli::yank::run_yank(&workspace, &specifier, registry.as_deref(), yes).await,
+            )
         }
-        Commands::Upgrade => cli::upgrade::run_upgrade(&PathBuf::from(".")),
+        Commands::Upgrade => success_exit(cli::upgrade::run_upgrade(&PathBuf::from("."))),
         Commands::Knowledge { subcommand } => {
             let workspace = PathBuf::from(".");
-            run_knowledge(subcommand, workspace)
+            success_exit(run_knowledge(subcommand, workspace))
         }
         Commands::Benchmark {
             showcase,
@@ -436,7 +469,7 @@ async fn run(cli: Cli) -> Result<()> {
             attempts,
             output,
             port,
-        } => cli::phase15_e2e::run(&task, &provider, attempts, output, port).await,
+        } => success_exit(cli::phase15_e2e::run(&task, &provider, attempts, output, port).await),
         Commands::Completions { shell } => {
             clap_complete::generate(
                 shell,
@@ -444,15 +477,19 @@ async fn run(cli: Cli) -> Result<()> {
                 "duumbi",
                 &mut std::io::stdout(),
             );
-            Ok(())
+            Ok(EXIT_SUCCESS)
         }
         Commands::Studio { port, dev } => studio(port, dev).await,
         Commands::Provider { subcommand } => {
             let workspace = PathBuf::from(".");
-            run_provider(subcommand, &workspace)
+            success_exit(run_provider(subcommand, &workspace))
         }
-        Commands::Mcp { sse, port } => run_mcp(sse, port).await,
+        Commands::Mcp { sse, port } => success_exit(run_mcp(sse, port).await),
     }
+}
+
+fn success_exit(result: Result<()>) -> Result<i32> {
+    result.map(|()| EXIT_SUCCESS)
 }
 
 // ---------------------------------------------------------------------------
@@ -601,7 +638,7 @@ async fn add(request: &str, yes: bool) -> Result<()> {
 }
 
 /// Dispatches `duumbi intent` subcommands.
-async fn run_intent(subcommand: cli::IntentSubcommand, workspace: PathBuf) -> Result<()> {
+async fn run_intent(subcommand: cli::IntentSubcommand, workspace: PathBuf) -> Result<i32> {
     match subcommand {
         cli::IntentSubcommand::Create { description, yes } => {
             let client = require_llm_client(&workspace)?;
@@ -610,17 +647,17 @@ async fn run_intent(subcommand: cli::IntentSubcommand, workspace: PathBuf) -> Re
             for line in &log {
                 eprintln!("{line}");
             }
-            Ok(())
+            Ok(EXIT_SUCCESS)
         }
         cli::IntentSubcommand::Review { name, edit } => {
-            match name {
+            success_exit(match name {
                 None => intent::review::print_intent_list(&workspace)
                     .map_err(|e| anyhow::anyhow!("{e}")),
                 Some(ref slug) if edit => intent::review::edit_intent(&workspace, slug)
                     .map_err(|e| anyhow::anyhow!("{e}")),
                 Some(ref slug) => intent::review::print_intent_detail(&workspace, slug)
                     .map_err(|e| anyhow::anyhow!("{e}")),
-            }
+            })
         }
         cli::IntentSubcommand::Execute { name } => {
             let client = require_llm_client(&workspace)?;
@@ -636,16 +673,18 @@ async fn run_intent(subcommand: cli::IntentSubcommand, workspace: PathBuf) -> Re
             )
             .await?;
             if !ok {
-                process::exit(1);
+                return Ok(EXIT_FAILURE);
             }
-            Ok(())
+            Ok(EXIT_SUCCESS)
         }
         cli::IntentSubcommand::Status { name } => match name {
-            None => {
-                intent::status::print_status_list(&workspace).map_err(|e| anyhow::anyhow!("{e}"))
-            }
-            Some(ref slug) => intent::status::print_status_detail(&workspace, slug)
-                .map_err(|e| anyhow::anyhow!("{e}")),
+            None => success_exit(
+                intent::status::print_status_list(&workspace).map_err(|e| anyhow::anyhow!("{e}")),
+            ),
+            Some(ref slug) => success_exit(
+                intent::status::print_status_detail(&workspace, slug)
+                    .map_err(|e| anyhow::anyhow!("{e}")),
+            ),
         },
     }
 }
@@ -835,7 +874,7 @@ fn require_llm_client(workspace: &Path) -> Result<agents::LlmClient> {
 /// Looks for the `studio` binary next to the running `duumbi` executable
 /// (both are built from the same cargo workspace). If found, execs into it;
 /// otherwise bails with build instructions.
-async fn studio(port: u16, _dev: bool) -> Result<()> {
+async fn studio(port: u16, _dev: bool) -> Result<i32> {
     let workspace = PathBuf::from(".");
     if !workspace.join(".duumbi").exists() {
         anyhow::bail!("No duumbi workspace found. Run `duumbi init` first.");
@@ -855,7 +894,7 @@ async fn studio(port: u16, _dev: bool) -> Result<()> {
                 .arg(port.to_string())
                 .status()
                 .with_context(|| format!("Failed to execute '{}'", studio_bin.display()))?;
-            process::exit(status.code().unwrap_or(1));
+            return Ok(status.code().unwrap_or(EXIT_FAILURE));
         }
     }
 
@@ -872,7 +911,7 @@ async fn run_benchmark(
     output: Option<PathBuf>,
     ci: bool,
     baseline: Option<PathBuf>,
-) -> Result<()> {
+) -> Result<i32> {
     let workspace = PathBuf::from(".");
     let cfg = config::load_effective_config(&workspace)?.config;
 
@@ -933,10 +972,10 @@ async fn run_benchmark(
 
     // CI exit code
     if ci && !report.kill_criterion_met {
-        process::exit(1);
+        Ok(EXIT_FAILURE)
+    } else {
+        Ok(EXIT_SUCCESS)
     }
-
-    Ok(())
 }
 
 /// Returns the current time as an ISO-8601 string (UTC, second precision).

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,17 +72,11 @@ async fn main() {
                 process::exit(1);
             }
         };
-        let logging_runtime = match logging::initialize(
+        let logging_runtime = initialize_logging(
             &workspace_root,
             &config.config,
             &logging::LoggingOverrides::default(),
-        ) {
-            Ok(runtime) => runtime,
-            Err(e) => {
-                eprintln!("error: failed to initialize logging: {e}");
-                process::exit(1);
-            }
-        };
+        );
         let repl_started = logging_runtime
             .performance()
             .map(|performance| performance.record_start("repl"));
@@ -116,19 +110,13 @@ async fn main() {
     }
 
     let cli = Cli::parse();
-    let workspace_root = PathBuf::from(".");
+    let workspace_root = logging_workspace_root(&cli.command);
     let command_name = command_name(&cli.command);
     let logging_config = config::load_effective_config(&workspace_root)
         .map(|effective| effective.config)
         .unwrap_or_default();
     let logging_runtime =
-        match logging::initialize(&workspace_root, &logging_config, &logging_overrides(&cli)) {
-            Ok(runtime) => runtime,
-            Err(e) => {
-                eprintln!("error: failed to initialize logging: {e}");
-                process::exit(1);
-            }
-        };
+        initialize_logging(&workspace_root, &logging_config, &logging_overrides(&cli));
     let command_started = logging_runtime
         .performance()
         .map(|performance| performance.record_start(command_name));
@@ -156,6 +144,34 @@ fn logging_overrides(cli: &Cli) -> logging::LoggingOverrides {
         performance_enabled: cli.perf_log.then_some(true),
         performance_path: cli.perf_log_file.clone(),
         performance_mode: cli.perf_log_mode.map(Into::into),
+    }
+}
+
+fn initialize_logging(
+    workspace_root: &Path,
+    config: &config::DuumbiConfig,
+    overrides: &logging::LoggingOverrides,
+) -> logging::RuntimeLogging {
+    match logging::initialize(workspace_root, config, overrides) {
+        Ok(runtime) => runtime,
+        Err(e) => {
+            eprintln!("warning: failed to initialize logging: {e}");
+            logging::RuntimeLogging::disabled()
+        }
+    }
+}
+
+fn logging_workspace_root(command: &Commands) -> PathBuf {
+    match command {
+        Commands::Build {
+            input: Some(input), ..
+        }
+        | Commands::Check { input: Some(input) }
+        | Commands::Describe { input: Some(input) } => {
+            cli::commands::workspace_root_for_graph_input(input)
+                .unwrap_or_else(|| PathBuf::from("."))
+        }
+        _ => PathBuf::from("."),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod intent;
 mod interaction;
 #[allow(dead_code)] // Binary uses a subset of knowledge API; rest is used via lib crate
 mod knowledge;
+mod logging;
 mod manifest;
 mod mcp;
 mod parser;
@@ -53,13 +54,6 @@ use cli::{Cli, Commands};
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
-        )
-        .init();
-
     // If invoked with no arguments and stdin is a terminal, enter the
     // interactive REPL — even without an initialised workspace.
     if std::env::args().len() == 1 && io::stdin().is_terminal() {
@@ -78,24 +72,116 @@ async fn main() {
                 process::exit(1);
             }
         };
+        let logging_runtime = match logging::initialize(
+            &workspace_root,
+            &config.config,
+            &logging::LoggingOverrides::default(),
+        ) {
+            Ok(runtime) => runtime,
+            Err(e) => {
+                eprintln!("error: failed to initialize logging: {e}");
+                process::exit(1);
+            }
+        };
+        let repl_started = logging_runtime
+            .performance()
+            .map(|performance| performance.record_start("repl"));
+        tracing::info!(command = "repl", "duumbi command started");
         let config = match auto_configure_startup_providers(&workspace_root, config).await {
             Ok(config) => config,
             Err(e) => {
+                if let (Some(performance), Some(started)) =
+                    (logging_runtime.performance(), repl_started)
+                {
+                    performance.record_error("repl", started, &format!("{e:#}"));
+                }
                 eprintln!("error: {e:#}");
                 process::exit(1);
             }
         };
         if let Err(e) = cli::repl::run(workspace_root, config).await {
+            if let (Some(performance), Some(started)) =
+                (logging_runtime.performance(), repl_started)
+            {
+                performance.record_error("repl", started, &format!("{e:#}"));
+            }
             eprintln!("error: {e:#}");
             process::exit(1);
         }
+        if let (Some(performance), Some(started)) = (logging_runtime.performance(), repl_started) {
+            performance.record_success("repl", started);
+        }
+        tracing::info!(command = "repl", "duumbi command finished");
         return;
     }
 
     let cli = Cli::parse();
+    let workspace_root = PathBuf::from(".");
+    let command_name = command_name(&cli.command);
+    let logging_config = config::load_effective_config(&workspace_root)
+        .map(|effective| effective.config)
+        .unwrap_or_default();
+    let logging_runtime =
+        match logging::initialize(&workspace_root, &logging_config, &logging_overrides(&cli)) {
+            Ok(runtime) => runtime,
+            Err(e) => {
+                eprintln!("error: failed to initialize logging: {e}");
+                process::exit(1);
+            }
+        };
+    let command_started = logging_runtime
+        .performance()
+        .map(|performance| performance.record_start(command_name));
+    tracing::info!(command = command_name, "duumbi command started");
     if let Err(e) = run(cli).await {
+        if let (Some(performance), Some(started)) = (logging_runtime.performance(), command_started)
+        {
+            performance.record_error(command_name, started, &format!("{e:#}"));
+        }
+        tracing::error!(command = command_name, error = %e, "duumbi command failed");
         eprintln!("error: {e:#}");
         process::exit(1);
+    }
+    if let (Some(performance), Some(started)) = (logging_runtime.performance(), command_started) {
+        performance.record_success(command_name, started);
+    }
+    tracing::info!(command = command_name, "duumbi command finished");
+}
+
+fn logging_overrides(cli: &Cli) -> logging::LoggingOverrides {
+    logging::LoggingOverrides {
+        general_level: cli.log_level.map(Into::into),
+        general_path: cli.log_file.clone(),
+        general_mode: cli.log_mode.map(Into::into),
+        performance_enabled: cli.perf_log.then_some(true),
+        performance_path: cli.perf_log_file.clone(),
+        performance_mode: cli.perf_log_mode.map(Into::into),
+    }
+}
+
+fn command_name(command: &Commands) -> &'static str {
+    match command {
+        Commands::Init { .. } => "init",
+        Commands::Build { .. } => "build",
+        Commands::Run { .. } => "run",
+        Commands::Check { .. } => "check",
+        Commands::Describe { .. } => "describe",
+        Commands::Add { .. } => "add",
+        Commands::Undo => "undo",
+        Commands::Deps { .. } => "deps",
+        Commands::Search { .. } => "search",
+        Commands::Intent { .. } => "intent",
+        Commands::Registry { .. } => "registry",
+        Commands::Publish { .. } => "publish",
+        Commands::Yank { .. } => "yank",
+        Commands::Upgrade => "upgrade",
+        Commands::Benchmark { .. } => "benchmark",
+        Commands::Phase15E2e { .. } => "phase15-e2e",
+        Commands::Completions { .. } => "completions",
+        Commands::Studio { .. } => "studio",
+        Commands::Knowledge { .. } => "knowledge",
+        Commands::Provider { .. } => "provider",
+        Commands::Mcp { .. } => "mcp",
     }
 }
 


### PR DESCRIPTION
## Summary
- add file-backed general and performance logging configuration under `.duumbi/logs`
- add CLI flags for log level, file path overrides, append/rewrite mode, and performance logging
- add TUI user config controls for default logging behavior

## Validation
- `cargo fmt --check`
- `cargo test --all`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI logging controls (levels, files, modes) and performance-logging toggles; startup is now asynchronous and records telemetry.
  * REPL gains a User Config/settings panel plus /settings and /config commands to adjust and persist logging defaults.
  * Added performance event tracking with file-based performance logging.

* **Documentation**
  * Updated architecture docs/data formats to list logging outputs (duumbi.log, performance.jsonl).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->