### PR TITLE
docs: add DUUMBI-488 product spec

### DIFF
--- a/specs/DUUMBI-488/PRODUCT.md
+++ b/specs/DUUMBI-488/PRODUCT.md
@@ -1,0 +1,307 @@
+# DUUMBI-488: Phase 15 E2E Math Library Sample
+
+## Summary
+
+Add product-level support for proving the third Phase 15 representative
+end-to-end workflow: a fresh user can create, execute, inspect, build, and run
+the Math Library sample through the CLI REPL and Duumbi Studio with a real
+configured LLM provider.
+
+The stable task id should be `math-library`. The canonical user intent is:
+
+```text
+Build a math library with: factorial (recursive), fibonacci (iterative), and is_prime functions. The main function should compute factorial(10), fibonacci(15), and check if 97 is prime.
+```
+
+This is the final engineering-heavy Phase 15 sample before #489 can consolidate
+the all-samples walkthrough. It should preserve the already validated
+Calculator and String Utilities behavior while adding a more complex math sample
+that exercises branching, recursion or repeated computation, cross-module calls,
+build/run evidence, and Studio graph/build/run presentation.
+
+## Problem
+
+Phase 15 claims that DUUMBI can support representative intent-driven
+development workflows across CLI REPL and Studio. Calculator has evidence, and
+String Utilities was completed by #487, but Phase 15 still lacks evidence for a
+moderate cross-module math workflow.
+
+Without this sample, DUUMBI can claim simple arithmetic and scoped string demo
+coverage, but not a stronger workflow that combines multiple functions, numeric
+control flow, cross-module calls, and deterministic run-output checks. That
+would leave the Phase 15 kill criterion partially unproven and would make #489
+premature.
+
+## Outcome
+
+When this is done:
+
+- `duumbi phase15-e2e math-library --provider <provider> --attempts 1 --output <path>` or an equivalent stable task naming path runs the Math Library E2E validation.
+- A fresh CLI workspace can create, execute, describe, build, and run the canonical Math Library intent using a configured provider.
+- Intent execution creates the canonical module `math/lib` and updates `app/main`.
+- Graph evidence shows `factorial`, `fibonacci`, and `is_prime`, or report-recorded semantically equivalent generated names if the implementation accepts equivalents.
+- The built program demonstrates all three functions with deterministic representative results:
+  - `factorial(10) = 3628800`
+  - `fibonacci(15) = 610`
+  - `is_prime(97) = true` or `1`
+- Studio validates the same generated workspace through the shared backend, including `Intents`, `Graph`, and `Build`, nested graph discovery, build, run, and read-only Query mode behavior.
+- The Phase 15 report records CLI evidence, Studio evidence, elapsed time, UX checks, failure category, provider guidance, and Ralph Gate guidance.
+- Missing provider credentials, provider timeout, provider error, compiler defects, graph validation defects, documentation mismatches, and evidence mismatches are distinguishable in the report.
+- `docs/testing/phase15-walkthrough.md` includes a dedicated Math Library section without turning #488 into the final all-samples protocol for #489.
+
+## Scope
+
+### In Scope
+
+- Add Math Library as a stable Phase 15 E2E task alongside Calculator and String Utilities.
+- Preserve existing Calculator and String Utilities task behavior and report shape.
+- Use `math-library` as the stable task id.
+- Use `math/lib` as the canonical generated module path.
+- Generate or validate functions named `factorial`, `fibonacci`, and `is_prime`.
+- Update `app/main` to call all three functions and print clear, human-readable result lines.
+- Validate CLI create, execute, describe or equivalent graph evidence, build, and run.
+- Validate Studio graph visibility, build endpoint, run endpoint, shared-backend workspace behavior, and the simplified three-panel workflow.
+- Validate Query mode remains read-only and mutation still requires Agent mode or explicit Intent execution.
+- Add or extend known benchmark normalization only if needed to make this Phase 15 sample deterministic enough for repeatable evidence.
+- Update `docs/testing/phase15-walkthrough.md` with Math Library setup, commands, pass criteria, provider behavior, and evidence expectations.
+- Add focused automated tests for harness/report behavior that do not require live provider credentials.
+
+### Explicitly Out Of Scope
+
+- Final all-samples E2E protocol consolidation, which belongs to #489 except for the Math Library section required here.
+- Phase 16 Windows and cross-platform work.
+- Phase 13 telemetry or self-healing work.
+- Marketing or GTM content updates.
+- New general-purpose math standard library design beyond what is necessary to validate this generated user module.
+- Broad Studio navigation, chat, provider setup, or model-selection product behavior unrelated to proving this sample.
+- Product spec approval, technical spec creation, Ralph-cycle authorization, or implementation work as part of this Stage 6 artifact.
+
+## Constraints And Assumptions
+
+Facts:
+
+- #488 is the accepted canonical execution issue for the Phase 15 Math Library sample.
+- Stage 5 acceptance exists and routes #488 to `Spec Needed`.
+- #486 Calculator is complete.
+- #487 String Utilities is complete.
+- #489 remains open and depends on #486, #487, and #488.
+- The current Phase 15 harness supports `calculator` and `string-utils`; it explicitly rejects `math-library` as unsupported.
+- `docs/testing/phase15-walkthrough.md` is currently scoped to Calculator and String Utilities and says not to expand into #488 or #489.
+- Source context already contains relevant algorithm hints for factorial, fibonacci, and prime checks in `src/intent/coordinator.rs`.
+- Existing E2E corpus material covers standalone factorial, fibonacci, and is_prime tasks.
+
+Assumptions:
+
+- The product goal is representative validation, not a fully general math package.
+- The canonical module path should be strict enough for the harness to check: `math/lib`.
+- Function names should be strict by default: `factorial`, `fibonacci`, and `is_prime`.
+- If implementation accepts semantically equivalent names, the report must record the mapping and Stage 7/Stage 11 review should be able to judge it.
+- Any configured supported provider is acceptable for the command, but the walkthrough may keep MiniMax as the documented example for consistency with prior Phase 15 evidence.
+- Provider-backed CLI execution remains the live mutation gate; Studio should validate graph/build/run and UX against the CLI-generated workspace through the shared backend instead of spending a second live provider mutation.
+
+Constraints:
+
+- Do not weaken Query/Agent/Intent mode safety: Query mode must remain read-only.
+- Do not log raw provider secrets in docs, reports, console output, or evidence files.
+- Missing credentials must produce structured `missing_provider_credentials` evidence, not a panic or ambiguous failure.
+- Provider timeout or provider instability must be classified separately from deterministic code, graph, compiler, docs, and evidence defects.
+- Nested module path handling must preserve slash-named modules on disk and in graph discovery.
+- The report must preserve the distinction between graph existence, function evidence, build success, run success, and output correctness.
+- The sample must not be marked passing if it only hardcodes final output in `app/main` without usable `math/lib` function evidence.
+
+## Decisions
+
+- **Decision:** #488 is the canonical Math Library execution issue.
+  **Evidence:** Stage 4 triage normalized #488 and found it to be the remaining Phase 15 Math Library issue.
+
+- **Decision:** The issue is accepted for specification.
+  **Evidence:** Stage 5 Human Acceptance Decision comment on #488 records `Decision: Accept` and `Next state: Spec Needed`.
+
+- **Decision:** This spec is file-based.
+  **Evidence:** The work is user-visible, cross-surface, non-trivial, likely to need review iteration, and useful as durable implementation context for Stage 8 and Stage 11.
+
+- **Decision:** The stable task id is `math-library`.
+  **Evidence:** #488 acceptance criteria use `duumbi phase15-e2e math-library`.
+
+- **Decision:** The canonical module path is `math/lib`.
+  **Evidence:** #488 names `math/lib` as the expected module, and strict module evidence is needed for a reliable Phase 15 sample.
+
+- **Decision:** #488 should not consolidate the final all-samples protocol.
+  **Evidence:** #489 is the separate final protocol issue and depends on #488.
+
+## Behavior
+
+### Defaults
+
+- The stable task id is `math-library`.
+- The canonical module path is `math/lib`.
+- The canonical functions are `factorial`, `fibonacci`, and `is_prime`.
+- The provider argument works consistently with the existing Phase 15 harness.
+- Attempt count, output path, Studio port, report structure, timeout behavior, and Ralph Gate guidance remain consistent with the existing harness unless Stage 8 identifies a necessary adjustment.
+
+### Inputs
+
+- Required task id: `math-library`.
+- Required provider selection: the existing provider argument path.
+- Optional attempts count.
+- Optional report output path.
+- Optional Studio port if already supported by the harness.
+- Provider credential through the existing provider-specific environment variable or configured provider path.
+- Canonical intent text:
+
+```text
+Build a math library with: factorial (recursive), fibonacci (iterative), and is_prime functions. The main function should compute factorial(10), fibonacci(15), and check if 97 is prime.
+```
+
+### Outputs
+
+- JSON report with task, provider, attempts, per-attempt CLI and Studio evidence, performance, UX checks, failure category, and Ralph Gate guidance.
+- CLI evidence including workspace path, intent slug, module checks, function checks, build output path, run result, stdout/stderr, elapsed time, seeded/harvested learning counts when available, and whether `math/lib` exists.
+- Studio evidence including shared backend workspace use, graph contains `math/lib`, build endpoint success, run endpoint success, footer workflow items, Query mode read-only state, and Agent mode availability.
+- Documentation updates in `docs/testing/phase15-walkthrough.md` that explain how to run and judge the Math Library sample.
+
+### Success States
+
+- The CLI leg creates a fresh workspace, creates the canonical intent, executes it, finds `math/lib`, finds `factorial`, `fibonacci`, and `is_prime`, builds successfully, runs successfully, and demonstrates the required representative results.
+- The Studio leg uses the CLI-generated workspace, confirms the three-panel workflow remains `Intents`, `Graph`, `Build`, sees `math/lib`, builds successfully, runs successfully, and confirms Query mode remains read-only.
+- The report is written to the requested output path and contains enough evidence for a human reviewer to decide whether the sample passed.
+
+### Representative Correct Results
+
+The sample must prove all three operations:
+
+- `factorial(10)` returns `3628800`.
+- `fibonacci(15)` returns `610`.
+- `is_prime(97)` returns true or `1`.
+
+Additional edge checks may be included in implementation or tests, such as
+`factorial(0) = 1`, `fibonacci(0) = 0`, `fibonacci(1) = 1`,
+`is_prime(1) = false/0`, and `is_prime(4) = false/0`, but they are not required
+for the product-level pass unless Stage 8 chooses to add them.
+
+### Empty And Error States
+
+- Unknown task ids should return a clear unsupported-task error that lists supported task ids, including `math-library` after this work is implemented.
+- Missing provider credentials should report `missing_provider_credentials` with the missing environment variable name and no secret value.
+- Provider authentication, rate-limit, network, timeout, and malformed-output failures should be classified separately where detectable.
+- Build failures should include structured build evidence and should not be misclassified as provider failures once graph generation has completed.
+- Run failures should distinguish missing binary, process launch failure, nonzero process exit with otherwise correct stdout, and output mismatch.
+- Missing `math/lib`, missing expected functions, missing cross-module calls, or incorrect representative outputs should be deterministic evidence failures.
+
+### Retry, Timeout, And Cancellation
+
+- Provider-backed CLI mutation should keep the existing bounded timeout model.
+- A timeout must write structured evidence and harvest any available sanitized learning records.
+- Attempts should be independent fresh workspaces while allowing the existing learning cache behavior to seed later attempts.
+- User interruption should leave any partial report or console evidence in a state that does not imply a pass.
+
+### Race Conditions And Invariants
+
+- Studio validation must not start until the CLI leg has passed and reported a reusable workspace.
+- Graph discovery must recursively include nested modules under `.duumbi/graph/**/*.jsonld`.
+- Slash-named module paths must remain slash paths on disk, not flattened names.
+- The report should preserve the distinction between generated graph existence, function evidence, build success, run success, and output correctness.
+- `app/main` must call or otherwise depend on functions from `math/lib`; a direct print-only demonstration in `app/main` must not satisfy the sample by itself.
+- Query mode must not mutate the workspace; mutation remains Agent mode or explicit Intent execution.
+
+### Accessibility And Focus Rules
+
+- The three primary Studio workflow items must remain visible and keyboard-reachable as `Intents`, `Graph`, and `Build`.
+- Query and Agent mode controls must remain distinguishable to keyboard and screen-reader users through existing labels/states.
+- Build and run results must remain exposed as readable text, not only transient visual state.
+
+## Tasks
+
+- Add a Math Library task descriptor to the Phase 15 harness with the canonical prompt, task id, module path, expected function names, output predicate, and failure-module label.
+- Preserve existing Calculator and String Utilities task descriptors and tests.
+- Add known benchmark normalization for the Math Library prompt only if provider variability prevents reliable evidence.
+- Define Math Library acceptance criteria and test cases for intent normalization if benchmark normalization is added.
+- Extend CLI leg evidence checks for `math/lib`, `factorial`, `fibonacci`, `is_prime`, build output, run stdout, and failure categories.
+- Extend Studio leg validation to check `math/lib` against the shared backend workspace, without triggering a second live provider mutation.
+- Ensure nested graph path checks work for `.duumbi/graph/math/lib.jsonld`.
+- Update report aggregation, performance, UX checks, and Ralph Gate guidance to account for the selected task.
+- Add focused tests for supported/unsupported task ids, missing provider credentials, report serialization, Math Library evidence classification, and nested module path checks.
+- Update `docs/testing/phase15-walkthrough.md` with Math Library commands, pass criteria, report examples, provider credential behavior, and evidence expectations.
+- Run regression checks and the live provider command when credentials are available.
+
+Independent work:
+
+- Harness task descriptor addition and unsupported-task tests.
+- Math Library output predicate and report tests.
+- Documentation update.
+- Optional benchmark-normalization tests.
+
+Sequential work:
+
+- Live provider CLI validation before Studio shared-backend validation.
+- Documentation evidence log after a local report path exists.
+- #489 final protocol consolidation only after this issue has real validation evidence.
+
+## Checks
+
+- `cargo fmt --check`
+- `cargo test --all`
+- `cargo test -p duumbi-studio --features ssr`
+- `cargo clippy --all-targets -- -D warnings`
+- Focused harness tests for:
+  - `calculator` remains supported.
+  - `string-utils` remains supported.
+  - `math-library` is supported.
+  - unsupported task ids return a clear error listing all supported tasks.
+  - missing provider credentials produce `missing_provider_credentials`.
+  - report JSON includes task-specific CLI evidence, Studio evidence, elapsed time, UX checks, failure category, and Ralph Gate guidance.
+  - nested module path checks preserve `math/lib`.
+  - Math Library output evidence recognizes `factorial(10)=3628800`, `fibonacci(15)=610`, and `is_prime(97)=true` or `1`.
+- Live/manual validation when credentials are available:
+
+```bash
+cargo build
+cargo build -p duumbi-studio --features ssr
+export MINIMAX_API_KEY="..."
+./target/debug/duumbi phase15-e2e math-library \
+  --provider minimax \
+  --attempts 1 \
+  --output /tmp/duumbi-phase15-math-library-report.json
+```
+
+Pass criteria:
+
+- The report result passes or, if blocked, clearly identifies a provider/credential class rather than a deterministic code/docs mismatch.
+- CLI evidence includes a fresh workspace, generated slug, `math/lib`, the three math functions, build path, run evidence, elapsed time, and failure category if any.
+- Studio evidence includes shared backend workspace, `math/lib` graph visibility, build success, run success, `Intents`/`Graph`/`Build` UX checks, Query read-only state, and Agent mode availability.
+- The walkthrough documents the protocol and at least one local evidence report path for this sample.
+
+## Open Questions
+
+None blocking for product specification.
+
+Non-blocking items for Stage 8:
+
+- Whether to require strict function names only, or allow semantically equivalent names with explicit report mapping.
+- Whether Math Library needs deterministic benchmark normalization, and how much normalization is acceptable before it weakens live-provider evidence.
+- Whether the implementation should prove iterative fibonacci literally, or may use recursive/repeated-computation behavior if current graph support makes true iteration inappropriate.
+- Whether `is_prime(97)` should be represented as true/false or `1`/`0` in output checks.
+
+## Sources
+
+- GitHub issue: https://github.com/hgahub/duumbi/issues/488
+- Stage 5 Human Acceptance Decision: https://github.com/hgahub/duumbi/issues/488#issuecomment-4445517611
+- Calculator precedent: https://github.com/hgahub/duumbi/issues/486
+- String Utilities precedent: https://github.com/hgahub/duumbi/issues/487
+- String Utilities implementation PR: https://github.com/hgahub/duumbi/pull/546
+- Qualified cross-module call prerequisite PR: https://github.com/hgahub/duumbi/pull/542
+- Final protocol documentation separate scope: https://github.com/hgahub/duumbi/issues/489
+- Existing String Utilities product spec: `specs/DUUMBI-487/PRODUCT.md`
+- Phase 15 walkthrough: `docs/testing/phase15-walkthrough.md`
+- Phase 15 harness: `src/cli/phase15_e2e.rs`
+- Known benchmark normalization: `src/intent/benchmarks.rs`
+- Algorithmic hints: `src/intent/coordinator.rs`
+- Core operation types: `src/types.rs`
+- Factorial E2E corpus: `docs/e2e/corpus/E08_factorial.gold.yaml`
+- Fibonacci E2E corpus: `docs/e2e/corpus/M01_fibonacci.gold.yaml`
+- Prime E2E corpus: `docs/e2e/corpus/M06_is_prime.gold.yaml`
+- DUUMBI PRD: `DUUMBI - PRD`
+- DUUMBI Glossary: `DUUMBI - Glossary`
+- DUUMBI Agentic Development Map: `DUUMBI Agentic Development Map`
+- DUUMBI Development Intake to Delivery Workflow: `DUUMBI - Development Intake to Delivery Workflow`
+- DUUMBI Product Roadmap 2026-05: `DUUMBI - Product Roadmap 2026-05`

