### PR TITLE
[codex] Fix qualified calculator intent graph calls

### DIFF
--- a/src/agents/orchestrator.rs
+++ b/src/agents/orchestrator.rs
@@ -54,8 +54,8 @@ Important rules:\n\
   (e.g. \"zero\", \"recurse\"), NOT full paths (NOT \"math/gcd/fib/zero\").\n\
   Each label must match exactly one block's duumbi:label in the same function.\n\
 - FUNCTION CALLS: duumbi:function must be the plain function name (e.g. \"gcd\", \"fib\"),\n\
-  NOT a full module path (NOT \"math/gcd/gcd\"). The module system resolves function names\n\
-  automatically — for both cross-module and recursive calls, use the simple name.\n\
+  NOT a full module path. For cross-module calls, add duumbi:module with the owning\n\
+  module name (e.g. \"calculator/ops\"). Recursive/local calls may omit duumbi:module.\n\
 - add_op APPENDS to the end of a block.\n\
 - To REWRITE a block body (change Add to Call, insert ops before Return, etc.):\n\
   Use replace_block — provide the block_id and the COMPLETE new ops array ending with Return/Branch.\n\
@@ -74,7 +74,7 @@ Op reference (exhaustive — no other @type values exist):\n\
 - Branch:  {\"@type\":\"duumbi:Branch\", \"duumbi:condition\":{\"@id\":\"…\"}, \"duumbi:trueBlock\":\"<label>\", \"duumbi:falseBlock\":\"<label>\"}\n\
 - Load:    {\"@type\":\"duumbi:Load\",   \"duumbi:variable\":\"<name>\", \"duumbi:resultType\":\"i64\"|\"f64\"|\"bool\"}\n\
 - Store:   {\"@type\":\"duumbi:Store\",  \"duumbi:variable\":\"<name>\", \"duumbi:operand\":{\"@id\":\"…\"}}\n\
-- Call:    {\"@type\":\"duumbi:Call\",   \"duumbi:function\":\"<name>\", \"duumbi:args\":[{\"@id\":\"…\"}], \"duumbi:resultType\":\"i64\"|\"f64\"|\"bool\"}\n\
+- Call:    {\"@type\":\"duumbi:Call\",   \"duumbi:module\":\"<optional-module>\", \"duumbi:function\":\"<name>\", \"duumbi:args\":[{\"@id\":\"…\"}], \"duumbi:resultType\":\"i64\"|\"f64\"|\"bool\"}\n\
 - Print:   {\"@type\":\"duumbi:Print\",  \"duumbi:operand\":{\"@id\":\"…\"}}\n\
 - Return:  {\"@type\":\"duumbi:Return\", \"duumbi:operand\":{\"@id\":\"…\"}}\n\
 \n\

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -289,7 +289,9 @@ fn emit_program_error_diagnostics(err: &deps::DepsError) {
     if let deps::DepsError::Program(errors) = err {
         for e in errors {
             match e {
-                ProgramError::UnresolvedCrossModuleRef { code, .. } => {
+                ProgramError::UnresolvedCrossModuleRef { code, .. }
+                | ProgramError::UnresolvedQualifiedCrossModuleRef { code, .. }
+                | ProgramError::AmbiguousCrossModuleRef { code, .. } => {
                     let diag = Diagnostic::error(code, e.to_string());
                     emit_diagnostic(&diag);
                 }

--- a/src/cli/describe.rs
+++ b/src/cli/describe.rs
@@ -121,7 +121,7 @@ fn describe_op(
                 format!("{}({cond}, ?, ?)", "Branch".magenta())
             }
         }
-        Op::Call { function } => {
+        Op::Call { module, function } => {
             let mut args: Vec<(usize, String)> = Vec::new();
             for e in &incoming {
                 if let GraphEdge::Arg(i) = e.weight() {
@@ -130,10 +130,13 @@ fn describe_op(
             }
             args.sort_by_key(|(i, _)| *i);
             let arg_strs: Vec<String> = args.into_iter().map(|(_, s)| s).collect();
+            let target = module
+                .as_ref()
+                .map_or_else(|| function.to_string(), |m| format!("{m}::{function}"));
             format!(
                 "{}({}, [{}])",
                 "Call".magenta(),
-                function.cyan(),
+                target.cyan(),
                 arg_strs.join(", ")
             )
         }

--- a/src/compiler/lowering.rs
+++ b/src/compiler/lowering.rs
@@ -20,7 +20,7 @@ use target_lexicon::Triple;
 
 use crate::graph::program::Program;
 use crate::graph::{FunctionInfo, GraphEdge, SemanticGraph};
-use crate::types::{CompareOp, DuumbiType, NodeId, Op};
+use crate::types::{CompareOp, DuumbiType, FunctionName, NodeId, Op};
 
 use super::CompileError;
 
@@ -84,6 +84,41 @@ struct RuntimeFuncs {
     string_to_upper: FuncId,
     string_to_lower: FuncId,
     string_replace: FuncId,
+}
+
+#[derive(Debug, Clone)]
+struct ImportedFunction<'a> {
+    key: String,
+    symbol: String,
+    function_name: String,
+    info: &'a FunctionInfo,
+}
+
+fn callable_key(module_name: &str, function_name: &str) -> String {
+    format!("{module_name}::{function_name}")
+}
+
+fn function_symbol_name(module_name: &str, function_name: &str) -> String {
+    if function_name == "main" {
+        "main".to_string()
+    } else {
+        format!(
+            "duumbi__{}__{}",
+            mangle_symbol_component(module_name),
+            mangle_symbol_component(function_name)
+        )
+    }
+}
+
+fn mangle_symbol_component(value: &str) -> String {
+    let mut out = String::new();
+    for byte in value.bytes() {
+        match byte {
+            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_' => out.push(byte as char),
+            _ => out.push_str(&format!("_x{byte:02x}_")),
+        }
+    }
+    if out.is_empty() { "_".to_string() } else { out }
 }
 
 /// Helper to declare an imported C function with given param/return types.
@@ -332,11 +367,15 @@ pub fn compile_to_object(graph: &SemanticGraph) -> Result<Vec<u8>, CompileError>
 #[allow(dead_code)] // Called by CLI in upcoming phase (#61)
 #[must_use = "compilation errors should be handled"]
 pub fn compile_program(program: &Program) -> Result<HashMap<String, Vec<u8>>, CompileError> {
-    // Build a cross-module function info lookup: fn_name → &FunctionInfo
-    let all_fn_info: HashMap<&str, &FunctionInfo> = program
+    // Build a cross-module function info lookup: (module_name, fn_name) → &FunctionInfo
+    let all_fn_info: HashMap<(String, String), &FunctionInfo> = program
         .modules
-        .values()
-        .flat_map(|sg| sg.functions.iter().map(|fi| (fi.name.0.as_str(), fi)))
+        .iter()
+        .flat_map(|(module_name, sg)| {
+            sg.functions
+                .iter()
+                .map(|fi| ((module_name.0.clone(), fi.name.0.clone()), fi))
+        })
         .collect();
 
     // Validate: at most one module may define `main`
@@ -356,10 +395,10 @@ pub fn compile_program(program: &Program) -> Result<HashMap<String, Vec<u8>>, Co
     for (module_name, sg) in &program.modules {
         // Functions exported by this module
         let exported_fns: HashSet<String> = program
-            .exports
+            .qualified_exports
             .iter()
-            .filter(|(_, mn)| mn.0 == module_name.0)
-            .map(|(fn_name, _)| fn_name.0.clone())
+            .filter(|(mn, _)| mn.0 == module_name.0)
+            .map(|(_, fn_name)| fn_name.0.clone())
             .collect();
 
         // Local function names defined in this module
@@ -367,19 +406,44 @@ pub fn compile_program(program: &Program) -> Result<HashMap<String, Vec<u8>>, Co
             sg.functions.iter().map(|f| f.name.0.as_str()).collect();
 
         // Cross-module calls: Call ops targeting functions not in this module
-        let mut imported: HashMap<String, &FunctionInfo> = HashMap::new();
+        let mut imported: HashMap<String, ImportedFunction<'_>> = HashMap::new();
         for node in sg.graph.node_weights() {
-            if let Op::Call { function } = &node.op
-                && !local_fn_names.contains(function.as_str())
-                && !imported.contains_key(function.as_str())
-                && let Some(fi) = all_fn_info.get(function.as_str())
-            {
-                imported.insert(function.clone(), fi);
+            if let Op::Call { module, function } = &node.op {
+                let target_module = if let Some(module) = module {
+                    module.clone()
+                } else if local_fn_names.contains(function.as_str()) {
+                    module_name.0.clone()
+                } else if let Some(resolved_module) =
+                    program.exports.get(&FunctionName(function.clone()))
+                {
+                    resolved_module.0.clone()
+                } else {
+                    continue;
+                };
+
+                if target_module == module_name.0 {
+                    continue;
+                }
+
+                let key = callable_key(&target_module, function);
+                if imported.contains_key(&key) {
+                    continue;
+                }
+                if let Some(fi) = all_fn_info.get(&(target_module.clone(), function.clone())) {
+                    imported.insert(
+                        key.clone(),
+                        ImportedFunction {
+                            key,
+                            symbol: function_symbol_name(&target_module, function),
+                            function_name: function.clone(),
+                            info: fi,
+                        },
+                    );
+                }
             }
         }
 
-        let imported_list: Vec<(&str, &FunctionInfo)> =
-            imported.iter().map(|(n, fi)| (n.as_str(), *fi)).collect();
+        let imported_list: Vec<ImportedFunction<'_>> = imported.into_values().collect();
 
         let obj_bytes = compile_to_object_impl(sg, &exported_fns, &imported_list)?;
         objects.insert(module_name.0.clone(), obj_bytes);
@@ -392,12 +456,12 @@ pub fn compile_program(program: &Program) -> Result<HashMap<String, Vec<u8>>, Co
 ///
 /// - `exported_fns`: function names in this module that get `Linkage::Export`
 ///   (in addition to `main` which is always exported).
-/// - `imported_fns`: `(name, FunctionInfo)` pairs for functions defined in other
-///   modules; declared with `Linkage::Import` so the linker resolves them.
+/// - `imported_fns`: functions defined in other modules; declared with
+///   `Linkage::Import` so the linker resolves them.
 fn compile_to_object_impl(
     graph: &SemanticGraph,
     exported_fns: &HashSet<String>,
-    imported_fns: &[(&str, &FunctionInfo)],
+    imported_fns: &[ImportedFunction<'_>],
 ) -> Result<Vec<u8>, CompileError> {
     let mut obj_module = create_object_module()?;
 
@@ -409,43 +473,62 @@ fn compile_to_object_impl(
 
     let mut func_ids: HashMap<String, FuncId> = HashMap::new();
     let mut func_sigs: HashMap<String, cranelift_codegen::ir::Signature> = HashMap::new();
+    let mut unqualified_imports: HashMap<String, String> = HashMap::new();
+    let mut ambiguous_unqualified_imports: HashSet<String> = HashSet::new();
 
     // Declare imported cross-module functions (Linkage::Import) first.
     // Their FuncIds are added to func_ids so compile_function can resolve calls.
-    for (name, fi) in imported_fns {
-        let sig = make_func_signature(&obj_module, fi);
+    for import in imported_fns {
+        let sig = make_func_signature(&obj_module, import.info);
         let func_id = obj_module
-            .declare_function(name, Linkage::Import, &sig)
+            .declare_function(&import.symbol, Linkage::Import, &sig)
             .map_err(|e| CompileError::Cranelift {
-                message: format!("Failed to declare imported function '{name}': {e}"),
+                message: format!(
+                    "Failed to declare imported function '{}': {e}",
+                    import.symbol
+                ),
             })?;
-        func_ids.insert((*name).to_string(), func_id);
-        func_sigs.insert((*name).to_string(), sig);
+        func_ids.insert(import.key.clone(), func_id);
+        func_sigs.insert(import.key.clone(), sig);
+        if ambiguous_unqualified_imports.contains(&import.function_name) {
+            continue;
+        }
+        if let Some(existing) = unqualified_imports.get(&import.function_name) {
+            if existing != &import.key {
+                unqualified_imports.remove(&import.function_name);
+                ambiguous_unqualified_imports.insert(import.function_name.clone());
+            }
+        } else {
+            unqualified_imports.insert(import.function_name.clone(), import.key.clone());
+        }
     }
 
     // Declare all local functions.
     // `main` and explicitly exported functions get Linkage::Export.
     for func_info in &graph.functions {
         let sig = make_func_signature(&obj_module, func_info);
+        let key = callable_key(&graph.module_name.0, &func_info.name.0);
+        let symbol = function_symbol_name(&graph.module_name.0, &func_info.name.0);
         let linkage = if func_info.name.0 == "main" || exported_fns.contains(&func_info.name.0) {
             Linkage::Export
         } else {
             Linkage::Local
         };
         let func_id = obj_module
-            .declare_function(&func_info.name.0, linkage, &sig)
+            .declare_function(&symbol, linkage, &sig)
             .map_err(|e| CompileError::Cranelift {
                 message: format!("Failed to declare function '{}': {e}", func_info.name),
             })?;
-        func_ids.insert(func_info.name.0.clone(), func_id);
-        func_sigs.insert(func_info.name.0.clone(), sig);
+        func_ids.insert(key.clone(), func_id);
+        func_sigs.insert(key, sig);
     }
 
     // Define each local function (emit Cranelift IR).
     let mut fn_builder_ctx = FunctionBuilderContext::new();
     for func_info in &graph.functions {
-        let func_id = func_ids[&func_info.name.0];
-        let sig = func_sigs[&func_info.name.0].clone();
+        let key = callable_key(&graph.module_name.0, &func_info.name.0);
+        let func_id = func_ids[&key];
+        let sig = func_sigs[&key].clone();
 
         let mut ctx = Context::new();
         ctx.func.signature = sig;
@@ -458,6 +541,7 @@ fn compile_to_object_impl(
             &mut obj_module,
             &func_ids,
             &func_sigs,
+            &unqualified_imports,
             &runtime,
             &string_data,
         )?;
@@ -529,6 +613,7 @@ fn compile_function(
     obj_module: &mut ObjectModule,
     func_ids: &HashMap<String, FuncId>,
     func_sigs: &HashMap<String, cranelift_codegen::ir::Signature>,
+    unqualified_imports: &HashMap<String, String>,
     runtime: &RuntimeFuncs,
     string_data: &HashMap<String, DataId>,
 ) -> Result<(), CompileError> {
@@ -726,8 +811,20 @@ fn compile_function(
                         .ins()
                         .brif(cond_val, true_block, &[], false_block, &[]);
                 }
-                Op::Call { function } => {
-                    let func_ref = func_refs.get(function).copied().ok_or_else(|| {
+                Op::Call { module, function } => {
+                    let local_key = callable_key(&graph.module_name.0, function);
+                    let target_key = if let Some(module) = module {
+                        callable_key(module, function)
+                    } else if func_refs.contains_key(&local_key) {
+                        local_key
+                    } else {
+                        unqualified_imports
+                            .get(function)
+                            .cloned()
+                            .unwrap_or_else(|| function.clone())
+                    };
+
+                    let func_ref = func_refs.get(&target_key).copied().ok_or_else(|| {
                         CompileError::Cranelift {
                             message: format!("Function '{function}' not found for call"),
                         }
@@ -737,7 +834,7 @@ fn compile_function(
                     let call_inst = builder.ins().call(func_ref, &args);
 
                     // Get return value if the called function returns something
-                    if let Some(target_sig) = func_sigs.get(function)
+                    if let Some(target_sig) = func_sigs.get(&target_key)
                         && !target_sig.returns.is_empty()
                     {
                         let ret_val = builder.inst_results(call_inst)[0];

--- a/src/compiler/lowering.rs
+++ b/src/compiler/lowering.rs
@@ -114,7 +114,7 @@ fn mangle_symbol_component(value: &str) -> String {
     let mut out = String::new();
     for byte in value.bytes() {
         match byte {
-            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_' => out.push(byte as char),
+            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' => out.push(byte as char),
             _ => out.push_str(&format!("_x{byte:02x}_")),
         }
     }
@@ -1872,6 +1872,18 @@ mod tests {
         assert!(
             is_macho || is_elf,
             "Output should be a valid Mach-O or ELF object file"
+        );
+    }
+
+    #[test]
+    fn symbol_component_mangling_is_injective_for_escape_like_names() {
+        assert_ne!(
+            mangle_symbol_component("a/b"),
+            mangle_symbol_component("a_x2f_b")
+        );
+        assert_ne!(
+            function_symbol_name("a/b", "helper"),
+            function_symbol_name("a_x2f_b", "helper")
         );
     }
 

--- a/src/graph/builder.rs
+++ b/src/graph/builder.rs
@@ -85,14 +85,21 @@ fn build_graph_impl(
                 // In multi-module mode (validate_calls = false) this check is
                 // skipped; the program layer performs cross-module validation.
                 if validate_calls
-                    && let crate::types::Op::Call { ref function } = op_ast.op
-                    && !function_names.contains(function.as_str())
+                    && let crate::types::Op::Call {
+                        module: ref call_module,
+                        ref function,
+                    } = op_ast.op
                 {
-                    errors.push(GraphError::OrphanRef {
-                        code: codes::E004_ORPHAN_REF,
-                        from_node: op_ast.id.0.clone(),
-                        target: function.clone(),
-                    });
+                    let is_local_call = call_module
+                        .as_deref()
+                        .is_none_or(|m| m == module.name.0.as_str());
+                    if is_local_call && !function_names.contains(function.as_str()) {
+                        errors.push(GraphError::OrphanRef {
+                            code: codes::E004_ORPHAN_REF,
+                            from_node: op_ast.id.0.clone(),
+                            target: function.clone(),
+                        });
+                    }
                 }
 
                 let node = GraphNode {
@@ -454,6 +461,7 @@ mod tests {
                     ops: vec![OpAst {
                         id: NodeId("duumbi:test/main/entry/0".to_string()),
                         op: Op::Call {
+                            module: None,
                             function: "nonexistent".to_string(),
                         },
                         result_type: Some(DuumbiType::I64),

--- a/src/graph/describe.rs
+++ b/src/graph/describe.rs
@@ -96,7 +96,7 @@ fn describe_op_plain(
                 format!("Branch({cond}, ?, ?)")
             }
         }
-        Op::Call { function } => {
+        Op::Call { module, function } => {
             let mut args: Vec<(usize, String)> = Vec::new();
             for e in &incoming {
                 if let GraphEdge::Arg(i) = e.weight() {
@@ -105,7 +105,10 @@ fn describe_op_plain(
             }
             args.sort_by_key(|(i, _)| *i);
             let arg_strs: Vec<String> = args.into_iter().map(|(_, s)| s).collect();
-            format!("Call({function}, [{}])", arg_strs.join(", "))
+            let target = module
+                .as_ref()
+                .map_or_else(|| function.to_string(), |m| format!("{m}::{function}"));
+            format!("Call({target}, [{}])", arg_strs.join(", "))
         }
         Op::Load { variable } => format!("Load({variable})"),
         Op::Store { variable } => {

--- a/src/graph/program.rs
+++ b/src/graph/program.rs
@@ -28,8 +28,13 @@ use crate::types::{FunctionName, ModuleName, Op};
 pub struct Program {
     /// Per-module semantic graphs, keyed by module name.
     pub modules: HashMap<ModuleName, SemanticGraph>,
-    /// Cross-module export table: exported function name → owning module.
+    /// Unambiguous cross-module export table: exported function name → owning module.
+    ///
+    /// Function names exported by more than one module are intentionally omitted
+    /// from this table and must be called with `duumbi:module`.
     pub exports: HashMap<FunctionName, ModuleName>,
+    /// Complete export table keyed by `(module, function)`.
+    pub qualified_exports: HashSet<(ModuleName, FunctionName)>,
 }
 
 /// Errors produced while loading a multi-module program.
@@ -66,6 +71,38 @@ pub enum ProgramError {
         function: String,
         /// The module containing the unresolved call.
         from_module: String,
+    },
+
+    /// A qualified `Call` op references a function that is not exported by the named module.
+    #[error(
+        "[{code}] Unresolved qualified cross-module reference: \
+         '{target_module}::{function}' called from module '{from_module}' is not exported"
+    )]
+    UnresolvedQualifiedCrossModuleRef {
+        /// Error code (E010).
+        code: &'static str,
+        /// The target module name.
+        target_module: String,
+        /// The callee function name.
+        function: String,
+        /// The module containing the unresolved call.
+        from_module: String,
+    },
+
+    /// An unqualified `Call` op matches more than one exported function.
+    #[error(
+        "[{code}] Ambiguous cross-module reference: '{function}' called from module \
+         '{from_module}' is exported by multiple modules: {candidates}"
+    )]
+    AmbiguousCrossModuleRef {
+        /// Error code (E010).
+        code: &'static str,
+        /// The callee function name.
+        function: String,
+        /// The module containing the ambiguous call.
+        from_module: String,
+        /// Candidate module names for this function.
+        candidates: String,
     },
 }
 
@@ -172,15 +209,18 @@ impl Program {
             }
         }
 
-        // Step 2: collect the combined export table (fn_name → module_name)
-        let all_exports: HashMap<String, String> = selected_asts
-            .iter()
-            .flat_map(|ast| {
-                ast.exports
-                    .iter()
-                    .map(|fn_name| (fn_name.clone(), ast.name.0.clone()))
-            })
-            .collect();
+        // Step 2: collect exports by both short and qualified names.
+        let mut exports_by_name: HashMap<String, Vec<String>> = HashMap::new();
+        let mut qualified_exports: HashSet<(ModuleName, FunctionName)> = HashSet::new();
+        for ast in &selected_asts {
+            for fn_name in &ast.exports {
+                exports_by_name
+                    .entry(fn_name.clone())
+                    .or_default()
+                    .push(ast.name.0.clone());
+                qualified_exports.insert((ast.name.clone(), FunctionName(fn_name.clone())));
+            }
+        }
 
         // Step 3: build per-module graphs without intra-module Call validation.
         // Cross-module calls are validated in step 4 using the export table.
@@ -207,20 +247,45 @@ impl Program {
         }
 
         // Step 4: cross-module call validation (E010)
-        // For each Call op, if the callee is not local and not exported → E010
         for (module_name, sg) in &modules {
             let local_fns: HashSet<&FunctionName> = sg.functions.iter().map(|f| &f.name).collect();
 
             for node in sg.graph.node_weights() {
-                if let Op::Call { function } = &node.op {
+                if let Op::Call { module, function } = &node.op {
                     let callee = FunctionName(function.clone());
-                    if !local_fns.contains(&callee) && !all_exports.contains_key(function.as_str())
-                    {
-                        errors.push(ProgramError::UnresolvedCrossModuleRef {
-                            code: codes::E010_UNRESOLVED_CROSS_MODULE,
-                            function: function.clone(),
-                            from_module: module_name.0.clone(),
-                        });
+                    if let Some(target_module) = module {
+                        let qualified_target = (ModuleName(target_module.clone()), callee);
+                        let is_local_qualified = target_module == &module_name.0
+                            && local_fns.contains(&qualified_target.1);
+                        if !is_local_qualified && !qualified_exports.contains(&qualified_target) {
+                            errors.push(ProgramError::UnresolvedQualifiedCrossModuleRef {
+                                code: codes::E010_UNRESOLVED_CROSS_MODULE,
+                                target_module: target_module.clone(),
+                                function: function.clone(),
+                                from_module: module_name.0.clone(),
+                            });
+                        }
+                    } else if !local_fns.contains(&callee) {
+                        match exports_by_name.get(function.as_str()).map(Vec::as_slice) {
+                            Some([_]) => {}
+                            Some(candidates) if candidates.len() > 1 => {
+                                let mut sorted = candidates.to_vec();
+                                sorted.sort();
+                                errors.push(ProgramError::AmbiguousCrossModuleRef {
+                                    code: codes::E010_UNRESOLVED_CROSS_MODULE,
+                                    function: function.clone(),
+                                    from_module: module_name.0.clone(),
+                                    candidates: sorted.join(", "),
+                                });
+                            }
+                            _ => {
+                                errors.push(ProgramError::UnresolvedCrossModuleRef {
+                                    code: codes::E010_UNRESOLVED_CROSS_MODULE,
+                                    function: function.clone(),
+                                    from_module: module_name.0.clone(),
+                                });
+                            }
+                        }
                     }
                 }
             }
@@ -230,13 +295,23 @@ impl Program {
             return Err(errors);
         }
 
-        // Build the typed export table from all_exports
-        let exports: HashMap<FunctionName, ModuleName> = all_exports
+        // Build the typed unambiguous export table from exports_by_name.
+        let exports: HashMap<FunctionName, ModuleName> = exports_by_name
             .into_iter()
-            .map(|(fn_name, mod_name)| (FunctionName(fn_name), ModuleName(mod_name)))
+            .filter_map(|(fn_name, modules)| {
+                if let [module_name] = modules.as_slice() {
+                    Some((FunctionName(fn_name), ModuleName(module_name.clone())))
+                } else {
+                    None
+                }
+            })
             .collect();
 
-        Ok(Program { modules, exports })
+        Ok(Program {
+            modules,
+            exports,
+            qualified_exports,
+        })
     }
 }
 
@@ -339,6 +414,69 @@ mod tests {
                 }},
                 {{"@type": "duumbi:Return", "@id": "duumbi:{name}/main/entry/2",
                   "duumbi:operand": {{"@id": "duumbi:{name}/main/entry/1"}}}}
+            ]
+        }}]
+    }}]
+}}"#
+        )
+    }
+
+    fn make_module_with_qualified_call(name: &str, target_module: &str, callee: &str) -> String {
+        format!(
+            r#"{{
+    "@context": {{"duumbi": "https://duumbi.dev/ns/core#"}},
+    "@type": "duumbi:Module",
+    "@id": "duumbi:{name}",
+    "duumbi:name": "{name}",
+    "duumbi:functions": [{{
+        "@type": "duumbi:Function",
+        "@id": "duumbi:{name}/main",
+        "duumbi:name": "main",
+        "duumbi:returnType": "i64",
+        "duumbi:blocks": [{{
+            "@type": "duumbi:Block",
+            "@id": "duumbi:{name}/main/entry",
+            "duumbi:label": "entry",
+            "duumbi:ops": [
+                {{
+                    "@type": "duumbi:Call",
+                    "@id": "duumbi:{name}/main/entry/0",
+                    "duumbi:module": "{target_module}",
+                    "duumbi:function": "{callee}",
+                    "duumbi:args": [],
+                    "duumbi:resultType": "i64"
+                }},
+                {{"@type": "duumbi:Return", "@id": "duumbi:{name}/main/entry/1",
+                  "duumbi:operand": {{"@id": "duumbi:{name}/main/entry/0"}}}}
+            ]
+        }}]
+    }}]
+}}"#
+        )
+    }
+
+    fn make_library_function_module(name: &str, function: &str, value: i64) -> String {
+        format!(
+            r#"{{
+    "@context": {{"duumbi": "https://duumbi.dev/ns/core#"}},
+    "@type": "duumbi:Module",
+    "@id": "duumbi:{name}",
+    "duumbi:name": "{name}",
+    "duumbi:exports": ["{function}"],
+    "duumbi:functions": [{{
+        "@type": "duumbi:Function",
+        "@id": "duumbi:{name}/{function}",
+        "duumbi:name": "{function}",
+        "duumbi:returnType": "i64",
+        "duumbi:blocks": [{{
+            "@type": "duumbi:Block",
+            "@id": "duumbi:{name}/{function}/entry",
+            "duumbi:label": "entry",
+            "duumbi:ops": [
+                {{"@type": "duumbi:Const", "@id": "duumbi:{name}/{function}/entry/0",
+                  "duumbi:value": {value}, "duumbi:resultType": "i64"}},
+                {{"@type": "duumbi:Return", "@id": "duumbi:{name}/{function}/entry/1",
+                  "duumbi:operand": {{"@id": "duumbi:{name}/{function}/entry/0"}}}}
             ]
         }}]
     }}]
@@ -456,6 +594,56 @@ mod tests {
                     if function == "secret" && *code == codes::E010_UNRESOLVED_CROSS_MODULE
             )),
             "expected E010 for unresolved 'secret', got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn qualified_call_resolves_duplicate_export_name() {
+        let app = make_module_with_qualified_call("app", "calculator/ops", "helper");
+        let calculator = make_library_function_module("calculator/ops", "helper", 42);
+        let utils = make_library_function_module("utils/ops", "helper", 7);
+
+        let ws = write_workspace(&[
+            ("app.jsonld", &app),
+            ("calculator/ops.jsonld", &calculator),
+            ("utils/ops.jsonld", &utils),
+        ]);
+
+        let program = Program::load(ws.path()).expect("qualified duplicate export must load");
+        assert!(program.qualified_exports.contains(&(
+            ModuleName("calculator/ops".to_string()),
+            FunctionName("helper".to_string())
+        )));
+        assert!(
+            !program
+                .exports
+                .contains_key(&FunctionName("helper".to_string())),
+            "duplicate short exports must not be available for unqualified calls"
+        );
+    }
+
+    #[test]
+    fn unqualified_call_to_duplicate_export_name_is_ambiguous() {
+        let app = make_module_with_call("app", "helper", &[]);
+        let calculator = make_library_function_module("calculator/ops", "helper", 42);
+        let utils = make_library_function_module("utils/ops", "helper", 7);
+
+        let ws = write_workspace(&[
+            ("app.jsonld", &app),
+            ("calculator/ops.jsonld", &calculator),
+            ("utils/ops.jsonld", &utils),
+        ]);
+
+        let errors = Program::load(ws.path()).expect_err("unqualified duplicate export must fail");
+        assert!(
+            errors.iter().any(|e| matches!(
+                e,
+                ProgramError::AmbiguousCrossModuleRef { function, candidates, .. }
+                    if function == "helper"
+                        && candidates.contains("calculator/ops")
+                        && candidates.contains("utils/ops")
+            )),
+            "expected ambiguous helper error, got: {errors:?}"
         );
     }
 

--- a/src/graph/program.rs
+++ b/src/graph/program.rs
@@ -210,14 +210,14 @@ impl Program {
         }
 
         // Step 2: collect exports by both short and qualified names.
-        let mut exports_by_name: HashMap<String, Vec<String>> = HashMap::new();
+        let mut exports_by_name: HashMap<String, HashSet<String>> = HashMap::new();
         let mut qualified_exports: HashSet<(ModuleName, FunctionName)> = HashSet::new();
         for ast in &selected_asts {
             for fn_name in &ast.exports {
                 exports_by_name
                     .entry(fn_name.clone())
                     .or_default()
-                    .push(ast.name.0.clone());
+                    .insert(ast.name.0.clone());
                 qualified_exports.insert((ast.name.clone(), FunctionName(fn_name.clone())));
             }
         }
@@ -266,10 +266,10 @@ impl Program {
                             });
                         }
                     } else if !local_fns.contains(&callee) {
-                        match exports_by_name.get(function.as_str()).map(Vec::as_slice) {
-                            Some([_]) => {}
+                        match exports_by_name.get(function.as_str()) {
+                            Some(candidates) if candidates.len() == 1 => {}
                             Some(candidates) if candidates.len() > 1 => {
-                                let mut sorted = candidates.to_vec();
+                                let mut sorted: Vec<_> = candidates.iter().cloned().collect();
                                 sorted.sort();
                                 errors.push(ProgramError::AmbiguousCrossModuleRef {
                                     code: codes::E010_UNRESOLVED_CROSS_MODULE,
@@ -299,8 +299,12 @@ impl Program {
         let exports: HashMap<FunctionName, ModuleName> = exports_by_name
             .into_iter()
             .filter_map(|(fn_name, modules)| {
-                if let [module_name] = modules.as_slice() {
-                    Some((FunctionName(fn_name), ModuleName(module_name.clone())))
+                if modules.len() == 1 {
+                    let module_name = modules
+                        .into_iter()
+                        .next()
+                        .expect("invariant: len checked above");
+                    Some((FunctionName(fn_name), ModuleName(module_name)))
                 } else {
                     None
                 }
@@ -619,6 +623,23 @@ mod tests {
                 .exports
                 .contains_key(&FunctionName("helper".to_string())),
             "duplicate short exports must not be available for unqualified calls"
+        );
+    }
+
+    #[test]
+    fn repeated_export_in_same_module_does_not_create_ambiguity() {
+        let app = make_module_with_call("app", "helper", &[]);
+        let math = make_library_function_module("math", "helper", 42).replace(
+            r#""duumbi:exports": ["helper"]"#,
+            r#""duumbi:exports": ["helper", "helper"]"#,
+        );
+
+        let ws = write_workspace(&[("app.jsonld", &app), ("math.jsonld", &math)]);
+
+        let program = Program::load(ws.path()).expect("duplicate export in one module must load");
+        assert_eq!(
+            program.exports[&FunctionName("helper".to_string())],
+            ModuleName("math".to_string())
         );
     }
 

--- a/src/graph/result_safety.rs
+++ b/src/graph/result_safety.rs
@@ -469,6 +469,7 @@ mod tests {
                 (
                     nid("call0"),
                     Op::Call {
+                        module: None,
                         function: "may_fail".to_string(),
                     },
                     Some(result_ty.clone()),
@@ -493,6 +494,7 @@ mod tests {
                 (
                     nid("call0"),
                     Op::Call {
+                        module: None,
                         function: "may_fail".to_string(),
                     },
                     Some(result_ty),
@@ -521,6 +523,7 @@ mod tests {
                 (
                     nid("call0"),
                     Op::Call {
+                        module: None,
                         function: "find".to_string(),
                     },
                     Some(option_ty),
@@ -545,6 +548,7 @@ mod tests {
                 (
                     nid("call0"),
                     Op::Call {
+                        module: None,
                         function: "find".to_string(),
                     },
                     Some(option_ty),
@@ -598,6 +602,7 @@ mod tests {
         let call_idx = graph.add_node(GraphNode {
             id: nid("call0"),
             op: Op::Call {
+                module: None,
                 function: "f".to_string(),
             },
             result_type: Some(result_ty.clone()),
@@ -745,6 +750,7 @@ mod tests {
                 (
                     nid("call0"),
                     Op::Call {
+                        module: None,
                         function: "f".to_string(),
                     },
                     Some(result_ty),
@@ -783,6 +789,7 @@ mod tests {
                 (
                     nid("call0"),
                     Op::Call {
+                        module: None,
                         function: "f".to_string(),
                     },
                     Some(result_ty),

--- a/src/intent/benchmarks.rs
+++ b/src/intent/benchmarks.rs
@@ -85,6 +85,12 @@ fn calculator_test_cases() -> Vec<TestCase> {
             args: vec![10, 2],
             expected_return: 5,
         },
+        TestCase {
+            name: "divide_ten_zero".to_string(),
+            function: "divide".to_string(),
+            args: vec![10, 0],
+            expected_return: 0,
+        },
     ]
 }
 
@@ -123,12 +129,15 @@ mod tests {
         assert_eq!(matched, Some("calculator"));
         assert_eq!(spec.modules.create, vec!["calculator/ops"]);
         assert_eq!(spec.modules.modify, vec!["app/main"]);
-        assert_eq!(spec.test_cases.len(), 4);
+        assert_eq!(spec.test_cases.len(), 5);
         assert_eq!(spec.test_cases[0].function, "add");
         assert_eq!(spec.test_cases[0].args, vec![3, 5]);
         assert_eq!(spec.test_cases[0].expected_return, 8);
         assert_eq!(spec.test_cases[3].function, "divide");
         assert_eq!(spec.test_cases[3].expected_return, 5);
+        assert_eq!(spec.test_cases[4].function, "divide");
+        assert_eq!(spec.test_cases[4].args, vec![10, 0]);
+        assert_eq!(spec.test_cases[4].expected_return, 0);
     }
 
     #[test]

--- a/src/intent/coordinator.rs
+++ b/src/intent/coordinator.rs
@@ -140,20 +140,25 @@ pub fn decompose(spec: &IntentSpec) -> Vec<Task> {
 
     let main_desc = if test_summary.is_empty() {
         format!(
-            "Update the main function to demonstrate the implementation. Modules: {}",
+            "Update the main function to demonstrate the implementation. Modules: {}. \
+             Demo main must return 0 after printing.",
             all_modules.join(", ")
         )
     } else {
         format!(
             "Update the main function to call and demonstrate: {test_summary}. \
-             The binary must exit with the result of the first call.\n\n\
+             The binary must return 0 after printing all demonstration lines.\n\n\
+             FUNCTION CALLS: When calling an exported function from another module, \
+             include \"duumbi:module\" with the owning module name and keep \
+             \"duumbi:function\" as the plain function name.\n\n\
              OUTPUT FORMAT: The program MUST produce human-readable formatted output.\n\
              1. Print a header: ConstString(\"=== {intent_title} ===\") → PrintString\n\
              2. For EACH test case, print a labeled result line:\n\
                 ConstString(\"func(a, b) = \") → StringFromI64(call_result) → StringConcat → PrintString\n\
+             3. End with ConstI64(0) → Return so successful demos exit cleanly.\n\
              Use this exact pattern for each line:\n\
                op/0: ConstString(\"func(args) = \")\n\
-               op/1: [Call the function → get i64 result]\n\
+               op/1: [Call the function → get i64 result; use duumbi:module for cross-module calls]\n\
                op/2: StringFromI64(op/1)\n\
                op/3: StringConcat(op/0, op/2)\n\
                op/4: PrintString(op/3)\n\
@@ -485,6 +490,27 @@ mod tests {
             !create_task.description.contains("main"),
             "exports hint must not include 'main'; got: {}",
             create_task.description
+        );
+    }
+
+    #[test]
+    fn modify_main_prompt_uses_qualified_calls_and_returns_zero() {
+        let spec = sample_spec();
+        let tasks = decompose(&spec);
+        let main_task = tasks
+            .iter()
+            .find(|t| matches!(&t.kind, TaskKind::ModifyMain { .. }))
+            .expect("must have main task");
+
+        assert!(
+            main_task.description.contains("duumbi:module"),
+            "main prompt must guide qualified cross-module calls: {}",
+            main_task.description
+        );
+        assert!(
+            main_task.description.contains("return 0"),
+            "main prompt must tell demo mains to return 0: {}",
+            main_task.description
         );
     }
 

--- a/src/intent/execute.rs
+++ b/src/intent/execute.rs
@@ -160,9 +160,9 @@ pub async fn run_execute_with_progress(
                 prompt.push_str(&format!(
                     "\n\nAvailable functions from other modules (do NOT re-define these, \
                      just call them):\n{exports_summary}\n\
-                     IMPORTANT: When creating Call ops to these functions, use ONLY the plain \
-                     function name in \"duumbi:function\" (e.g., \"add\", NOT \"ops:add\" or \
-                     \"module:add\"). The module resolution is automatic."
+                     IMPORTANT: When creating cross-module Call ops to these functions, set \
+                     \"duumbi:module\" to the owning module name and keep \"duumbi:function\" \
+                     as the plain function name."
                 ));
             }
         }
@@ -660,14 +660,11 @@ fn module_name_to_relative_path(module_name: &str) -> PathBuf {
 /// expected to populate it with the names of functions it creates. The
 /// system prompt in [`build_task_prompt`] reminds the LLM to do this.
 fn empty_module_template(module_name: &str) -> serde_json::Value {
-    // Use the last path component as the short name for ids
-    let short_name = module_name.rsplit('/').next().unwrap_or(module_name);
-
     json!({
         "@context": { "duumbi": "https://duumbi.dev/ns/core#" },
         "@type": "duumbi:Module",
-        "@id": format!("duumbi:{short_name}"),
-        "duumbi:name": short_name,
+        "@id": format!("duumbi:{module_name}"),
+        "duumbi:name": module_name,
         "duumbi:exports": [],
         "duumbi:functions": []
     })
@@ -738,7 +735,7 @@ fn collect_module_exports(graph_dir: &Path) -> String {
 
         if !sigs.is_empty() {
             lines.push(format!(
-                "- from module \"{}\": {} (call with plain name, e.g. \"add\" not \"{}:add\")",
+                "- from module \"{}\": {} (call with duumbi:module \"{}\" and plain duumbi:function)",
                 module_name,
                 sigs.join(", "),
                 module_name
@@ -1027,5 +1024,12 @@ mod tests {
             module_name_to_relative_path("../calculator weird/ops"),
             PathBuf::from("calculator_weird/ops.jsonld")
         );
+    }
+
+    #[test]
+    fn empty_module_template_preserves_full_module_identity() {
+        let template = empty_module_template("calculator/ops");
+        assert_eq!(template["@id"], "duumbi:calculator/ops");
+        assert_eq!(template["duumbi:name"], "calculator/ops");
     }
 }

--- a/src/intent/spec.rs
+++ b/src/intent/spec.rs
@@ -108,11 +108,12 @@ impl Task {
             TaskKind::CreateModule { module_name } => {
                 format!(
                     "Create a new module named '{}'. {} \
-                     IMPORTANT: This is a standalone module (NOT the main module). \
-                     You MUST add all function names to the \"duumbi:exports\" array \
-                     so they can be called from other modules. Do NOT add a main function \
-                     to this module — it is a library module.",
-                    module_name, self.description
+	                     IMPORTANT: This is a standalone module (NOT the main module). \
+	                     Set both @id and duumbi:name from the full module name '{}'. \
+	                     You MUST add all function names to the \"duumbi:exports\" array \
+	                     so they can be called from other modules. Do NOT add a main function \
+	                     to this module — it is a library module.",
+                    module_name, self.description, module_name
                 )
             }
             TaskKind::AddFunction {

--- a/src/mcp/tools/graph.rs
+++ b/src/mcp/tools/graph.rs
@@ -296,7 +296,10 @@ fn format_op(op: &crate::types::Op) -> String {
         Op::Return => "return".to_string(),
         Op::Load { variable } => format!("load {variable}"),
         Op::Store { variable } => format!("store {variable}"),
-        Op::Call { function } => format!("call {function}"),
+        Op::Call { module, function } => module.as_ref().map_or_else(
+            || format!("call {function}"),
+            |m| format!("call {m}::{function}"),
+        ),
         Op::Compare(cmp) => format!("compare {cmp:?}"),
         Op::Branch => "branch".to_string(),
         _ => format!("{op:?}"),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -488,6 +488,10 @@ fn parse_op(value: &serde_json::Value) -> Result<OpAst, ParseError> {
         }
         "duumbi:Call" => {
             let function_name = get_str(value, "duumbi:function", node_id_str)?;
+            let module_name = value
+                .get("duumbi:module")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
             let args = if let Some(args_val) = value.get("duumbi:args") {
                 if let Some(args_arr) = args_val.as_array() {
                     let mut refs = Vec::with_capacity(args_arr.len());
@@ -513,6 +517,7 @@ fn parse_op(value: &serde_json::Value) -> Result<OpAst, ParseError> {
             let mut ast = make_op_ast(
                 NodeId(node_id_str.to_string()),
                 Op::Call {
+                    module: module_name,
                     function: function_name.to_string(),
                 },
                 result_type,
@@ -1202,11 +1207,47 @@ mod tests {
         assert_eq!(
             call.op,
             Op::Call {
+                module: None,
                 function: "fib".to_string()
             }
         );
         assert_eq!(call.args.len(), 1);
         assert_eq!(call.args[0].id.0, "duumbi:t/main/e/0");
+    }
+
+    #[test]
+    fn parse_qualified_call() {
+        let json = r#"{
+            "@type": "duumbi:Module", "@id": "duumbi:t", "duumbi:name": "t",
+            "duumbi:functions": [{
+                "@type": "duumbi:Function", "@id": "duumbi:t/main",
+                "duumbi:name": "main", "duumbi:returnType": "i64",
+                "duumbi:blocks": [{
+                    "@type": "duumbi:Block", "@id": "duumbi:t/main/e",
+                    "duumbi:label": "entry",
+                    "duumbi:ops": [
+                        {"@type": "duumbi:Const", "@id": "duumbi:t/main/e/0", "duumbi:value": 10, "duumbi:resultType": "i64"},
+                        {
+                            "@type": "duumbi:Call",
+                            "@id": "duumbi:t/main/e/1",
+                            "duumbi:module": "calculator/ops",
+                            "duumbi:function": "add",
+                            "duumbi:args": [{"@id": "duumbi:t/main/e/0"}],
+                            "duumbi:resultType": "i64"
+                        }
+                    ]
+                }]
+            }]
+        }"#;
+        let module = parse_jsonld(json).expect("parse should succeed");
+        let call = &module.functions[0].blocks[0].ops[1];
+        assert_eq!(
+            call.op,
+            Op::Call {
+                module: Some("calculator/ops".to_string()),
+                function: "add".to_string()
+            }
+        );
     }
 
     #[test]

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -270,8 +270,9 @@ fn build_tool_specs() -> Vec<ToolSpec> {
                             "duumbi:operand": { "type": "object" },
                             "duumbi:condition": { "type": "object" },
                             "duumbi:trueBlock": { "type": "string" },
-                            "duumbi:falseBlock": { "type": "string" },
-                            "duumbi:function": { "type": "string" },
+                                "duumbi:falseBlock": { "type": "string" },
+                                "duumbi:module": { "type": "string" },
+                                "duumbi:function": { "type": "string" },
                             "duumbi:args": { "type": "array", "items": {} },
                             "duumbi:variable": { "type": "string" },
                             "duumbi:operator": { "type": "string" }

--- a/src/types.rs
+++ b/src/types.rs
@@ -114,6 +114,8 @@ pub enum Op {
     Branch,
     /// Function call: `duumbi:Call`
     Call {
+        /// Optional module qualifier for cross-module calls.
+        module: Option<String>,
         /// Name of the function to call.
         function: String,
     },
@@ -292,7 +294,13 @@ impl fmt::Display for Op {
             Op::Div => f.write_str("Div"),
             Op::Compare(op) => write!(f, "Compare({op})"),
             Op::Branch => f.write_str("Branch"),
-            Op::Call { function } => write!(f, "Call({function})"),
+            Op::Call { module, function } => {
+                if let Some(module) = module {
+                    write!(f, "Call({module}::{function})")
+                } else {
+                    write!(f, "Call({function})")
+                }
+            }
             Op::Load { variable } => write!(f, "Load({variable})"),
             Op::Store { variable } => write!(f, "Store({variable})"),
             Op::Print => f.write_str("Print"),
@@ -565,10 +573,19 @@ mod tests {
         assert_eq!(Op::Branch.to_string(), "Branch");
         assert_eq!(
             Op::Call {
+                module: None,
                 function: "fib".to_string()
             }
             .to_string(),
             "Call(fib)"
+        );
+        assert_eq!(
+            Op::Call {
+                module: Some("math/ops".to_string()),
+                function: "fib".to_string()
+            }
+            .to_string(),
+            "Call(math/ops::fib)"
         );
         assert_eq!(
             Op::Load {

--- a/tests/integration_phase4.rs
+++ b/tests/integration_phase4.rs
@@ -56,6 +56,9 @@ fn link_and_run(objects: &std::collections::HashMap<String, Vec<u8>>) -> (String
     for name in &all_names {
         if let Some(bytes) = objects.get(*name) {
             let path = tmp_dir.join(format!("{name}.o"));
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("invariant: create obj dir");
+            }
             fs::write(&path, bytes).expect("invariant: write obj");
             obj_paths.push(path);
         }
@@ -118,6 +121,85 @@ fn phase4_two_module_program_links_and_runs() {
 
     assert_eq!(stdout, "42", "expected double(21)=42 printed");
     assert_eq!(exit_code, 42, "expected exit code 42");
+}
+
+#[test]
+fn phase4_qualified_call_disambiguates_duplicate_exports() {
+    let ws = tempfile::TempDir::new().expect("invariant: tempdir must be creatable");
+    let graph_dir = ws.path().join(".duumbi").join("graph");
+    fs::create_dir_all(&graph_dir).expect("invariant: must create graph dir");
+
+    let main_jsonld = r#"{
+  "@context": {"duumbi": "https://duumbi.dev/ns/core#"},
+  "@type": "duumbi:Module",
+  "@id": "duumbi:main",
+  "duumbi:name": "main",
+  "duumbi:functions": [{
+    "@type": "duumbi:Function",
+    "@id": "duumbi:main/main",
+    "duumbi:name": "main",
+    "duumbi:returnType": "i64",
+    "duumbi:blocks": [{
+      "@type": "duumbi:Block",
+      "@id": "duumbi:main/main/entry",
+      "duumbi:label": "entry",
+      "duumbi:ops": [
+        {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/0",
+          "duumbi:module": "calculator/ops", "duumbi:function": "value",
+          "duumbi:args": [], "duumbi:resultType": "i64"},
+        {"@type": "duumbi:Print", "@id": "duumbi:main/main/entry/1",
+          "duumbi:operand": {"@id": "duumbi:main/main/entry/0"}},
+        {"@type": "duumbi:Return", "@id": "duumbi:main/main/entry/2",
+          "duumbi:operand": {"@id": "duumbi:main/main/entry/0"}}
+      ]
+    }]
+  }]
+}"#;
+
+    fn lib_module(name: &str, value: i64) -> String {
+        format!(
+            r#"{{
+  "@context": {{"duumbi": "https://duumbi.dev/ns/core#"}},
+  "@type": "duumbi:Module",
+  "@id": "duumbi:{name}",
+  "duumbi:name": "{name}",
+  "duumbi:exports": ["value"],
+  "duumbi:functions": [{{
+    "@type": "duumbi:Function",
+    "@id": "duumbi:{name}/value",
+    "duumbi:name": "value",
+    "duumbi:returnType": "i64",
+    "duumbi:blocks": [{{
+      "@type": "duumbi:Block",
+      "@id": "duumbi:{name}/value/entry",
+      "duumbi:label": "entry",
+      "duumbi:ops": [
+        {{"@type": "duumbi:Const", "@id": "duumbi:{name}/value/entry/0",
+          "duumbi:value": {value}, "duumbi:resultType": "i64"}},
+        {{"@type": "duumbi:Return", "@id": "duumbi:{name}/value/entry/1",
+          "duumbi:operand": {{"@id": "duumbi:{name}/value/entry/0"}}}}
+      ]
+    }}]
+  }}]
+}}"#
+        )
+    }
+
+    fs::write(graph_dir.join("main.jsonld"), main_jsonld).expect("write main");
+    let calc_path = graph_dir.join("calculator").join("ops.jsonld");
+    fs::create_dir_all(calc_path.parent().unwrap()).expect("create calc dir");
+    fs::write(&calc_path, lib_module("calculator/ops", 42)).expect("write calculator");
+    let utils_path = graph_dir.join("utils").join("ops.jsonld");
+    fs::create_dir_all(utils_path.parent().unwrap()).expect("create utils dir");
+    fs::write(&utils_path, lib_module("utils/ops", 7)).expect("write utils");
+
+    let program = Program::load(ws.path()).expect("qualified duplicate exports must load");
+    let objects =
+        lowering::compile_program(&program).expect("qualified duplicate exports must compile");
+    let (stdout, exit_code) = link_and_run(&objects);
+
+    assert_eq!(stdout, "42", "qualified call must target calculator/ops");
+    assert_eq!(exit_code, 42, "main returns the qualified call result");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements the plan from #541 for calculator intent graph generation and cross-module call resolution.

- Adds optional `duumbi:module` support to `duumbi:Call` parsing, display, tooling schemas, graph validation, and compiler lowering.
- Preserves nested module identity such as `calculator/ops` in generated module templates.
- Validates qualified calls explicitly and rejects ambiguous unqualified duplicate exports with E010.
- Mangles non-`main` compiler symbols by module/function so duplicate exported short names can link safely.
- Updates intent guidance so generated demo `main` functions call cross-module exports with `duumbi:module` and return `0` after printing.
- Adds regression coverage for qualified duplicate-export compilation/linking and calculator divide-by-zero benchmark behavior.

## Validation

- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/duumbi-target cargo clippy --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/duumbi-target cargo test --all`

Refs #541

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for qualified cross-module calls using module::function syntax; call displays now include module when present.

* **Bug Fixes**
  * Improved validation and diagnostics for unresolved or ambiguous cross-module references.
  * Ensure per-module object file paths are created before writing to avoid write failures.

* **Tests**
  * New unit, integration, and benchmark tests covering qualified calls, symbol mangling, and divide-by-zero scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->