### PR TITLE
docs: add DUUMBI-489 product spec

### DIFF
--- a/specs/DUUMBI-489/PRODUCT.md
+++ b/specs/DUUMBI-489/PRODUCT.md
@@ -1,0 +1,273 @@
+# DUUMBI-489: Phase 15 Final E2E Walkthrough Protocol
+
+## Summary
+
+Consolidate the Phase 15 end-to-end evidence into one operational walkthrough for proving DUUMBI across the CLI REPL and Studio workflow.
+
+The final walkthrough should cover all three representative Phase 15 samples:
+
+- Calculator from #486.
+- String Utilities from #487.
+- Math Library from #488.
+
+The artifact should help a developer or reviewer run the protocol from a fresh local checkout, understand prerequisites, execute the sample paths, inspect evidence, classify failures, and decide whether Phase 15 has enough evidence to support the Studio workflow claim.
+
+## Problem
+
+Phase 15 is evidence-oriented: DUUMBI needs credible proof that intent-driven work can move through CLI and Studio surfaces in a way a human can rerun and inspect. The current walkthrough is useful but incomplete. It explicitly covers only Calculator and String Utilities, and it says not to expand into #488 or #489.
+
+That leaves a developer-experience and review gap. Individual sample issues can pass while Phase 15 remains hard to close because the commands, prerequisites, timing expectations, provider setup, Studio checks, report fields, troubleshooting, and issue evidence are spread across issue threads, PRs, and partial documentation.
+
+## Outcome
+
+When this is done:
+
+- `docs/testing/phase15-walkthrough.md` is the canonical Phase 15 all-samples walkthrough.
+- A developer can follow the document to validate Calculator, String Utilities, and Math Library through CLI and Studio.
+- The walkthrough states the prerequisites for Rust, the local binary, Studio, provider configuration, and evidence output paths.
+- Each sample has copy-pasteable commands, expected graph/build/run evidence, timing targets, and pass/fail criteria.
+- Studio validation steps cover the simplified `Intents`, `Graph`, and `Build` workflow for each sample.
+- Query mode remains documented and verified as read-only; mutation remains Agent mode or explicit intent execution.
+- Provider, graph, compiler, run-output, report, and Studio shared-backend failures are distinguishable.
+- The document links the canonical issues and evidence for #486, #487, #488, and #489.
+- Phase 15 reviewers can use the document as the operational protocol instead of reconstructing evidence from history.
+
+## Scope
+
+### In Scope
+
+- Update `docs/testing/phase15-walkthrough.md` into the final all-samples Phase 15 protocol.
+- Cover CLI REPL validation for Calculator, String Utilities, and Math Library.
+- Cover Studio validation for Calculator, String Utilities, and Math Library.
+- Include prerequisite setup for the Rust toolchain, C compiler, local DUUMBI binary, Studio build, and provider configuration.
+- Include expected evidence for graph modules, generated functions, build output, run output, report fields, elapsed timing, UX checks, and Ralph Gate guidance.
+- Include sample-specific pass criteria:
+  - Calculator: calculator module, arithmetic operations, build/run success, Studio graph/build/run visibility.
+  - String Utilities: `string/utils`, reverse, vowel count, palindrome behavior, build/run success, Studio graph/build/run visibility.
+  - Math Library: canonical Math Library evidence defined by #488, build/run success, Studio graph/build/run visibility.
+- Include troubleshooting guidance for missing credentials, provider authentication/rate-limit/network/timeout failures, graph evidence mismatches, compiler failures, run-output mismatches, report serialization failures, and Studio shared-backend failures.
+- Preserve traceability to #486, #487, #488, #489, and relevant implementation PRs.
+- Record whether the final accepted evidence uses one provider for all samples or documents the provider per sample.
+- Make the main walkthrough operational, with historical logs linked rather than embedded as the primary path.
+
+### Explicitly Out Of Scope
+
+- Implementing or changing the Math Library harness or generated sample behavior for #488.
+- Changing CLI, Studio, provider, graph, build, or run behavior except through later approved implementation work.
+- Creating Phase 16 Windows work, Phase 13 telemetry or self-healing work, Phase 14 launch work, or stdlib ecosystem work.
+- Creating public marketing copy or external claims that Phase 15 is complete.
+- Product spec approval, technical spec creation, Ralph-cycle authorization, or implementation work as part of this Stage 6 artifact.
+
+## Constraints And Assumptions
+
+Facts:
+
+- #489 is the accepted canonical issue for the final Phase 15 all-samples walkthrough.
+- Stage 5 Human Acceptance exists for #489 and routes it to `Spec Needed`.
+- #489 is in the Phase 15 milestone.
+- #486 Calculator evidence is complete.
+- #487 String Utilities evidence is complete and closed by PR #546.
+- #488 Math Library is accepted but not yet complete at the time this product spec is drafted.
+- The current walkthrough covers Calculator and String Utilities only and explicitly excludes #488 and #489.
+- The current Phase 15 harness supports `calculator` and `string-utils`; `math-library` remains tied to #488.
+
+Assumptions:
+
+- Stage 6 product spec drafting may proceed now because the human explicitly requested it, but implementation of the final walkthrough remains gated on #488 evidence.
+- #488 is a hard implementation prerequisite for #489. The final all-samples document should not be completed with speculative Math Library evidence.
+- The final protocol may document the provider used for each accepted evidence run unless Stage 7 decides that one provider must be used across all three samples.
+- Screenshot-ready Studio steps are sufficient unless Stage 7 explicitly requires committed screenshots.
+- The existing `docs/testing/phase15-walkthrough.md` remains the target document unless Stage 8 identifies a stronger documentation structure.
+
+Constraints:
+
+- Do not claim Phase 15 completion unless the final walkthrough matches real accepted evidence.
+- Do not expose raw provider secrets in documentation, report examples, logs, screenshots, or issue comments.
+- Missing credentials must be explained as a setup or provider-evidence condition, not as a deterministic product failure.
+- Provider failures must be distinguishable from graph, compiler, run-output, report, and Studio validation failures.
+- Query mode must remain read-only in the protocol and in any described validation path.
+- The walkthrough must remain copy-pasteable enough for a reviewer to run without knowing the issue history.
+
+## Decisions
+
+- **Decision:** #489 should use a file-based product spec.
+  **Evidence:** The work is durable, cross-surface documentation that will guide technical specification, implementation, review, and later Phase 15 closure.
+
+- **Decision:** #488 is a hard prerequisite for implementation, not a blocker for Stage 6 drafting.
+  **Evidence:** Stage 5 recorded this question explicitly, and the user requested Stage 6 now. A product spec can define the dependency while preventing speculative implementation.
+
+- **Decision:** The final walkthrough should be operational rather than historical.
+  **Evidence:** #489's user outcome is that a developer can run one reliable protocol without reconstructing prerequisites, commands, timing expectations, provider setup, troubleshooting, or evidence from scattered history.
+
+- **Decision:** The final walkthrough should preserve traceability to sample issues and PR evidence.
+  **Evidence:** DUUMBI workflow relies on issue, spec, PR, and evidence links for human review and closure.
+
+- **Decision:** Provider evidence should be explicit per accepted run unless Stage 7 requires a single-provider rule.
+  **Evidence:** Existing Phase 15 evidence has used provider-parameterized execution and more than one configured provider path; requiring one provider across all samples is a review policy decision, not necessary for product specification.
+
+## Behavior
+
+### Defaults
+
+- The canonical output document is `docs/testing/phase15-walkthrough.md`.
+- The default protocol sequence is:
+  1. Verify prerequisites.
+  2. Build the local CLI and Studio artifacts needed for the walkthrough.
+  3. Run Calculator evidence.
+  4. Run String Utilities evidence.
+  5. Run Math Library evidence after #488 is complete.
+  6. Validate Studio behavior against generated workspaces.
+  7. Review reports, timing, failure categories, and issue traceability.
+- The document should prefer concrete commands and expected evidence over prose-only explanations.
+
+### Inputs
+
+- Local DUUMBI source checkout.
+- Rust toolchain and C compiler.
+- Built DUUMBI CLI binary.
+- Built Studio artifact or documented Studio command, as required by the current implementation.
+- Provider selection and credentials through the existing provider configuration mechanism.
+- Output paths for Phase 15 JSON reports.
+- Links to accepted evidence for #486, #487, and #488.
+
+### Outputs
+
+- Updated `docs/testing/phase15-walkthrough.md`.
+- Copy-pasteable CLI commands for each sample.
+- Studio validation steps for each sample.
+- Expected module/function/build/run evidence for each sample.
+- Expected report fields and example report output paths.
+- Timing targets and interpretation guidance.
+- Troubleshooting table or equivalent structured guidance.
+- Traceability links to issues, specs, PRs, reports, and evidence comments.
+
+### Success States
+
+- A reviewer can follow the walkthrough from a fresh local checkout and know what to run first.
+- All three sample sections identify the task id, provider command, output report path, expected generated module evidence, expected build/run evidence, Studio checks, and pass criteria.
+- The document says how to classify common failure modes without reading source code.
+- The document identifies #488 as the prerequisite source for Math Library evidence and does not invent evidence before #488 is complete.
+- The document makes it clear whether the evidence was collected with one provider across all samples or records the provider per sample.
+- The document links the canonical issues and relevant PR or evidence comments.
+
+### Empty And Error States
+
+- If provider credentials are missing, the walkthrough should tell the user how to identify the missing configuration without revealing secrets.
+- If a provider request fails because of authentication, rate limits, network, malformed output, or timeout, the walkthrough should map that to the expected failure category.
+- If graph evidence is missing or wrong, the walkthrough should distinguish missing module files from missing expected function semantics.
+- If build succeeds but run output is wrong, the walkthrough should classify the problem as run-output or evidence mismatch rather than provider failure.
+- If Studio cannot attach to the generated workspace, the walkthrough should distinguish shared-backend or server setup failure from CLI evidence failure.
+- If Math Library evidence is not yet accepted, the walkthrough update should remain incomplete and implementation should stop rather than speculating.
+
+### Timing And Performance
+
+- The walkthrough should state expected elapsed-time targets:
+  - Calculator target: under 10 minutes for a normal single-sample run.
+  - String Utilities target: under 15 minutes for a normal single-sample run.
+  - Math Library target: under 15 minutes for a normal single-sample run, unless #488 evidence justifies a different target.
+- Timeout and retry behavior should be described in terms of evidence interpretation, not as a promise that every provider run will complete.
+- The protocol should explain where elapsed time appears in the report and how a reviewer should compare it with the target.
+
+### Studio Behavior
+
+- Studio steps should validate the three visible workflow areas: `Intents`, `Graph`, and `Build`.
+- For each sample, Studio validation should confirm graph visibility, build endpoint behavior, run endpoint behavior, and readable output.
+- Query mode should be checked as read-only.
+- Mutation should remain tied to Agent mode or explicit intent execution.
+- Screenshot-ready instructions should be deterministic enough that a reviewer can capture the same states later.
+
+### Documentation Quality
+
+- Commands should be copy-pasteable and avoid hidden environment assumptions.
+- Links should be specific enough to support Stage 7, Stage 8, Stage 11, and Stage 12 traceability.
+- The main path should stay concise; historical logs and older evidence should be linked rather than pasted inline.
+- The document should avoid stale statements that say #488 or #489 are out of scope once the final protocol work is complete.
+
+## Tasks
+
+- Review the accepted evidence and implementation state for #486 and #487.
+- Wait for or verify accepted #488 Math Library evidence before finalizing the all-samples walkthrough.
+- Update `docs/testing/phase15-walkthrough.md` from a two-sample walkthrough into the final Phase 15 protocol.
+- Add or revise prerequisite setup instructions for CLI, Studio, provider credentials, and output directories.
+- Add all-sample command sections with consistent report paths and expected task ids.
+- Add sample-specific evidence expectations for Calculator, String Utilities, and Math Library.
+- Add Studio validation sections for all three samples.
+- Add timing targets and where to verify elapsed time.
+- Add troubleshooting guidance for provider, graph, build, run, report, and Studio shared-backend failure classes.
+- Add traceability links to issues, specs, PRs, evidence comments, and reports.
+- Remove or update stale scope language that says #488 and #489 are excluded.
+- Verify the documentation against actual accepted evidence rather than speculative desired behavior.
+
+Independent work:
+
+- Documentation structure and prerequisite cleanup can be prepared before #488 completes.
+- Traceability link inventory can be prepared before #488 completes.
+- Failure-class troubleshooting can be drafted from existing Phase 15 evidence before #488 completes.
+
+Sequential work:
+
+- Math Library command, expected evidence, timing, and Studio steps must wait for #488 accepted evidence.
+- Final pass/fail language must wait until all three sample evidence paths are real.
+- Phase 15 closure-facing language must wait until the completed walkthrough matches accepted evidence.
+
+## Checks
+
+Required documentation checks:
+
+- Inspect the rendered Markdown locally or in GitHub preview for readable headings, code blocks, tables, and links.
+- Verify every command block is copy-pasteable or clearly marked as an example.
+- Verify every referenced issue, PR, spec, report, or evidence comment link resolves.
+- Verify the document no longer incorrectly excludes #488 or #489 after this work is implemented.
+- Verify no raw provider secret appears in the document.
+- Verify the document states #488 as a prerequisite if #488 evidence is not yet merged when implementation starts.
+
+Required evidence checks once #488 is complete:
+
+- Re-run or verify Calculator evidence from the final walkthrough.
+- Re-run or verify String Utilities evidence from the final walkthrough.
+- Re-run or verify Math Library evidence from the final walkthrough.
+- Verify Studio steps for all three samples against the generated or accepted workspaces.
+- Verify timing targets are either met or explicitly explained by accepted evidence.
+
+Recommended repository checks for a docs-only implementation:
+
+```bash
+git diff --check
+```
+
+If the implementation changes docs tooling, command wrappers, harness behavior, or source code, Stage 8 should require the corresponding repository tests in addition to the docs-only checks.
+
+Pass criteria:
+
+- A reviewer can run the final protocol without reading #486, #487, or #488 first.
+- The final walkthrough is faithful to real accepted evidence.
+- The final walkthrough identifies failure classes clearly enough to support follow-up issue creation.
+- The final walkthrough preserves Query mode read-only expectations.
+- The final walkthrough supports a later Phase 15 closure decision.
+
+## Open Questions
+
+None blocking for product specification.
+
+Non-blocking items for Stage 7 or Stage 8:
+
+- Should Stage 7 require one provider across all three samples, or accept provider-per-sample evidence when each provider is recorded?
+- Should committed screenshots be required, or are deterministic screenshot-ready Studio steps enough?
+- Should the Math Library elapsed-time target remain under 15 minutes, or should #488 evidence define a different target?
+- Should the final walkthrough include a compact evidence matrix near the top, or keep evidence only within sample sections?
+
+## Sources
+
+- GitHub issue: https://github.com/hgahub/duumbi/issues/489
+- Stage 5 Human Acceptance Decision: https://github.com/hgahub/duumbi/issues/489#issuecomment-4448729008
+- Calculator sample: https://github.com/hgahub/duumbi/issues/486
+- String Utilities sample: https://github.com/hgahub/duumbi/issues/487
+- Math Library sample: https://github.com/hgahub/duumbi/issues/488
+- String Utilities implementation PR: https://github.com/hgahub/duumbi/pull/546
+- Phase 15 walkthrough: `docs/testing/phase15-walkthrough.md`
+- Phase 15 harness: `src/cli/phase15_e2e.rs`
+- DUUMBI PRD: `DUUMBI - PRD`
+- DUUMBI Development Intake to Delivery Workflow: `DUUMBI - Development Intake to Delivery Workflow`
+- DUUMBI Glossary: `DUUMBI - Glossary`
+- DUUMBI Agentic Development Map: `DUUMBI Agentic Development Map`
+- DUUMBI Service and Research Direction: `DUUMBI - Service and Research Direction`