--- a/specs/DUUMBI-488/TECHNICAL.md
+++ b/specs/DUUMBI-488/TECHNICAL.md
@@ -1,0 +1,468 @@
+# DUUMBI-488: Phase 15 E2E Math Library Sample - Technical Specification
+
+## Implementation Objective
+
+Implement the approved DUUMBI-488 product spec by adding a `math-library`
+Phase 15 E2E validation task alongside the existing `calculator` and
+`string-utils` tasks. The implementation must prove that a fresh workspace can
+create, execute, inspect, build, run, and present the Math Library sample
+through both CLI and Studio without regressing the completed Phase 15 samples.
+
+This technical spec implements these approved product-spec outcomes:
+
+- `duumbi phase15-e2e math-library --provider <provider> --attempts 1 --output <path>` runs a stable Math Library E2E task.
+- The CLI leg creates a fresh workspace, uses a real configured provider, creates the canonical intent, executes it, inspects graph evidence, builds, runs, and writes a structured report.
+- Intent execution creates the canonical module `math/lib` and updates `app/main`.
+- Graph/report evidence shows `factorial`, `fibonacci`, and `is_prime`.
+- `app/main` calls the generated math functions and prints clear representative results:
+  - `factorial(10) = 3628800`
+  - `fibonacci(15) = 610`
+  - `is_prime(97) = true` or `1`
+- Studio validates the same CLI-generated workspace through the shared backend, including graph visibility, build, run, `Intents`/`Graph`/`Build` UX checks, Query read-only state, and Agent mode availability.
+- Missing credentials, provider timeout/auth/rate-limit issues, compiler defects, graph validation defects, documentation mismatches, and evidence mismatches remain distinguishable.
+- `docs/testing/phase15-walkthrough.md` gains a dedicated Math Library section without taking over #489 final all-samples protocol consolidation.
+
+## Agent Audience
+
+Primary implementation agents:
+
+- Codex for local source edits, focused tests, documentation updates, deterministic checks, and GitHub evidence reporting.
+- Oz or another cloud runner only when a human explicitly approves a Ralph cycle that needs orchestration-heavy or long-running live-provider validation.
+
+Review and verification agents:
+
+- Codex or Oz for Stage 9 technical-spec review.
+- A specialized tester may run live-provider validation after deterministic checks pass and credentials are available.
+
+## Source Context
+
+Verified facts:
+
+- Product spec: `specs/DUUMBI-488/PRODUCT.md`.
+- GitHub issue: https://github.com/hgahub/duumbi/issues/488.
+- Stage 5 acceptance: https://github.com/hgahub/duumbi/issues/488#issuecomment-4445517611.
+- Stage 7 product-spec approval: https://github.com/hgahub/duumbi/issues/488#issuecomment-4449098629.
+- Product spec draft PR: https://github.com/hgahub/duumbi/pull/548.
+- Related implementation precedent: #487 String Utilities was completed by PR #546, and the current local source includes its descriptor-based Phase 15 harness changes.
+- Existing harness: `src/cli/phase15_e2e.rs` defines `Phase15Task`, supports `calculator` and `string-utils`, rejects `math-library`, records `Phase15Report`, creates fresh workspaces, runs provider-backed CLI generation first, then validates Studio against the same CLI-generated workspace.
+- Existing task descriptors: `calculator` uses `calculator/ops`; `string-utils` uses `string/utils` and expected functions `reverse`, `count_vowels`, `is_palindrome`.
+- Existing CLI help: `src/cli/mod.rs` says hidden `phase15-e2e` accepts `calculator` or `string-utils`.
+- Existing benchmark normalization: `src/intent/benchmarks.rs` recognizes `calculator` and `string-utils`, can build fallback specs, returns expected benchmark functions, and returns task-specific guidance for String Utilities.
+- Existing intent creation prompt: `src/intent/create.rs` currently models verifier test cases as i64-only and instructs normal user-generated tests not to target `main`.
+- Existing intent execution: `src/intent/execute.rs` derives expected exports from test cases and `expected_functions_for_benchmark`, preserves slash-named modules through `module_name_to_relative_path`, verifies intent test cases, and supports known-benchmark guidance.
+- Existing algorithmic hints: `src/intent/coordinator.rs` contains hints for fibonacci, factorial, and prime checks. The fibonacci/factorial branch currently uses `if ... else if ...`, so a combined prompt containing both may not emit both hints unless implementation changes this or provides benchmark-specific guidance elsewhere.
+- Existing graph/build/run backend: `src/workflow.rs` exposes `graph_evidence`, `build_workspace`, and `run_workspace`; graph evidence recursively scans `.duumbi/graph/**/*.jsonld`.
+- Existing Studio API/backend: `crates/duumbi-studio/src/server_fns.rs` discovers nested modules such as `calculator/ops`, wraps shared build/run helpers, and exposes workspace status. `crates/duumbi-studio/src/lib.rs` exposes JSON endpoints including `/api/graph/context`, `/api/build`, and `/api/run`.
+- Existing Studio UX evidence: `src/cli/phase15_e2e.rs` verifies footer items `Intents`, `Graph`, `Build`, Query default/read-only state, and Agent mode availability by inspecting SSR HTML.
+- Existing Math source material: `docs/e2e/corpus/E08_factorial.gold.yaml`, `docs/e2e/corpus/M01_fibonacci.gold.yaml`, and `docs/e2e/corpus/M06_is_prime.gold.yaml` provide standalone i64 expectations for factorial, fibonacci, and prime checks.
+- Existing math operation support: `src/types.rs`, `src/parser/mod.rs`, `src/compiler/lowering.rs`, and tests cover `duumbi:Modulo`, which is relevant for primality.
+- Current Phase 15 walkthrough: `docs/testing/phase15-walkthrough.md` is scoped to #486 and #487 and explicitly says not to expand into #488 or #489.
+- Repo instructions: `AGENTS.md`, `docs/architecture.md`, and `docs/coding-conventions.md` require graph-first transformations, Query mode read-only by default, provider setup through `/provider`, no `.unwrap()` in library code, doc comments for public items, zero-warning clippy, and focused state-machine/manual smoke checks for REPL/TUI UX changes.
+- Relevant Obsidian notes inspected:
+  - `DUUMBI - PRD`: DUUMBI should expose intent, structure, executable behavior, and evidence as connected artifacts.
+  - `DUUMBI - Development Intake to Delivery Workflow`: Stage 8 creates a technical spec only after product approval and requires bounded Ralph cycles for implementation.
+  - `DUUMBI Agentic Development Map`: agents should ask read-only questions first, create technical plans with affected files/risks/tests/evidence, and use CI/review/human verification before merge.
+  - `DUUMBI - Product Roadmap 2026-05`: Phase 15 should close before broader surface expansion; Math Library is one remaining sample before #489.
+  - `DUUMBI - Phase 15 - Studio Workflow Redesign`: the three sample tasks are the kill-criterion validation set for CLI REPL and Studio.
+  - `DUUMBI - Service and Research Direction`: Studio E2E workflow remains partial until evidence is strong enough for public-facing claims.
+  - `DUUMBI - Glossary`: agent skills are reusable operational playbooks.
+
+Assumptions:
+
+- The technical-spec PR may be stacked on the product-spec branch while PR #548 remains open; the artifact path and issue comment must make the dependency clear.
+- Any configured supported provider remains acceptable for the live command. MiniMax may remain the documented example because the Phase 15 walkthrough currently uses `MINIMAX_API_KEY`.
+- Studio should continue to validate the CLI-generated workspace rather than spending a second live provider-backed mutation.
+- The first implementation should prefer deterministic Math Library benchmark normalization unless inspection proves the current generic prompt path already creates stable `math/lib`, functions, test cases, and report evidence.
+- True static proof that `fibonacci` is implemented with a literal loop is not required for the initial pass. The required evidence is deterministic function behavior, `math/lib` function presence, cross-module calls from `app/main`, and representative output. If a reviewer requires literal iteration evidence, that should be handled as a Stage 9 or Ralph-cycle approval decision.
+
+## Affected Areas
+
+Expected source changes:
+
+- `src/cli/phase15_e2e.rs`
+  - Add a `math-library` task descriptor with canonical intent, module path `math/lib`, expected functions `factorial`, `fibonacci`, `is_prime`, task-specific output predicate, display name, and failure module.
+  - Update task lookup tests so `math-library` is supported and unsupported-task guidance lists `calculator`, `string-utils`, and `math-library`.
+  - Add Math Library output predicate tests for the representative result lines.
+  - Add graph/module evidence tests for `math/lib`.
+  - Ensure report evidence keys remain deterministic, for example `module_math_lib_exists=true`, `describe_contains_factorial=true`, `describe_contains_fibonacci=true`, `describe_contains_is_prime=true`, `graph_has_math_lib=true`, `stdout=...`.
+  - Update Ralph Gate wording so it does not hardcode stale Calculator or #486 language for every task.
+
+- `src/cli/mod.rs`
+  - Update hidden `phase15-e2e` task help text to list `calculator`, `string-utils`, and `math-library`.
+
+- `src/intent/benchmarks.rs`
+  - Add Math Library benchmark recognition for prompts containing enough of `math library`, `factorial`, `fibonacci`, and `prime`/`is_prime`.
+  - Add deterministic normalization to create `math/lib`, modify `app/main`, and set i64-compatible test cases for the expected functions.
+  - Add `MATH_LIBRARY_EXPECTED_FUNCTIONS` to `expected_functions_for_benchmark`.
+  - Add Math Library guidance only if needed to keep provider-generated graph mutations inside supported DUUMBI operations and canonical sample behavior.
+
+- `src/intent/execute.rs`
+  - No broad redesign expected.
+  - Existing `expected_functions_for_benchmark` integration should pick up Math Library functions after `benchmarks.rs` is extended.
+  - Modify only if implementation proves create-module retry, benchmark guidance, or `main` handling needs a small extension.
+
+- `src/intent/coordinator.rs`
+  - Optional but likely: make math algorithmic hints accumulate so combined prompts can include factorial, fibonacci, and prime guidance together, or rely on explicit Math Library benchmark guidance if that produces better-scoped behavior.
+
+- `docs/testing/phase15-walkthrough.md`
+  - Update top-level issue/scope text to include #488 while keeping #489 out of scope.
+  - Add a dedicated Math Library protocol section with CLI, Studio, automated harness command, pass criteria, missing-credential behavior, provider guidance, and evidence expectations.
+  - Do not consolidate the final all-samples protocol; #489 owns that.
+
+Expected test changes:
+
+- Unit tests in `src/cli/phase15_e2e.rs` for task lookup, unsupported task guidance, Math Library output predicate, function evidence, graph module evidence, and task-specific Ralph Gate text.
+- Unit tests in `src/intent/benchmarks.rs` for Math Library matching, normalization, expected functions, deterministic fallback spec, and optional guidance.
+- Existing or new unit tests in `src/intent/execute.rs` if a Math Library benchmark-specific create-module retry path needs direct coverage.
+- Existing or new tests in `src/intent/coordinator.rs` if algorithmic hint accumulation is changed.
+- Existing Studio nested module tests may be extended to include `math/lib` only if implementation changes module discovery behavior. Do not add redundant tests if current generic nested-module coverage already proves the contract.
+
+Expected generated/local artifacts during validation:
+
+- `/tmp/duumbi-phase15-math-library-report.json` for local live evidence.
+- Temporary workspaces under the OS temp directory, created by the harness.
+- No generated reports should be committed unless a later approved docs decision explicitly asks for a checked-in sample artifact.
+
+CI/check paths:
+
+- `cargo fmt --check`
+- `cargo test phase15`
+- `cargo test benchmarks`
+- Any focused `cargo test` command for changed `intent::execute` or `intent::coordinator` tests.
+- `cargo test -p duumbi-studio --features ssr` if Studio module discovery/API code changes.
+- `cargo test --all`
+- `cargo clippy --all-targets -- -D warnings`
+
+## Technical Approach
+
+### 1. Extend The Phase 15 Task Descriptor Model
+
+Add a Math Library descriptor to the existing `PHASE15_TASKS` array rather than creating a second harness path.
+
+Recommended descriptor shape:
+
+```rust
+const MATH_LIBRARY_INTENT: &str = "Build a math library with: factorial (recursive), fibonacci (iterative), and is_prime functions. The main function should compute factorial(10), fibonacci(15), and check if 97 is prime.";
+const MATH_LIBRARY_FUNCTIONS: &[&str] = &["factorial", "fibonacci", "is_prime"];
+
+Phase15Task {
+    id: "math-library",
+    display_name: "Math Library",
+    intent: MATH_LIBRARY_INTENT,
+    module_path: "math/lib",
+    expected_functions: MATH_LIBRARY_FUNCTIONS,
+    output_check: output_mentions_math_library_results,
+    failure_module: "math/lib",
+}
+```
+
+The output predicate should normalize whitespace, casing, and optional boolean representation while still requiring all three representative checks. It should accept labeled equivalents but reject output that omits any operation.
+
+Minimum output evidence:
+
+- factorial label and `3628800`
+- fibonacci label and `610`
+- `is_prime`/prime label, `97`, and `true` or `1`
+
+Do not require `main` exit code `0` as the only success signal unless the normalized benchmark explicitly makes that stable. Preserve the existing harness behavior that treats stdout evidence as the product-facing pass signal, while recording `run_exit_code` for review.
+
+### 2. Add Deterministic Math Library Benchmark Normalization
+
+Add a known benchmark rule in `src/intent/benchmarks.rs` unless Stage 10 inspection proves it is unnecessary. The recommended path is to add it because #488 requires strict module/function naming, cross-module calls, and repeatable evidence.
+
+Matching predicate:
+
+- Match prompts that contain enough of:
+  - `math`
+  - `library`
+  - `factorial`
+  - `fibonacci`
+  - `prime` or `is_prime`
+
+Normalization:
+
+- Set `modules.create = ["math/lib"]`.
+- Ensure `modules.modify` contains `app/main`.
+- Set acceptance criteria that require:
+  - `factorial(n)` returns correct i64 factorial values for representative non-negative inputs.
+  - `fibonacci(n)` returns correct i64 Fibonacci values for representative inputs.
+  - `is_prime(n)` returns `1` for prime and `0` for non-prime values.
+  - `main` calls `math/lib::factorial`, `math/lib::fibonacci`, and `math/lib::is_prime`, prints labeled lines for the three canonical representative results, and returns a stable value.
+- Set i64 verifier test cases that prove functions, not just `app/main`, for example:
+  - `factorial(0) = 1`
+  - `factorial(1) = 1`
+  - `factorial(5) = 120`
+  - `factorial(10) = 3628800`
+  - `fibonacci(0) = 0`
+  - `fibonacci(1) = 1`
+  - `fibonacci(2) = 1`
+  - `fibonacci(10) = 55`
+  - `fibonacci(15) = 610`
+  - `is_prime(1) = 0`
+  - `is_prime(2) = 1`
+  - `is_prime(4) = 0`
+  - `is_prime(97) = 1`
+
+Reasoning:
+
+- The current verifier is already i64-oriented, so Math Library can use normal test cases without extending the schema.
+- Verifier tests protect against a trivial `app/main` that prints hardcoded results while leaving unusable functions.
+- Harness stdout checks still prove the user-facing demonstration required by the product spec.
+
+Guidance recommendation:
+
+- Add task-specific benchmark guidance if live attempts otherwise drift into unsupported graph shapes or non-canonical modules.
+- Guidance should prefer supported operations: `Const`, `Load`, `Compare`, `Branch`, `Call`, `Add`, `Sub`, `Mul`, `Div`, `Modulo`, `Print`, `PrintString`, `StringConcat`, `StringFromI64`, and `Return`.
+- If current graph/control-flow support makes literal iterative Fibonacci unreliable, allow recursive Fibonacci or bounded repeated computation while recording that the representative validation remains behavioral, not static algorithm-shape proof.
+
+Rejected alternatives:
+
+- Do not extend `IntentSpec::TestCase` beyond i64 for #488.
+- Do not introduce a new generic math standard library.
+- Do not add a static algorithm-shape validator for recursion/iteration unless Stage 9 or an approved Ralph cycle explicitly requires it.
+- Do not run Studio as a second provider-backed mutation path.
+
+### 3. Validate CLI Evidence
+
+The CLI leg should:
+
+1. Create a fresh temp workspace.
+2. Write provider config without logging secrets.
+3. Seed Phase 15 learning cache using the task/provider-specific cache path.
+4. Create and execute the canonical Math Library intent.
+5. Inspect graph evidence and/or `describe` output.
+6. Confirm `.duumbi/graph/math/lib.jsonld` exists.
+7. Confirm graph/source evidence contains `factorial`, `fibonacci`, and `is_prime`.
+8. Build through `crate::workflow::build_workspace`.
+9. Run through `crate::workflow::run_workspace`.
+10. Check stdout for all three representative results.
+11. Record pass/fail, elapsed time, generated slug, workspace, build/run evidence, stdout, and failure category.
+
+Recommended evidence keys:
+
+- `module_math_lib_exists=true`
+- `describe_contains_factorial=true`
+- `describe_contains_fibonacci=true`
+- `describe_contains_is_prime=true`
+- `run_exit_code=<n>`
+- `stdout=<truncated output>`
+- `seeded_learning_records=<n>`
+- `harvested_learning_records=<n>`
+
+Failure categories should reuse existing categories where possible:
+
+- `missing_provider_credentials`
+- `provider_timeout`
+- `provider_auth`
+- `provider_rate_limit`
+- `provider_server_error`
+- `provider_or_intent_error`
+- `mutation_failed`
+- `describe_failed`
+- `build_failed`
+- `run_failed`
+- `evidence_mismatch`
+- `docs_mismatch`
+- `studio_ux_failed`
+- `studio_http_failed`
+- `skipped_cli_failed`
+
+Add a new category only if an observed failure cannot be represented without ambiguity.
+
+### 4. Validate Studio Against The Same Workspace
+
+Keep the established shared-backend pattern:
+
+- Start Studio only after the CLI leg passes.
+- Use the CLI-generated workspace as the Studio working directory.
+- Do not spend a second live provider-backed mutation.
+- Use the existing HTTP flow:
+  - GET `/`
+  - GET `/api/graph/context`
+  - POST `/api/build`
+  - POST `/api/run`
+- Require graph modules to include `math/lib`.
+- Require build JSON `ok == true`.
+- Require run stdout to satisfy the Math Library output predicate.
+- Keep the existing UX checks:
+  - footer labels exactly `Intents`, `Graph`, `Build`
+  - Query default active
+  - Query mode exposes read-only title/state
+  - Agent mode is available
+
+If `GET /api/graph/context` continues to return module context through `load_initial_data`, do not redesign the Studio API. This issue validates the shared backend, not a new graph endpoint contract.
+
+### 5. Update Documentation Without Performing #489
+
+Update `docs/testing/phase15-walkthrough.md` with a dedicated #488 section:
+
+- CLI manual path.
+- Studio shared-backend path.
+- Automated harness command:
+
+```bash
+$DUUMBI phase15-e2e math-library \
+  --provider minimax \
+  --attempts 1 \
+  --output /tmp/duumbi-phase15-math-library-report.json
+```
+
+- Pass criteria for `math/lib`, functions, build, run, stdout, Studio module visibility, and UX checks.
+- Missing credential behavior with `missing_provider_credentials`.
+- Provider failure classification guidance.
+- Evidence report path for local validation.
+
+Do not rewrite the document into the final cross-sample protocol. Leave final consolidation, cross-sample comparison, and public-facing completion language to #489.
+
+## Invariants
+
+- Preserve existing `calculator` and `string-utils` behavior, report shape, task ids, output predicates, and walkthrough sections.
+- Keep Query mode read-only by default; mutation remains Agent mode or explicit Intent execution.
+- Do not log raw provider secrets in console output, docs, reports, GitHub comments, or learning records.
+- Missing credentials must produce structured blocked evidence, not a panic or ambiguous failure.
+- Provider failures must stay distinguishable from deterministic code, graph, compiler, Studio, documentation, and evidence defects.
+- Slash-named module paths must remain nested paths on disk: `math/lib` maps to `.duumbi/graph/math/lib.jsonld`.
+- Graph discovery must keep recursively scanning `.duumbi/graph/**/*.jsonld`.
+- `app/main` must call or otherwise depend on functions from `math/lib`; a direct print-only main must not satisfy the sample.
+- Function names are strict for the default pass: `factorial`, `fibonacci`, and `is_prime`. If implementation accepts equivalents, the report must record the mapping and Stage 11 must judge it explicitly.
+- Live provider validation requires explicit Ralph-cycle approval before any paid/API attempt.
+- No implementation cycle may expand into #489 final protocol consolidation, Phase 16, Phase 13, provider model-selection UI, marketing/GTM work, or new general-purpose math stdlib design.
+
+## Ralph Cycle Protocol
+
+Each cycle must:
+
+1. summarize the current state and remaining unmet requirements
+2. propose one bounded implementation goal
+3. list intended file areas and commands
+4. estimate resource use and risk
+5. ask for explicit approval before starting
+6. implement only the approved goal
+7. run the agreed checks
+8. report evidence, failures, and remaining gaps
+9. stop if requirements are met or request approval for the next cycle
+
+No Ralph cycle may start from this technical spec alone. Stage 9 approval and an explicit cycle approval comment are required first.
+
+## Cycle Budget
+
+- Default cycle size: one bounded implementation goal per cycle.
+- Max files or modules per cycle:
+  - Deterministic harness/benchmark cycle: up to 4 source modules plus focused tests.
+  - Documentation cycle: `docs/testing/phase15-walkthrough.md` only, unless evidence forces a small linked correction.
+  - Live validation cycle: no planned source edits; one provider-backed run only.
+- Expected command budget:
+  - Focused implementation cycle: `cargo fmt --check`, `cargo test phase15`, `cargo test benchmarks`, and one or two exact focused tests for touched modules.
+  - Broader readiness cycle: `cargo test --all`, `cargo test -p duumbi-studio --features ssr` if Studio code changed, and `cargo clippy --all-targets -- -D warnings`.
+  - Live validation cycle: `cargo build`, `cargo build -p duumbi-studio --features ssr`, and exactly one approved `phase15-e2e math-library` command.
+- Approval required before every cycle: yes.
+- When to stop and ask for human guidance:
+  - A cycle needs to change implementation code outside the planned file areas.
+  - The work would require broad verifier schema changes, general loop semantics, a new math stdlib, or new Studio navigation.
+  - More than one live provider attempt is needed.
+  - Product requirements conflict, especially strict iterative Fibonacci versus currently practical graph behavior.
+  - The implementation would weaken Query mode safety, provider secret handling, or existing #486/#487 evidence.
+  - #489 final protocol consolidation becomes necessary to make #488 pass.
+
+Recommended initial cycles:
+
+1. Add deterministic Math Library descriptor, output predicate, benchmark normalization, expected functions, guidance as needed, and focused unit tests.
+2. Add or refine coordinator/execute support only if focused tests or local dry inspection prove the benchmark path misses factorial/fibonacci/prime functions or guidance.
+3. Update the Phase 15 walkthrough with the Math Library section and evidence instructions.
+4. Run broader deterministic checks and fix only direct regressions.
+5. Request a separate live-provider validation cycle for exactly one `math-library` attempt.
+
+## Task Breakdown
+
+1. Confirm the issue remains in the correct workflow state and product/technical specs are linked before implementation starts.
+2. Inspect the current `Phase15Task` descriptor model and tests.
+3. Add `math-library` descriptor and output predicate in `src/cli/phase15_e2e.rs`.
+4. Update supported-task help text in `src/cli/mod.rs`.
+5. Add focused harness tests for lookup, unsupported-task messaging, output matching, function evidence, module evidence, and task-specific Ralph Gate wording.
+6. Add Math Library benchmark normalization in `src/intent/benchmarks.rs` with deterministic i64 test cases and expected functions.
+7. Add focused benchmark tests for matching, normalization, deterministic fallback spec, expected functions, and optional guidance.
+8. Inspect whether existing `src/intent/execute.rs` expected-export integration already covers Math Library after benchmark extension. If yes, leave it unchanged.
+9. If implementation changes algorithmic hints, add a focused `src/intent/coordinator.rs` test proving combined factorial/fibonacci/prime prompts get enough guidance.
+10. Update the Phase 15 walkthrough with Math Library CLI, Studio, automated harness, pass criteria, report path, and missing credential behavior.
+11. Run focused deterministic checks.
+12. Run broader readiness checks.
+13. Request and run one live-provider validation cycle only after explicit approval and available credentials.
+14. Open or update the implementation PR only after completion criteria and approved evidence are available.
+
+## Verification Plan
+
+Spec-only Stage 8 validation:
+
+- `git diff --check`
+- no implementation tests required for this technical-spec-only PR
+
+Implementation verification:
+
+- `cargo fmt --check`
+- `cargo test phase15`
+- `cargo test benchmarks`
+- Focused tests for any changed `src/intent/execute.rs` or `src/intent/coordinator.rs` helpers.
+- `cargo test -p duumbi-studio --features ssr` if Studio code or module discovery tests change.
+- `cargo test --all`
+- `cargo clippy --all-targets -- -D warnings`
+
+Live/manual verification after explicit approval:
+
+```bash
+cargo build
+cargo build -p duumbi-studio --features ssr
+$DUUMBI phase15-e2e math-library \
+  --provider minimax \
+  --attempts 1 \
+  --output /tmp/duumbi-phase15-math-library-report.json
+```
+
+Provider may be changed to any configured supported provider if the approving comment names it. Do not switch provider or retry without a new approval.
+
+Live report checks:
+
+- Top-level `task` is `math-library`.
+- CLI leg passes or reports a structured provider/credential class.
+- CLI evidence includes workspace path, generated slug, `module_math_lib_exists=true`, all three `describe_contains_*` keys, build/run evidence, stdout, elapsed time, and failure category when applicable.
+- Studio leg runs only after CLI pass.
+- Studio evidence includes `shared_backend_workspace=true`, `graph_has_math_lib=true`, build output path, run stdout, `ux_footer_items=Intents,Graph,Build`, `ux_query_default_active=true`, `ux_query_read_only=true`, and `ux_agent_mode_available=true`.
+- Output evidence includes `factorial(10)=3628800`, `fibonacci(15)=610`, and `is_prime(97)=true` or `1`.
+- Report distinguishes provider timeout/auth/rate-limit/server errors from compiler, graph validation, verifier, Studio, docs, and evidence mismatches.
+- Walkthrough commands and pass criteria match the implemented behavior.
+
+## Completion Criteria
+
+The implementation is ready for PR review only when all of these are true:
+
+- `phase15-e2e` accepts `math-library` and unsupported-task errors list all supported tasks.
+- Existing `calculator` and `string-utils` tests and behavior remain supported.
+- The harness checks `math/lib`, `factorial`, `fibonacci`, `is_prime`, and all representative output results.
+- Known benchmark handling creates or preserves `math/lib`, `app/main`, canonical expected functions, and i64 verifier test cases for Math Library.
+- `app/main` in the generated workspace calls `math/lib` functions rather than satisfying the sample only with direct hardcoded output.
+- Studio validates the same CLI-generated workspace through shared build/run APIs and graph module evidence.
+- The Phase 15 walkthrough includes Math Library instructions and explicitly leaves #489 final protocol consolidation out of scope.
+- Required deterministic checks pass or every failure is explained with an approved follow-up cycle request.
+- One live-provider run has either passed with CLI and Studio evidence or is blocked by structured missing-credential/provider evidence accepted by the reviewer.
+- No product spec, technical spec approval, generated report, runtime asset, implementation branch policy, or unrelated workflow file was changed outside approved scope.
+
+## Failure And Escalation
+
+- If focused tests fail, report the failing command, first relevant error, suspected cause, and the smallest next approved fix. Do not broaden scope automatically.
+- If `cargo test --all` or clippy exposes unrelated failures, record them separately and ask whether to handle them in this issue or defer.
+- If provider credentials are missing, record `missing_provider_credentials` and the missing environment variable name only. Do not ask the user to paste secrets into chat, docs, issue comments, or reports.
+- If a live provider attempt times out or fails with auth/rate-limit/server errors, stop after the approved attempt and report provider evidence. Do not switch providers or retry without approval.
+- If generated graph output uses semantically equivalent function names instead of strict names, mark the harness result as failed unless an approved cycle explicitly adds report-mapped equivalence handling.
+- If generated output hardcodes only `app/main` output and lacks usable `math/lib` functions, classify as `evidence_mismatch` or verifier failure, not success.
+- If strict iterative Fibonacci becomes a blocker, ask the human whether behavioral Fibonacci evidence is acceptable for #488 or whether to add static algorithm-shape validation at additional cost.
+- If #489 consolidation appears necessary, stop. #489 is a separate issue and must not be folded into #488.
+- If implementation touches provider setup UX, Query/Agent safety, broad Studio navigation, verifier schema, runtime assets, or compiler semantics beyond direct Math Library needs, stop and request a new scoped approval.
+
+## Open Questions
+
+None blocking.
+
+Non-blocking items for Stage 9 or Ralph-cycle approval:
+
+- Whether reviewers want strict static proof of iterative Fibonacci, or whether behavioral `fibonacci(15)=610` plus function/verifier evidence is enough for the Phase 15 sample.
+- Whether a successful live run must use MiniMax for consistency with the walkthrough, or any configured supported provider is acceptable.
+- Whether semantically equivalent generated function names should ever be accepted if the report records a mapping. The default technical recommendation is strict names only.


### PR DESCRIPTION
## Summary

- Adds specs/DUUMBI-488/PRODUCT.md for the accepted Phase 15 Math Library E2E issue.
- Captures product behavior, scope, constraints, decisions, checks, and non-blocking Stage 8 questions.
- Keeps #489 final protocol consolidation, technical spec work, and implementation explicitly out of scope.

## Validation

- git diff --cached --check

Closes no issues. Stage 7 should review the product spec before #488 moves beyond Spec Review.