--- a/specs/DUUMBI-489/TECHNICAL.md
+++ b/specs/DUUMBI-489/TECHNICAL.md
@@ -1,0 +1,306 @@
+# DUUMBI-489: docs(phase15): End-to-end test protocol document - Technical Specification
+
+## Implementation Objective
+
+Implement the approved DUUMBI-489 product spec by turning `docs/testing/phase15-walkthrough.md` into the canonical Phase 15 all-samples operational walkthrough for Calculator, String Utilities, and Math Library.
+
+Verified product-spec outcomes this technical spec implements:
+
+- `docs/testing/phase15-walkthrough.md` becomes the canonical Phase 15 all-samples walkthrough.
+- A developer can follow the document from a fresh checkout to validate CLI REPL and Studio behavior for Calculator, String Utilities, and Math Library.
+- The walkthrough states prerequisites for Rust, C compiler, local DUUMBI binary, Studio, provider configuration, and evidence report paths.
+- Each sample section has copy-pasteable commands, expected graph/build/run evidence, timing targets, and pass/fail criteria.
+- Studio validation covers the `Intents`, `Graph`, and `Build` workflow for each sample.
+- Query mode remains documented and verified as read-only; mutation remains Agent mode or explicit intent execution.
+- Provider, graph, compiler, run-output, report, and Studio shared-backend failures are distinguishable.
+- The document links canonical issues and evidence for #486, #487, #488, and #489.
+- Phase 15 closure language remains evidence-based and must not claim completion until all three sample paths match real accepted evidence.
+
+This technical spec does not authorize implementation during Stage 8. Stage 10 implementation agents must request explicit Ralph-cycle approval before changing docs, code, tests, generated artifacts, or runtime assets.
+
+## Agent Audience
+
+Primary implementation agents:
+
+- Codex for local documentation edits, source inspection, focused deterministic checks, and PR evidence.
+- Oz or another cloud runner only if a human explicitly approves a Ralph cycle that needs long-running live-provider validation.
+
+Review agents:
+
+- Codex or Oz for Stage 9 technical spec review.
+- A specialized tester may run live-provider Phase 15 evidence after #488 is implemented and credentials are available.
+
+## Source Context
+
+Verified facts:
+
+- Product spec: `specs/DUUMBI-489/PRODUCT.md`.
+- GitHub issue: https://github.com/hgahub/duumbi/issues/489.
+- Stage 7 approval: https://github.com/hgahub/duumbi/issues/489#issuecomment-4449106306 approved the product spec and recorded no blocking findings.
+- Workflow gate: #489 is open, labeled `product-spec-approved` and `needs-tech-spec`, and its Project status is `Technical Spec Needed`.
+- Dependency issue: #488 is open and approved for technical specification. Its issue body defines the Math Library target intent and expected evidence, but its implementation evidence is not present in this worktree.
+- Current walkthrough: `docs/testing/phase15-walkthrough.md` is scoped to Calculator and String Utilities and explicitly says not to expand into #488 or #489.
+- Current harness: `src/cli/phase15_e2e.rs` supports `calculator` and `string-utils`; `math-library` is rejected as unsupported by an existing test.
+- Current CLI command: `src/cli/mod.rs` describes hidden `phase15-e2e` task choices as `calculator` or `string-utils`.
+- Current benchmark normalization: `src/intent/benchmarks.rs` recognizes Calculator and String Utilities only.
+- Shared backend: `src/workflow.rs` exposes graph evidence, build, and run helpers. Graph evidence recursively scans `.duumbi/graph/**/*.jsonld`.
+- Studio API surface: `crates/duumbi-studio/src/lib.rs` exposes `POST /api/build` and `POST /api/run` returning structured JSON.
+- Studio workflow surface: `crates/duumbi-studio/src/components/footer.rs` renders exactly `Intents`, `Graph`, and `Build`.
+- Studio chat behavior: `crates/duumbi-studio/src/ws.rs` routes Query mode through read-only query handling; Intent mode tells users to use the Intents panel; mutation occurs through Agent mode.
+- Studio panel behavior: `crates/duumbi-studio/src/components/panels/intents_panel.rs` creates and executes intents, and `crates/duumbi-studio/src/components/panels/build_panel.rs` builds and runs the workspace.
+- Existing #487 technical spec: `specs/DUUMBI-487/TECHNICAL.md` defines and implemented the current String Utilities harness/documentation pattern and explicitly deferred #489 final all-samples consolidation.
+- Repo instructions: `AGENTS.md` requires source-aware work, Query mode read-only behavior, provider UX through `/provider`, focused REPL/TUI tests for interaction changes, and the standard Rust checks when code changes.
+- Relevant Obsidian notes inspected:
+  - `DUUMBI - PRD`: DUUMBI is evidence-oriented and human-verifiable.
+  - `DUUMBI - Development Intake to Delivery Workflow`: GitHub is execution source of truth; Stage 8 produces technical specs; Stage 10 owns implementation through approval-gated Ralph cycles.
+  - `DUUMBI Agentic Development Map`: read-only context gathering precedes write-capable mutation.
+  - `DUUMBI - Service and Research Direction`: Studio E2E workflow remains partial until evidence is strong enough for public-facing claims.
+
+Assumptions and recommendations:
+
+- #488 accepted evidence is a hard implementation prerequisite for final Math Library command, timing, Studio, and pass/fail sections. Implementation may prepare document structure and prerequisite/failure-class sections before #488 completes, but must not invent Math Library evidence.
+- Provider-per-sample evidence is acceptable if each provider is recorded, because Stage 7 explicitly treated single-provider consistency as non-blocking.
+- Deterministic screenshot-ready Studio steps are acceptable unless Stage 9 or a human reviewer requires committed screenshots.
+
+## Affected Areas
+
+Expected documentation changes:
+
+- `docs/testing/phase15-walkthrough.md`
+  - Replace two-sample scope language with final all-samples protocol scope.
+  - Add or revise prerequisites for Rust, C compiler, `cargo build`, Studio build/run, provider setup through `/provider` or supported env vars, and output directories.
+  - Add a compact evidence matrix near the top unless Stage 10 proposes and gets approval for an equally scannable structure.
+  - Normalize Calculator, String Utilities, and Math Library sections around consistent fields: issue, task id, provider, command, report path, expected graph evidence, expected build/run evidence, Studio checks, timing target, failure classification, and pass criteria.
+  - Link canonical issues #486, #487, #488, #489 and relevant PR/evidence artifacts.
+  - Remove stale statements that #488 or #489 are out of scope after the final protocol is implemented.
+
+Implementation-dependent source areas to inspect during Stage 10, but not necessarily change for #489:
+
+- `src/cli/phase15_e2e.rs` for supported task ids, report shape, timing, failure categories, Studio shared-backend evidence, and Ralph Gate output.
+- `src/cli/mod.rs` for `phase15-e2e` task help text.
+- `src/intent/benchmarks.rs` for known benchmark normalization and expected functions.
+- `src/workflow.rs` for graph/build/run evidence behavior.
+- `crates/duumbi-studio/src/lib.rs`, `crates/duumbi-studio/src/ws.rs`, `crates/duumbi-studio/src/components/footer.rs`, `crates/duumbi-studio/src/components/panels/intents_panel.rs`, and `crates/duumbi-studio/src/components/panels/build_panel.rs` for Studio API and UX facts.
+
+Potential test/check areas if implementation touches code:
+
+- `src/cli/phase15_e2e.rs` unit tests for task lookup, output predicates, graph evidence, UX checks, failure categories, and Math Library support if #488 adds it.
+- `src/intent/benchmarks.rs` tests if known benchmark behavior changes.
+- `src/workflow.rs` tests if graph evidence or build/run shared backend behavior changes.
+- `crates/duumbi-studio/tests/` if Studio UI behavior changes.
+
+Generated/local artifacts expected only during validation:
+
+- `/tmp/duumbi-phase15-calculator-report.json`
+- `/tmp/duumbi-phase15-string-utils-report.json`
+- `/tmp/duumbi-phase15-math-library-report.json` or the accepted #488 report path
+- Temporary workspaces under the OS temp directory
+
+No generated reports, screenshots, binaries, runtime assets, or provider secrets should be committed unless a later approved spec revision explicitly requires them.
+
+## Technical Approach
+
+### 1. Convert The Walkthrough Into An Operational Protocol
+
+Replace historical or issue-scoped framing with a reviewer-oriented protocol:
+
+- Purpose and scope: prove Phase 15 CLI REPL and Studio workflow across all three accepted sample issues.
+- Evidence status: distinguish accepted evidence, implementation prerequisite, local rerun command, and optional repeatability run.
+- Prerequisites: Rust, C compiler, local `duumbi` binary, Studio server, provider setup, safe report paths, and secret-handling rules.
+- Common workflow: build once, set `DUUMBI`, configure provider, run one sample, inspect report, validate Studio, classify failures, decide whether another Ralph loop is useful.
+- Failure taxonomy: missing credentials, provider authentication/rate-limit/network/timeout, graph evidence mismatch, compiler/build failure, run-output mismatch, report serialization failure, Studio shared-backend failure, and UX/read-only-mode regression.
+
+Recommendation: include a compact evidence matrix near the top with rows for `calculator`, `string-utils`, and `math-library`; columns should include issue, task id, module, expected functions/results, report path, CLI target, Studio target, timing target, and evidence status.
+
+### 2. Preserve Existing Calculator And String Utilities Evidence
+
+For Calculator:
+
+- Preserve the canonical intent from #486.
+- Keep module evidence for `calculator/ops`.
+- Keep representative arithmetic output checks including `3 + 5 = 8` and `10 / 2 = 5` or the accepted equivalent evidence.
+- Keep the under-10-minute target from the product spec.
+- Link accepted issue/PR/evidence rather than embedding long historical logs as the primary path.
+
+For String Utilities:
+
+- Preserve the canonical intent from #487.
+- Keep module evidence for `string/utils`.
+- Keep function evidence for `reverse`, `count_vowels`, and `is_palindrome`.
+- Keep representative output checks for `duumbi`, `ibmuud`, vowel count `3`, and `level` palindrome behavior.
+- Use the under-15-minute target from the #489 product spec.
+- Link accepted #487 implementation/evidence artifacts, including PR #546 where appropriate.
+
+### 3. Gate Math Library Content On #488 Evidence
+
+Math Library final content must be based on accepted #488 evidence.
+
+Required Math Library facts from #488 issue context:
+
+- Canonical target intent: `Build a math library with: factorial (recursive), fibonacci (iterative), and is_prime functions. The main function should compute factorial(10), fibonacci(15), and check if 97 is prime.`
+- Stable task id should be `math-library` or an explicitly accepted equivalent.
+- Expected module is `math/lib` unless #488 implementation accepts and records an equivalent mapping.
+- Expected functions are `factorial`, `fibonacci`, and `is_prime`.
+- Expected deterministic outputs are `factorial(10)=3628800`, `fibonacci(15)=610`, and `is_prime(97)=true` or `1`.
+- Expected Studio validation uses the same shared backend style as Calculator and String Utilities.
+
+Implementation agents may draft a clearly marked placeholder subsection before #488 completes, but the final walkthrough must not present speculative command output, timing, report paths, or Studio screenshots as accepted evidence. If #488 is still incomplete when a Stage 10 cycle reaches Math Library finalization, stop and request human guidance.
+
+### 4. Keep Query And Provider UX Boundaries Intact
+
+The walkthrough must state:
+
+- Query mode is read-only by default.
+- Graph mutation requires Agent mode or explicit intent execution.
+- Provider setup should route through `/provider` or documented existing configuration paths.
+- Documentation must not ask users to paste raw provider secrets into issues, docs, report examples, screenshots, or logs.
+- Missing credentials are a blocked evidence condition, not a deterministic product failure.
+
+### 5. Avoid Broad Source Changes In #489 Unless Needed By Reality
+
+The expected #489 implementation is documentation-only if #488 has already added `math-library` harness support and accepted evidence. If Stage 10 discovers the final walkthrough cannot be truthful without source changes, the agent must stop the current docs-only cycle and propose a new bounded cycle explaining:
+
+- the source gap
+- the exact affected files/modules
+- why #488 did not already own that change
+- what tests and live evidence would be required
+- whether the work exceeds #489's approved scope
+
+Rejected alternatives:
+
+- Do not make #489 implement the Math Library harness if #488 remains incomplete. That would collapse the prerequisite boundary and make the final protocol speculative.
+- Do not broaden the walkthrough into Phase 16, Phase 13, Phase 14, public marketing, or stdlib ecosystem claims.
+- Do not commit raw logs as the primary walkthrough path. Link historical logs and keep the main path operational.
+
+## Invariants
+
+- Product spec approval and technical spec approval remain separate; this document does not approve itself.
+- Stage 10 implementation must run only after explicit Ralph-cycle approval.
+- Query mode must remain read-only in CLI/Studio documentation and evidence.
+- Mutation must remain Agent mode or explicit intent execution.
+- Provider secrets must never appear in committed docs, reports, screenshots, logs, or GitHub comments.
+- #488 is a hard prerequisite for final Math Library evidence and final all-samples pass/fail language.
+- The final walkthrough must not claim Phase 15 completion unless all three sample paths are backed by accepted evidence.
+- Existing Calculator and String Utilities behavior and traceability must not regress.
+- Implementation must not modify generated artifacts, runtime assets, product specs, or unrelated source files unless a later approved cycle explicitly authorizes it.
+
+## Ralph Cycle Protocol
+
+Each cycle must:
+
+1. summarize the current state and remaining unmet requirements
+2. propose one bounded implementation goal
+3. list intended file areas and commands
+4. estimate resource use and risk
+5. ask for explicit approval before starting
+6. implement only the approved goal
+7. run the agreed checks
+8. report evidence, failures, and remaining gaps
+9. stop if requirements are met or request approval for the next cycle
+
+## Cycle Budget
+
+- Default cycle size: one bounded implementation goal per cycle.
+- Max files or modules per cycle: default 1 documentation file; up to 3 source/test modules only if source reality blocks truthful documentation and the user approves a code-touching cycle.
+- Expected command budget for docs-only cycles: `git diff --check`, targeted Markdown inspection, and link verification by opening or otherwise validating referenced issue/PR URLs.
+- Expected command budget for code-touching cycles, if approved later: focused unit tests for touched modules, `cargo fmt --check`, relevant `cargo test ...`, and broader `cargo test --all` / `cargo clippy --all-targets -- -D warnings` when shared behavior changes.
+- Live-provider command budget: at most one approved `phase15-e2e` attempt per sample per cycle, unless the evidence report shows provider instability and the human approves another paid run.
+- Approval required before every cycle: yes.
+- When to stop and ask for human guidance: #488 evidence missing when Math Library finalization is needed; source changes exceed docs-only #489 scope; provider cost or timeout repeats; accepted evidence conflicts with the product spec; reviewer asks for committed screenshots or single-provider policy not currently approved.
+
+## Task Breakdown
+
+1. Preflight and evidence inventory
+   - Confirm #489 remains in the correct workflow state.
+   - Confirm #488 implementation/evidence status before finalizing Math Library content.
+   - Inventory accepted evidence links for #486, #487, #488, and #489.
+
+2. Walkthrough structure update
+   - Rewrite top-level scope from two-sample historical log to all-samples operational protocol.
+   - Add prerequisite and common execution sections.
+   - Add compact evidence matrix.
+
+3. Calculator section normalization
+   - Preserve accepted command paths and pass criteria.
+   - Move long historical logs behind links or an appendix if the document remains too noisy.
+   - Keep timing and failure interpretation explicit.
+
+4. String Utilities section normalization
+   - Preserve accepted command paths and pass criteria.
+   - Record provider/evidence path from accepted #487 artifacts.
+   - Keep Studio shared-backend validation explicit.
+
+5. Math Library section finalization
+   - Use accepted #488 evidence only.
+   - Add task id, command, report path, module/function evidence, expected outputs, timing, Studio checks, and pass/fail criteria.
+   - If accepted #488 evidence is absent, stop with a blocking report instead of inventing content.
+
+6. Failure taxonomy and reviewer decision flow
+   - Add structured troubleshooting for provider, graph, compiler/build, run-output, report, Studio shared-backend, and UX/read-only failures.
+   - Add guidance for when to rerun, switch provider, file a follow-up issue, or stop.
+
+7. Final documentation review
+   - Check headings, code fences, links, copy-pasteability, and secret safety.
+   - Verify stale #488/#489 exclusion language is gone when final protocol is complete.
+   - Report remaining gaps and evidence status.
+
+## Verification Plan
+
+Required for docs-only implementation:
+
+- Inspect `docs/testing/phase15-walkthrough.md` rendered or as Markdown for readable heading hierarchy, code fences, tables, and links.
+- Run `git diff --check`.
+- Verify every command block is copy-pasteable or clearly marked as an example.
+- Verify every referenced issue, PR, spec, report, or evidence comment link resolves.
+- Verify no raw provider secret appears in the document.
+- Verify stale statements excluding #488 or #489 are removed after final implementation.
+- Verify the document explicitly gates Math Library finalization on accepted #488 evidence when that evidence is not yet merged or available.
+
+Required once #488 is complete and accepted:
+
+- Verify Calculator evidence from the final walkthrough by rerun or accepted evidence link.
+- Verify String Utilities evidence from the final walkthrough by rerun or accepted evidence link.
+- Verify Math Library evidence from the final walkthrough by rerun or accepted evidence link.
+- Verify Studio `Intents`, `Graph`, and `Build` steps for all three samples against generated or accepted workspaces.
+- Verify Query mode read-only behavior remains documented and, where harness evidence exists, reported.
+- Verify timing targets are met or deviations are explicitly explained by accepted evidence.
+
+Required if implementation touches code:
+
+- Run focused tests for every touched Rust module.
+- Run `cargo fmt --check`.
+- Run `cargo test --all` and `cargo clippy --all-targets -- -D warnings` when shared CLI, Studio, workflow, intent, or harness behavior changes.
+- Run at least one manual smoke path for changed REPL/TUI/Studio interactions when relevant.
+
+## Completion Criteria
+
+- `docs/testing/phase15-walkthrough.md` is the canonical Phase 15 all-samples protocol.
+- The walkthrough covers Calculator, String Utilities, and Math Library with consistent task id, provider command, output report path, expected graph evidence, build/run evidence, Studio checks, timing target, and pass criteria.
+- The walkthrough is faithful to accepted evidence and does not invent Math Library evidence before #488 is complete.
+- The document links #486, #487, #488, #489, specs, PRs, and evidence artifacts clearly enough for Stage 9, Stage 11, and Stage 12 traceability.
+- Provider, graph, compiler/build, run-output, report, and Studio shared-backend failures are distinguishable.
+- Query mode read-only expectations are preserved.
+- No raw provider secrets, generated reports, screenshots, binaries, or runtime assets are committed.
+- Required docs-only checks pass, or code-touching checks pass if a later approved cycle expands scope.
+
+## Failure And Escalation
+
+- If #489 loses `Technical Spec Needed` status or product spec approval, stop and report the missing gate.
+- If #488 evidence is missing when Math Library finalization is needed, stop and report that implementation is blocked on #488.
+- If accepted #488 evidence conflicts with the #489 product spec, stop and request human guidance before choosing a documented behavior.
+- If docs-only implementation exposes a source bug, stop after documenting the evidence and request approval for a separate code-touching cycle or follow-up issue.
+- If provider credentials are missing, classify validation as blocked and explain the relevant env var/setup path without asking for raw secrets.
+- If provider errors repeat, report provider-specific evidence and ask before spending another live attempt.
+- If checks fail, report the failing command, relevant output summary, suspected cause, and the smallest next cycle needed.
+- If scope expands into implementation code, generated artifacts, runtime assets, public marketing, Phase 16, Phase 13, or Phase 14, stop and ask for human approval or a separate issue.
+
+## Open Questions
+
+None blocking for implementation planning.
+
+Non-blocking items for Stage 9 or Stage 10:
+
+- Should the final protocol require a single provider across all three sample evidence runs, or is provider-per-sample evidence acceptable when each provider is recorded?
+- Should committed screenshots be required, or are deterministic screenshot-ready Studio steps enough?
+- Should the Math Library elapsed-time target remain under 15 minutes, or should accepted #488 evidence define a different target?
+- Should the evidence matrix remain near the top, or should evidence live only within sample sections if reviewers find the matrix redundant?


### PR DESCRIPTION
## Summary
- Adds specs/DUUMBI-489/PRODUCT.md for the accepted Phase 15 final E2E walkthrough issue.
- Keeps #488 as a hard implementation prerequisite while allowing product-spec review now.
- Does not add technical spec, implementation code, or Ralph-cycle work.

## Checks
- git diff --check
- git diff --cached --check

Refs #489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Phase 15 Specifications**: Added comprehensive product and technical specification documents outlining the end-to-end walkthrough protocol, including prerequisites, expected outputs, validation procedures, and success criteria for Phase 15 implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hgahub/duumbi/pull/547)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->