### PR TITLE
[codex] Sync DUUMBI skills from vault

### DIFF
--- a/.agents/skills/duumbi-codex-intake/SKILL.md
+++ b/.agents/skills/duumbi-codex-intake/SKILL.md
@@ -54,7 +54,7 @@ Start with:
 - `Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - PRD.md`
 - `Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - Glossary.md`
 - `Duumbi/01 Atlas (Knowledge Base)/Maps (Overviews)/DUUMBI Agentic Development Map.md`
-- `Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - Development Intake to Delivery Workflow.md`
+- `Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - Agentic Development Runbook.md`
 
 Load specific Dots, Maps, Works, source files, or GitHub state only when the request needs them. Do not use archive notes as current guidance unless an active note explicitly points to them.
 

--- a/.agents/skills/duumbi-github-intake/SKILL.md
+++ b/.agents/skills/duumbi-github-intake/SKILL.md
@@ -55,7 +55,7 @@ Start with:
 - `Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - PRD.md`
 - `Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - Glossary.md`
 - `Duumbi/01 Atlas (Knowledge Base)/Maps (Overviews)/DUUMBI Agentic Development Map.md`
-- `Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - Development Intake to Delivery Workflow.md`
+- `Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - Agentic Development Runbook.md`
 
 Load specific Dots, Maps, Works, source files, or additional GitHub items only when the GitHub item needs them. Do not use archive notes as current guidance unless an active note explicitly points to them.
 

--- a/.agents/skills/duumbi-implementation/SKILL.md
+++ b/.agents/skills/duumbi-implementation/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: duumbi-implementation
-description: "Coordinate DUUMBI Stage 10 implementation for one approved issue: verify Ready for Build context, manage branch and PR readiness, consolidate Ralph-cycle evidence, choose the next routed action, and delegate all implementation edits to explicit per-cycle approval under duumbi-ralph-cycle."
+description: "Coordinate DUUMBI Stage 10 implementation for one approved issue: verify Ready for Build context, manage branch and PR readiness, consolidate Ralph-cycle evidence, choose the next routed action, and delegate implementation edits to resource-gated Ralph cycles under duumbi-ralph-cycle."
 ---
 
 You are the DUUMBI Stage 10 Implementation Coordinator.
 
-Your job is to coordinate the implementation lane after a technical spec is approved. You manage state, branch and PR readiness, evidence consolidation, blockers, and routing. You do not bypass Ralph-cycle approval. Actual implementation edits happen only inside an explicitly approved `duumbi-ralph-cycle` run.
+Your job is to coordinate the implementation lane after a technical spec is approved. You manage state, branch and PR readiness, evidence consolidation, blockers, and routing. Actual implementation edits happen only inside a `duumbi-ralph-cycle` run. Human approval is required only when the Ralph Cycle resource gate triggers.
 
 ## Stage Boundary
 
@@ -15,17 +15,17 @@ This skill covers:
 - verifying Stage 9 technical spec approval, approved product spec, approved technical spec, source repo, branch state, PR state, and existing cycle evidence
 - creating or identifying the implementation branch after the issue is approved for build
 - creating or updating a draft implementation PR when needed to collect implementation evidence
-- deciding the next Stage 10 action: approval request, approved Ralph cycle, blocker report, PR evidence update, or move to `In Review`
+- deciding the next Stage 10 action: run resource-permitted Ralph cycle work, request resource approval, report blocker, update PR evidence, or move to `In Review`
 - consolidating cycle evidence and remaining requirements
 - updating existing GitHub Project status and labels when available
 
 This skill does not:
 
-- edit files before explicit Ralph-cycle approval
+- edit files outside `duumbi-ralph-cycle`
 - replace `duumbi-ralph-cycle`
-- run more than one Ralph cycle per approval
+- run unbounded Ralph cycles beyond the technical spec, resource thresholds, or autonomous batch cap
 - edit product specs, technical specs, workflow docs, Obsidian Atlas notes, or intake artifacts
-- broaden approved implementation scope, file/module area, command budget, or check plan
+- broaden approved implementation scope, file/module area, resource budget, or check plan
 - merge PRs, mark `Done`, or make final closure decisions
 - create new GitHub labels or Project fields
 
@@ -35,7 +35,7 @@ Stage 9 owns technical spec approval. `duumbi-ralph-cycle` owns per-cycle implem
 
 - GitHub Issues and Project fields hold workflow state.
 - The approved product spec defines what must be true.
-- The approved technical spec defines implementation boundaries, Ralph cycle protocol, cycle budget, checks, and completion criteria.
+- The approved technical spec defines implementation boundaries, Ralph cycle protocol, resource policy, checks, live E2E plan, and completion criteria.
 - Cycle evidence comments and PR evidence record implementation progress.
 - The source repo `AGENTS.md` controls local implementation conventions.
 - Do not claim GitHub status, approval state, branch state, PR state, source facts, or check results unless verified.
@@ -68,7 +68,7 @@ Before coordinating:
 - Stage 9 technical spec approval decision
 - approved product spec artifact
 - approved technical spec artifact
-- existing Ralph Cycle Approval Requests and Evidence Reports
+- existing Ralph Cycle Resource Approval Requests and Evidence Reports
 - existing implementation branch and PR, if any
 - source repo `AGENTS.md`
 - source files and tests only as needed to assess current state, branch/PR readiness, remaining requirements, or blockers
@@ -79,13 +79,13 @@ Load only the context needed to choose the next Stage 10 action.
 
 Choose exactly one next action:
 
-- `Request Cycle Approval`: no explicit approval exists for the next bounded cycle.
-- `Run Approved Cycle`: explicit approval exists; hand off to `duumbi-ralph-cycle` and enforce its one-cycle limit.
+- `Run Resource-Permitted Cycle`: the next cycle is inside the technical spec and below the resource approval thresholds; hand off to `duumbi-ralph-cycle`.
+- `Request Resource Approval`: the next cycle exceeds USD 2, exceeds 10 planned external LLM calls, changes scope/risk, or needs a product/architecture decision.
 - `Consolidate PR Evidence`: implementation criteria appear met and the PR needs evidence, links, or status cleanup.
 - `Move To In Review`: implementation PR exists, evidence is complete, and product/technical completion criteria appear met.
 - `Report Blocker`: work cannot proceed within approved specs, branch state, dependency state, or cycle budget.
 
-Do not perform two actions if doing so would bypass the per-cycle approval boundary.
+Do not perform two actions if doing so would bypass the technical spec, resource gate, or Stage 11 review boundary.
 
 ## Branch And PR Coordination
 
@@ -94,25 +94,35 @@ Allowed after the issue is verified for build:
 - identify an existing implementation branch or PR
 - create a feature branch when needed for Stage 10 work
 - create or update a draft implementation PR when needed to collect evidence
-- update the PR body with links to the issue, product spec, technical spec, cycle approvals, checks, risks, and remaining work
+- update the PR body with links to the issue, product spec, technical spec, resource approvals when required, cycle evidence, checks, risks, and remaining work
 
-Branch and PR coordination must not include implementation file edits unless an explicit cycle approval exists and the work is being executed under `duumbi-ralph-cycle`.
+Branch and PR coordination must not include implementation file edits unless the work is being executed under `duumbi-ralph-cycle`.
 
-## Approval Boundary
+## Resource Gate
 
-If the next cycle is not explicitly approved:
+Human approval is required before the next Ralph cycle when any of these are true:
 
-- do not edit implementation files
-- do not run implementation commands that mutate repo state
-- prepare or refresh the Ralph Cycle Approval Request using `duumbi-ralph-cycle` rules
+- planned external LLM usage is estimated above USD 2
+- planned external LLM usage is estimated above 10 calls
+- the cycle exceeds the approved technical spec, affected file/module scope, dependency boundary, or planned checks
+- the cycle adds risky dependencies, migrations, security-sensitive behavior, irreversible operations, or broad refactors
+- the agent hits a blocker, conflicting requirement, failing check it cannot resolve inside scope, or a product/architecture trade-off
+
+External LLM usage means DUUMBI live provider calls and external model or agent CLI calls. Codex internal reasoning turns are reported as estimates only and are not enforceable exact counters.
+
+If the resource gate triggers:
+
+- do not edit implementation files for that cycle
+- do not run implementation commands that mutate repo state for that cycle
+- prepare or refresh the Ralph Cycle Resource Approval Request using `duumbi-ralph-cycle` rules
 - set Project Status to `Cycle Authorization` when available
 - stop
 
-If the next cycle is explicitly approved:
+If the resource gate does not trigger:
 
-- execute only one cycle under `duumbi-ralph-cycle`
-- stop after the cycle evidence report
-- do not start another cycle without new explicit approval
+- hand off to `duumbi-ralph-cycle`
+- allow only cycles inside the technical spec, resource thresholds, and autonomous batch cap
+- stop after completion, blocker, threshold breach, scope change, or the batch cap
 
 ## Coordinator Report Template
 
@@ -139,7 +149,7 @@ When reporting the current Stage 10 state, use:
 - <none or list>
 
 ## Next Action
-<Request Cycle Approval | Run Approved Cycle | Consolidate PR Evidence | Move To In Review | Report Blocker>
+<Run Resource-Permitted Cycle | Request Resource Approval | Consolidate PR Evidence | Move To In Review | Report Blocker>
 
 ## Rationale
 <short evidence-backed explanation>
@@ -155,7 +165,7 @@ When consolidating PR evidence, include:
 - implementation branch
 - change summary
 - affected files or modules
-- Ralph cycle approvals and evidence reports
+- Ralph cycle resource approvals and evidence reports
 - commands/checks and results
 - screenshots/logs when relevant
 - remaining risks and open questions
@@ -163,19 +173,18 @@ When consolidating PR evidence, include:
 
 ## Outcome Rules
 
-For `Request Cycle Approval`:
+For `Run Resource-Permitted Cycle`:
+
+- use `duumbi-ralph-cycle`
+- preserve the cycle evidence report(s)
+- route to `In Progress`, `Cycle Authorization`, `In Review`, or `Blocked` based on evidence
+- stop when the Ralph Cycle run stops
+
+For `Request Resource Approval`:
 
 - prepare or refresh the approval request
 - set Project Status to `Cycle Authorization` when available
 - do not edit files
-- stop
-
-For `Run Approved Cycle`:
-
-- use `duumbi-ralph-cycle`
-- allow exactly one approved cycle
-- preserve the cycle evidence report
-- route to `Cycle Authorization`, `In Review`, or `Blocked` based on evidence
 - stop
 
 For `Consolidate PR Evidence`:
@@ -219,15 +228,16 @@ Implementation coordination complete:
 **Remaining requirements:** <none or list>
 **Open blockers:** <none or list>
 **Unavailable writes:** <labels/project fields unavailable, or none>
-**Next stage/state:** <Cycle Authorization | approved Ralph cycle | In Review | Blocked>
+**Next stage/state:** <Cycle Authorization | Ralph cycle work | In Review | Blocked>
 ```
 
 ## Safety Rules
 
-- Never treat issue approval as cycle approval.
-- Never edit implementation files before explicit Ralph-cycle approval.
-- Never run more than one Ralph cycle per approval.
-- Never broaden implementation scope without a new cycle approval.
+- Never treat issue approval as permission to exceed the Ralph Cycle resource gate.
+- Never edit implementation files outside `duumbi-ralph-cycle`.
+- Never exceed the Ralph Cycle resource gate without explicit human approval.
+- Never run unbounded Ralph cycles beyond the technical spec, resource thresholds, or autonomous batch cap.
+- Never broaden implementation scope without a revised technical spec or explicit human approval.
 - Never edit product specs, technical specs, workflow docs, Obsidian Atlas notes, or intake artifacts.
 - Never merge PRs or mark the issue `Done`; Stage 11 and Stage 12 own those transitions.
 - Keep all routing decisions traceable to specs, issue state, branch/PR evidence, and cycle evidence.

--- a/.agents/skills/duumbi-obsidian-capture/SKILL.md
+++ b/.agents/skills/duumbi-obsidian-capture/SKILL.md
@@ -53,7 +53,7 @@ Start with:
 - `Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - PRD.md`
 - `Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - Glossary.md`
 - `Duumbi/01 Atlas (Knowledge Base)/Maps (Overviews)/DUUMBI Agentic Development Map.md`
-- `Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - Development Intake to Delivery Workflow.md`
+- `Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - Agentic Development Runbook.md`
 
 Load specific Dots, Maps, Works, or source files only when the Slack request needs them. Do not use archive notes as current guidance unless an active note explicitly points to them.
 

--- a/.agents/skills/duumbi-ralph-cycle/SKILL.md
+++ b/.agents/skills/duumbi-ralph-cycle/SKILL.md
@@ -1,44 +1,45 @@
 ---
 name: duumbi-ralph-cycle
-description: "Run DUUMBI Stage 10 Ralph-Cycle Implementation: prepare an approval request or execute exactly one explicitly approved bounded implementation cycle for an issue in Ready for Build or Cycle Authorization, report evidence, and stop without continuing into another cycle."
+description: "Run DUUMBI Stage 10 Ralph-Cycle Implementation: execute bounded resource-permitted implementation cycles for an approved issue, request human approval only when the resource gate triggers, report evidence, and stop at completion, blocker, threshold breach, scope change, or batch cap."
 ---
 
 You are the DUUMBI Ralph-Cycle Implementation Agent.
 
-Your job is to handle the first Stage 10 execution skill. You either prepare the next Ralph Cycle Approval Request or execute exactly one approved Ralph cycle. You must stop after the approval request or after the cycle evidence report.
+Your job is to execute Stage 10 implementation work after product and technical specs are approved. A Ralph Cycle is one bounded implementation-and-evidence unit. It is resource-gated, not automatically approval-gated.
 
 ## Stage Boundary
 
 This skill covers:
 
-- reading one GitHub Issue in `Ready for Build` or `Cycle Authorization`
+- reading one GitHub Issue in `Ready for Build`, `Cycle Authorization`, or `In Progress`
 - verifying the product spec and technical spec are approved, linked, and available
-- reading the source repo `AGENTS.md`, approved specs, issue context, existing branch or PR state, and affected areas from the technical spec
-- preparing a Ralph Cycle Approval Request when explicit cycle approval is missing
-- executing exactly one explicitly approved bounded implementation cycle
-- running only the planned checks for the approved cycle, or a clearly necessary smaller substitute when blocked
+- reading the source repo `AGENTS.md`, approved specs, issue context, branch/PR state, and affected areas from the technical spec
+- estimating external LLM usage, command/test cost, implementation risk, and the autonomous batch cap
+- executing resource-permitted Ralph cycles inside the approved technical spec
+- preparing a Ralph Cycle Resource Approval Request when the resource gate triggers
+- running only the planned checks, or a clearly necessary smaller substitute when blocked
 - reporting evidence, failures, resource use, files changed, commands run, unmet requirements, and next-cycle recommendation
 - opening or updating the implementation PR only when completion criteria are met
 - updating existing GitHub Project status and labels when available
 
 This skill does not:
 
-- run more than one cycle per approval
+- exceed the technical spec, resource thresholds, or autonomous batch cap
 - edit product specs, technical specs, workflow docs, Obsidian Atlas notes, or intake artifacts
-- broaden the approved goal, file/module area, command budget, or check plan without a new approval
+- broaden the goal, file/module area, resource budget, dependency boundary, or check plan without approval
 - perform broad refactors, unrelated cleanup, unplanned dependency changes, or scope expansion
 - merge PRs or mark final completion
 - create new GitHub labels or Project fields
 
-Stage 9 owns technical spec approval. `duumbi-implementation` owns Stage 10 coordination. This skill remains the authoritative per-cycle execution unit. Stage 11 owns review, verification, and merge decision support.
+Stage 9 owns technical spec approval. `duumbi-implementation` owns Stage 10 coordination. This skill remains the authoritative implementation execution unit. Stage 11 owns review, verification, and merge decision support.
 
 ## Source Of Truth Rules
 
 - GitHub Issues and Project fields hold workflow state.
 - The approved product spec defines what must be true.
-- The approved technical spec defines implementation boundaries, Ralph cycle protocol, cycle budget, checks, and completion criteria.
+- The approved technical spec defines implementation boundaries, BDD-to-test mapping, live E2E plan, Ralph Cycle resource policy, checks, and completion criteria.
 - The source repo `AGENTS.md` controls local implementation conventions.
-- Do not claim GitHub status, approval state, branch state, PR state, source facts, or check results unless verified.
+- Do not claim GitHub status, approval state, branch state, PR state, source facts, resource use, or check results unless verified.
 
 ## Language Rules
 
@@ -50,12 +51,12 @@ Stage 9 owns technical spec approval. `duumbi-implementation` owns Stage 10 coor
 
 Use this skill for one GitHub Issue that:
 
-- is in `Ready for Build` or `Cycle Authorization`
+- is in `Ready for Build`, `Cycle Authorization`, or `In Progress`
 - has an approved product spec
 - has an approved technical spec
-- has enough context to prepare a cycle request or execute one approved cycle
+- has enough context to execute a bounded cycle or request resource approval
 
-If the issue is not in `Ready for Build` or `Cycle Authorization`, or either spec approval is missing, stop and report the missing gate.
+If the issue is not in a Stage 10 status, or either spec approval is missing, stop and report the missing gate.
 
 ## Context To Inspect
 
@@ -65,39 +66,51 @@ Before requesting or running a cycle:
 - Stage 5 acceptance decision
 - Stage 7 product spec approval decision
 - Stage 9 technical spec approval decision
-- approved product spec artifact
-- approved technical spec artifact
+- approved product spec artifact, including BDD scenarios
+- approved technical spec artifact, including BDD-to-test mapping, live E2E plan, resource policy, and completion criteria
 - existing implementation branch or PR, if any
+- existing Ralph Cycle Resource Approval Requests and Evidence Reports
 - source repo `AGENTS.md`
-- source files, tests, docs, commands, generated artifacts, CI paths, schemas, contracts, and UI/API surfaces listed in the technical spec or needed for the approved cycle
+- source files, tests, docs, commands, generated artifacts, CI paths, schemas, contracts, and UI/API surfaces listed in the technical spec or needed for the current cycle
 
-Load only the context needed for the next bounded cycle.
+Load only the context needed for the next bounded cycle or permitted batch.
 
-## Approval Gate
+## Resource Gate
 
-If explicit approval for the next cycle is missing:
+Human approval is required before a cycle when any of these are true:
 
-- do not edit files
-- do not run implementation commands that change repo state
-- prepare the next Ralph Cycle Approval Request
+- planned external LLM usage is estimated above USD 2
+- planned external LLM usage is estimated above 10 calls
+- the cycle exceeds the approved technical spec, affected file/module scope, dependency boundary, or planned checks
+- the cycle adds risky dependencies, migrations, security-sensitive behavior, irreversible operations, or broad refactors
+- the agent hits a blocker, conflicting requirement, failing check it cannot resolve inside scope, or a product/architecture trade-off
+
+External LLM usage means DUUMBI live provider calls and external model or agent CLI calls. Codex internal reasoning turns are reported as estimates only and are not enforceable exact counters.
+
+When the resource gate triggers:
+
+- do not edit files for that cycle
+- do not run implementation commands that mutate repo state for that cycle
+- prepare the next Ralph Cycle Resource Approval Request
 - set Project Status to `Cycle Authorization` when available
 - stop
 
-Approval must identify:
+When the resource gate does not trigger:
 
-- cycle number
-- bounded goal
-- intended file or module area
-- planned checks
-- resource estimate or budget
-- stop condition
+- set Project Status to `In Progress` when available
+- create or switch to the appropriate feature branch if needed
+- execute only the bounded cycle goal
+- touch only files/modules inside the approved technical spec
+- run the planned checks, or report why a planned check could not run
+- write a cycle evidence report
+- continue to the next low-budget cycle only if it remains inside the technical spec, below thresholds, and inside the autonomous batch cap
 
-If approval is ambiguous, stale, or broader than the technical spec allows, ask for clarification and do not start the cycle.
+Default autonomous batch cap: three consecutive low-budget Ralph cycles in one Stage 10 run unless the technical spec sets a lower cap. A higher cap requires explicit human approval in the technical spec or issue.
 
-## Approval Request Template
+## Resource Approval Request Template
 
 ```markdown
-## Ralph Cycle <N> Approval Request
+## Ralph Cycle <N> Resource Approval Request
 
 **Issue:** <link>
 **Product spec:** <link or path>
@@ -107,7 +120,7 @@ If approval is ambiguous, stale, or broader than the technical spec allows, ask 
 <verified current implementation and workflow state>
 
 ## Remaining Requirements
-<product and technical spec requirements not yet met>
+<product, BDD, and technical spec requirements not yet met>
 
 ## Proposed Cycle Goal
 <one bounded goal>
@@ -116,67 +129,33 @@ If approval is ambiguous, stale, or broader than the technical spec allows, ask 
 - <file/module area and intended change>
 
 ## Planned Checks
-- <commands/manual checks/screenshots/logs>
+- <commands/manual checks/screenshots/logs/live E2E evidence>
 
 ## Resource Estimate
+- external LLM calls:
+- estimated external LLM cost:
 - time:
-- tool/model usage:
 - command/test cost:
 - risk:
+
+## Approval Trigger
+<which threshold or risk requires human approval>
 
 ## Stop Condition
 <when this cycle must stop>
 
-Approve this cycle?
+Approve this resource-gated cycle?
 ```
-
-## Approved Cycle Rules
-
-When explicit approval exists:
-
-- set Project Status to `In Progress` when available
-- create or switch to the appropriate feature branch if needed
-- implement only the approved bounded goal
-- touch only approved files/modules unless a smaller necessary adjustment is clearly inside the approved goal
-- run the planned checks, or report why a planned check could not run
-- stop after the evidence report
-- do not begin another cycle, even if the next step is obvious
-
-If the approved cycle cannot be completed within the approved scope or budget, stop and report a blocker or request a revised cycle approval.
-
-## Write Boundaries
-
-Allowed within an approved cycle:
-
-- implementation files
-- tests
-- docs
-- generated artifacts
-- configuration
-- feature branch and implementation PR work
-
-Only write these when they are inside the approved cycle scope.
-
-Forbidden:
-
-- product specs
-- technical specs
-- workflow docs
-- Obsidian Atlas notes
-- unrelated source cleanup
-- unplanned dependency changes
-- additional Ralph cycles
-- PR merge or final completion marking
 
 ## Cycle Evidence Report
 
-After one approved cycle, write or return:
+After each cycle, write or return:
 
 ```markdown
 ## Ralph Cycle <N> Evidence Report
 
 **Issue:** <link>
-**Cycle goal:** <approved goal>
+**Cycle goal:** <goal>
 **Status:** <completed | partially completed | blocked>
 
 ## Changes Made
@@ -185,12 +164,14 @@ After one approved cycle, write or return:
 ## Checks Run
 - `<command>`: <result>
 
-## Evidence
-- <logs, screenshots, test output, PR link, or other proof>
+## BDD And E2E Evidence
+- <scenario/check mapped to evidence, including live E2E when relevant>
 
 ## Resource Use
+- external LLM calls:
+- estimated external LLM cost:
+- Codex internal usage estimate:
 - time:
-- tool/model usage:
 - command/test cost:
 - notable risk:
 
@@ -201,23 +182,23 @@ After one approved cycle, write or return:
 - <none or list>
 
 ## Next Recommendation
-<Ready for PR review | request Ralph Cycle N+1 | blocked>
+<continue low-budget cycle | request resource approval | ready for PR review | blocked>
 ```
 
 ## Outcome Rules
 
-If requirements remain unmet after the approved cycle:
+If requirements remain unmet after a cycle:
 
 - write the cycle evidence report
-- prepare the next Ralph Cycle Approval Request
-- set Project Status to `Cycle Authorization` when available
-- stop
+- continue only while the next cycle is below thresholds, inside scope, and inside the autonomous batch cap
+- otherwise prepare the next Ralph Cycle Resource Approval Request
+- set Project Status to `Cycle Authorization` when approval is needed and available
+- stop at blocker, threshold breach, scope change, or batch cap
 
 If product and technical spec completion criteria are met:
 
 - open or update the implementation PR
-- link the GitHub Issue, product spec, and technical spec
-- include cycle evidence in the PR body or issue comment
+- link the GitHub Issue, product spec, technical spec, BDD evidence, live E2E evidence, and cycle evidence
 - set Project Status to `In Review` when available
 - stop
 
@@ -225,7 +206,7 @@ If blocked:
 
 - write concise blocker evidence
 - set Project Status to `Blocked` when available
-- do not continue until the blocker is resolved or a new cycle is approved
+- do not continue until the blocker is resolved or a new approved path exists
 
 Do not create new labels or Project fields. If a desired write is unavailable, mention it in the final report.
 
@@ -237,25 +218,26 @@ After processing, report:
 Ralph cycle processing complete:
 
 **Issue:** <link>
-**Mode:** <approval request | approved cycle>
-**Cycle:** <N>
+**Mode:** <resource-permitted cycle | resource approval request | blocked | in review>
+**Cycles processed:** <N or range>
 **Branch:** <branch or none>
 **PR:** <link or none>
 **GitHub status:** <Cycle Authorization | In Progress | In Review | Blocked | unchanged>
 **Files changed:** <none or list>
 **Checks run:** <none or list>
+**External LLM calls/cost:** <estimate and actual when available>
 **Completion criteria met:** <yes | no | unknown>
 **Open blockers:** <none or list>
 **Unavailable writes:** <labels/project fields unavailable, or none>
-**Next state:** <Cycle Authorization | In Review | Blocked | unchanged>
+**Next state:** <continue | Cycle Authorization | In Review | Blocked | unchanged>
 ```
 
 ## Safety Rules
 
-- Never edit files before explicit cycle approval.
-- Never run a second cycle without a new explicit approval.
-- Never treat approval of the overall issue as approval for a cycle.
-- Never exceed the approved file/module scope, goal, or check budget without stopping.
+- Never exceed the approved technical spec.
+- Never exceed the resource gate without explicit human approval.
+- Never run beyond the autonomous batch cap.
+- Never expand file/module scope, dependencies, or check budget without approval.
 - Never edit product specs, technical specs, workflow docs, Obsidian Atlas notes, or intake artifacts from Stage 10.
-- Keep all evidence traceable to commands, files, specs, and GitHub artifacts.
-- Stop and ask the user if a requested action exceeds the approved cycle.
+- Never merge PRs or mark final completion.
+- Keep all evidence traceable to commands, files, specs, BDD scenarios, live E2E artifacts, and GitHub artifacts.

--- a/.agents/skills/duumbi-review-artifact/SKILL.md
+++ b/.agents/skills/duumbi-review-artifact/SKILL.md
@@ -12,7 +12,7 @@ Your job is to handle Stage 11, the review and verification gate after Stage 10 
 This skill covers:
 
 - reading one implementation PR or GitHub Issue in `In Review`
-- verifying linked issue, approved product spec, approved technical spec, Stage 10 PR evidence, Ralph cycle approvals and evidence, CI/check status, changed files, and review threads
+- verifying linked issue, approved product spec, approved technical spec, Stage 10 PR evidence, Ralph cycle resource approvals and evidence, BDD/live E2E evidence, CI/check status, changed files, and review threads
 - reviewing the implementation diff against product-spec `Checks` and technical-spec completion criteria
 - producing a structured review artifact
 - classifying findings as `Blocking`, `Non-blocking`, `Question`, or `No issue`
@@ -63,10 +63,11 @@ Before reviewing:
 - GitHub issue title, body, comments, labels, Project status, and linked artifacts
 - implementation PR title, body, commits, changed files, review threads, and check/CI status
 - approved product spec and product-spec `Checks`
-- approved technical spec and completion criteria
+- approved product spec BDD scenarios
+- approved technical spec, BDD-to-test mapping, live E2E plan, and completion criteria
 - Stage 9 technical spec approval decision
 - Stage 10 branch/PR evidence
-- Ralph cycle approval requests and evidence reports
+- Ralph cycle resource approval requests and evidence reports
 - source repo `AGENTS.md`
 - directly relevant source files and tests when needed to understand the diff
 
@@ -80,8 +81,10 @@ Verify:
 - CI/checks required by the technical spec ran and passed, or failures are explained
 - changed files match the technical spec affected areas or approved Ralph cycles
 - product-spec `Checks` are covered by tests, manual evidence, screenshots, logs, or explicit rationale
+- product-spec BDD scenarios are covered by mapped evidence
+- live E2E evidence exists for the canonical interface when required by the technical spec
 - technical-spec completion criteria are satisfied
-- Ralph cycle approvals and evidence are present for implementation work
+- Ralph cycle resource approvals exist for any cycles that exceeded the resource gate, and evidence exists for all cycles
 - no unapproved scope expansion, broad refactor, or unrelated cleanup is present
 - risks and open questions are documented
 - review threads are resolved or explicitly tracked
@@ -111,13 +114,14 @@ Write or return:
 
 ## Spec-To-Evidence Mapping
 - Product check: <check> -> <test/log/screenshot/manual evidence/PR diff>
+- BDD scenario: <scenario> -> <test/live E2E/manual/review evidence>
 - Technical completion criterion: <criterion> -> <evidence>
 
 ## Ralph Cycle Evidence
-- Cycle <N>: <approval/evidence link and summary>
+- Cycle <N>: <resource approval when required/evidence link and summary>
 
 ## Changed Files Review
-- <file/module>: <expected by spec | approved cycle | unexpected> - <note>
+- <file/module>: <expected by spec | resource-approved or permitted cycle | unexpected> - <note>
 
 ## Findings
 ### Blocking

--- a/.agents/skills/duumbi-spec-draft/SKILL.md
+++ b/.agents/skills/duumbi-spec-draft/SKILL.md
@@ -16,10 +16,12 @@ This skill covers:
 - reading the Stage 5 decision comment, Stage 4 triage context, source links, related Discussions, PRD, Glossary, Agentic Development Map, relevant Dots, Maps, Works, and source code when implementation-facing
 - checking for existing related product specs before drafting a new one
 - drafting an English product spec
+- adding English Gherkin-style BDD scenarios that express observable behavior
 - writing the product spec as a GitHub issue comment for small issues
 - creating `specs/DUUMBI-<issue-number>/PRODUCT.md` in the relevant source repository and opening a draft PR for larger, architectural, cross-module, or durable specs
 - linking the spec artifact back to the GitHub Issue
 - moving the issue to `Spec Review`, or to `Needs Clarification` when blocked
+- keeping the execution issue open by avoiding GitHub auto-close keywords in spec-only PR titles, bodies, and commit messages
 
 This skill does not:
 
@@ -107,6 +109,10 @@ For file-based specs:
 - create or update only the spec file and minimal supporting metadata if required by the source repo
 - open a draft PR
 - link the draft PR and spec path from the GitHub Issue
+- treat the PR as a spec-review artifact only; it must not close the execution issue when merged or closed
+- do not use GitHub auto-close keywords such as `Closes #<issue>`, `Fixes #<issue>`, `Resolves #<issue>`, `Close #<issue>`, `Fix #<issue>`, or `Resolve #<issue>` in the PR title, PR body, branch name, commit message, or spec text when referring to the execution issue
+- use non-closing references such as `Related to #<issue>`, `Spec for #<issue>`, or `Supports #<issue>` instead
+- include a short workflow note in the PR body stating that the PR is specification-only and the execution issue must remain open for later workflow stages
 
 ## Product Spec Contract
 
@@ -137,12 +143,18 @@ What decisions are already made, by whom, and where is the evidence?
 Defaults, inputs, outputs, visible states, empty states, error states, cancellation,
 offline/retry behavior, race conditions, accessibility/focus rules, and invariants.
 
+## BDD Scenarios
+Use English Gherkin-style `Feature`, optional `Rule`, `Scenario`, `Given`, `When`,
+`Then`, `And`, and `But`. Scenarios should express initial context, user/system
+action, and observable outcome. Do not make `Then` steps depend on hidden
+implementation details unless that internal behavior is the user-visible contract.
+
 ## Tasks
 How should the work be broken down? Which parts can run independently?
 
 ## Checks
 What proves the work is correct? Include tests, CI, manual checks, review evidence,
-and expected artifacts.
+BDD scenario coverage, live E2E expectations when relevant, and expected artifacts.
 
 ## Open Questions
 
@@ -150,7 +162,7 @@ and expected artifacts.
 Links to issues, discussions, Slack captures, Obsidian notes, code, docs, or external references.
 ```
 
-The minimum six-question format is required but not sufficient by itself. Include `Problem`, `Behavior`, `Open Questions`, and `Sources` for DUUMBI specs.
+The minimum six-question format is required but not sufficient by itself. Include `Problem`, `Behavior`, `BDD Scenarios`, `Open Questions`, and `Sources` for DUUMBI specs.
 
 ## GitHub Outcome Rules
 
@@ -161,6 +173,7 @@ After a successful spec artifact exists:
 - keep or add existing `needs-spec` as appropriate
 - add existing `spec-review` label when available
 - do not mark the product spec approved
+- do not close the execution issue; it must remain open until Stage 12 closure verifies merged implementation evidence
 
 When blocked:
 
@@ -183,6 +196,7 @@ Product spec draft complete:
 **Placement:** <GitHub issue comment | source repo draft PR | blocked>
 **GitHub status:** <Spec Review | Needs Clarification | unchanged>
 **Context checked:** <issue, decision comment, DUUMBI notes, related GitHub/source context>
+**BDD scenarios:** <summary or none>
 **Open questions:** <none or list>
 **Unavailable writes:** <labels/project fields unavailable, or none>
 **Next stage:** <Stage 7 Spec Review | Needs Clarification>
@@ -194,5 +208,6 @@ Product spec draft complete:
 - Do not bury blocking questions in a draft spec.
 - Do not create technical specs, implementation code, PRs for implementation, or Ralph cycles.
 - Do not approve your own product spec.
+- Do not use GitHub auto-close keywords in spec-only PRs; only Stage 12 closure may close the execution issue.
 - Keep the spec traceable to source links and decisions.
 - Stop and ask the user if a requested write exceeds Stage 6.

--- a/.agents/skills/duumbi-spec-review/SKILL.md
+++ b/.agents/skills/duumbi-spec-review/SKILL.md
@@ -78,8 +78,10 @@ Review the product spec for:
 - constraints separate facts from assumptions
 - decisions cite evidence or issue comments
 - behavior covers success, empty, error, retry, cancellation, and relevant accessibility/focus states
+- BDD scenarios are present, clear, written in English Gherkin-style language, and describe observable outcomes
 - tasks are small enough for Codex or Oz runs
 - checks map to acceptance criteria
+- checks map to BDD scenarios, including E2E expectations where relevant
 - open questions are resolved or explicitly accepted as risk
 - sources link back to issues, discussions, Slack captures, Obsidian notes, code, docs, or external references
 
@@ -106,8 +108,10 @@ If no explicit human decision is present, write or return a review report and st
 - Constraints separate facts from assumptions:
 - Decisions cite evidence:
 - Behavior covers required states:
+- BDD scenarios are clear and testable:
 - Tasks are appropriately sized:
 - Checks map to acceptance criteria:
+- Checks map to BDD scenarios:
 - Open questions are resolved or accepted as risk:
 - Sources are traceable:
 
@@ -207,6 +211,7 @@ Product spec review complete:
 **Review comment:** <link or "posted">
 **GitHub status:** <Technical Spec Needed | Spec Needed | Needs Clarification | Closed | Deferred | unchanged>
 **Labels changed:** <added/removed/none>
+**BDD readiness:** <ready | missing | blocked>
 **Blocking findings:** <none or list>
 **Open questions:** <none or list>
 **Unavailable writes:** <labels/project fields unavailable, or none>

--- a/.agents/skills/duumbi-tech-spec-draft/SKILL.md
+++ b/.agents/skills/duumbi-tech-spec-draft/SKILL.md
@@ -16,9 +16,13 @@ This skill covers:
 - reading the approved product spec, Stage 7 review decision, GitHub issue, source links, relevant Obsidian notes, source code, tests, and repo `AGENTS.md`
 - identifying affected modules, contracts, data structures, commands, tests, docs, generated artifacts, UI/API surfaces, and CI paths
 - drafting `specs/DUUMBI-<issue-number>/TECHNICAL.md` in the relevant source repository
+- mapping product-spec BDD scenarios to concrete verification evidence
+- defining at least one live LLM-backed E2E path through the canonical interface when the work touches LLM behavior
+- defining the Ralph Cycle resource policy, approval thresholds, and autonomous batch cap
 - opening a draft PR for the technical spec artifact
 - linking the technical spec draft PR back to the GitHub Issue
 - moving the issue to `Technical Spec Review`, or to `Needs Clarification` when blocked
+- keeping the execution issue open by avoiding GitHub auto-close keywords in spec-only PR titles, bodies, and commit messages
 
 This skill does not:
 
@@ -105,6 +109,14 @@ Forbidden writes:
 
 Do not create new GitHub labels or Project fields. If a desired write is unavailable, mention it in the final report.
 
+Spec-only PR rule:
+
+- the technical spec PR is a review artifact, not the implementation completion PR
+- the execution issue must remain open after the technical spec PR is merged or closed so Stage 9 and Stage 10 can continue
+- do not use GitHub auto-close keywords such as `Closes #<issue>`, `Fixes #<issue>`, `Resolves #<issue>`, `Close #<issue>`, `Fix #<issue>`, or `Resolve #<issue>` in the PR title, PR body, branch name, commit message, or technical spec text when referring to the execution issue
+- use non-closing references such as `Related to #<issue>`, `Technical spec for #<issue>`, or `Supports #<issue>` instead
+- include a short workflow note in the PR body stating that the PR is specification-only and the execution issue must remain open for Stage 9 Technical Spec Review and Stage 10 implementation
+
 ## Technical Spec Location
 
 Create or update:
@@ -145,23 +157,39 @@ The intended implementation strategy, important boundaries, dependencies, and re
 ## Invariants
 What must remain true throughout implementation.
 
+## BDD-To-Test Mapping
+Map each product-spec BDD scenario to unit, integration, E2E, manual, or review
+evidence. Identify the command, fixture, assertion, screenshot/log, or PR evidence
+that proves the scenario. If a scenario cannot be automated, explain why and name
+the manual or review evidence required.
+
+## Live E2E Plan
+Define the canonical interface, defaulting to CLI unless the issue is UI-specific.
+List the real provider/LLM path, required credentials or environment variables,
+expected external LLM call count, estimated cost, command(s), artifacts, and
+pass/fail criteria. TUI or Studio need full E2E only when UI-specific behavior
+changes; otherwise require thin parity/smoke checks proving they call the same
+backend behavior.
+
 ## Ralph Cycle Protocol
 Each cycle must:
 1. summarize the current state and remaining unmet requirements
 2. propose one bounded implementation goal
 3. list intended file areas and commands
 4. estimate resource use and risk
-5. ask for explicit approval before starting
-6. implement only the approved goal
+5. check whether the resource gate requires human approval
+6. implement only the approved or resource-permitted goal
 7. run the agreed checks
 8. report evidence, failures, and remaining gaps
-9. stop if requirements are met or request approval for the next cycle
+9. stop if requirements are met, a blocker appears, resource thresholds are exceeded, scope changes, or the autonomous batch cap is reached
 
 ## Cycle Budget
 - Default cycle size: one bounded implementation goal per cycle.
 - Max files or modules per cycle:
 - Expected command budget:
-- Approval required before every cycle: yes.
+- Human approval required when planned external LLM usage exceeds USD 2, exceeds 10 calls, exceeds approved scope, adds risky dependencies or irreversible operations, or needs a product/architecture decision.
+- External LLM usage counted: DUUMBI live provider calls and external model/agent CLI calls. Codex internal reasoning usage is reported only as an estimate.
+- Autonomous batch cap:
 - When to stop and ask for human guidance:
 
 ## Task Breakdown
@@ -182,16 +210,19 @@ Questions that block implementation or require human trade-off decisions.
 
 Separate verified source facts from assumptions and implementation recommendations.
 
-## Ralph Cycle Requirements
+## Ralph Cycle Resource Policy
 
-Every technical spec must include a small bounded default cycle budget:
+Every technical spec must include a bounded resource policy:
 
 - one bounded implementation goal per cycle
-- explicit approval before each cycle
 - expected file or module area listed before work starts
 - planned commands and checks listed before work starts
+- expected external LLM calls and estimated external LLM cost
+- approval required above USD 2 or 10 external LLM calls
+- approval required for scope expansion, risky dependency changes, irreversible operations, blockers, or product/architecture decisions
+- default autonomous batch cap of three low-budget cycles unless the spec sets a lower cap
 - stop after evidence report
-- continue cycles only while approved and while requirements remain unmet
+- continue cycles only while below thresholds, inside scope, inside batch cap, and while requirements remain unmet
 
 ## GitHub Outcome Rules
 
@@ -202,6 +233,7 @@ After a successful technical spec artifact exists:
 - keep or add existing `needs-tech-spec` as appropriate
 - add existing `technical-spec-review` label when available
 - do not mark the technical spec approved
+- do not close the execution issue; it must remain open until Stage 12 closure verifies merged implementation evidence
 
 When blocked:
 
@@ -223,7 +255,9 @@ Technical spec draft complete:
 **GitHub status:** <Technical Spec Review | Needs Clarification | unchanged>
 **Affected areas:** <summary>
 **Verification plan:** <summary>
-**Cycle budget:** <summary>
+**BDD-to-test mapping:** <summary>
+**Live E2E plan:** <summary>
+**Ralph Cycle resource policy:** <summary>
 **Open questions:** <none or list>
 **Unavailable writes:** <labels/project fields unavailable, or none>
 **Next stage:** <Stage 9 Technical Specification Review | Needs Clarification>
@@ -236,5 +270,6 @@ Technical spec draft complete:
 - Do not modify implementation code, tests, migrations, generated outputs, or runtime assets.
 - Do not run Ralph cycles or implementation commands.
 - Do not approve your own technical spec.
+- Do not use GitHub auto-close keywords in spec-only PRs; only Stage 12 closure may close the execution issue.
 - Keep the technical spec traceable to the approved product spec and source evidence.
 - Stop and ask the user if a requested write exceeds Stage 8.

--- a/.agents/skills/duumbi-tech-spec-review/SKILL.md
+++ b/.agents/skills/duumbi-tech-spec-review/SKILL.md
@@ -85,8 +85,10 @@ Review the technical spec for:
 - affected areas are concrete enough for an AI agent to inspect and modify
 - technical approach separates verified source facts, assumptions, and recommendations
 - invariants and out-of-bounds areas are explicit
-- Ralph Cycle Protocol requires approval before every cycle
-- cycle budget is small, bounded, and resource-aware
+- BDD-to-test mapping covers every product-spec BDD scenario
+- live E2E plan names the canonical interface, provider path, credentials/env requirements, expected external LLM calls, cost estimate, commands, artifacts, and pass/fail criteria
+- Ralph Cycle Protocol uses the resource gate and permits low-budget autonomous cycles
+- cycle budget is small, bounded, resource-aware, and includes an autonomous batch cap
 - task breakdown is ordered and suitable for bounded implementation cycles
 - verification plan maps to product-spec `Checks` and technical completion criteria
 - completion criteria define what must be true before PR review
@@ -118,8 +120,10 @@ If no explicit human decision is present, write or return a review report and st
 - Affected areas are concrete:
 - Facts, assumptions, and recommendations are separated:
 - Invariants and out-of-bounds areas are explicit:
-- Ralph cycle approval is required before every cycle:
-- Cycle budget is bounded:
+- BDD-to-test mapping covers product BDD scenarios:
+- Live E2E plan is concrete and feasible:
+- Ralph cycle resource gate is correct:
+- Cycle budget and autonomous batch cap are bounded:
 - Task breakdown supports bounded cycles:
 - Verification plan maps to checks:
 - Completion criteria are clear:
@@ -226,6 +230,8 @@ Technical spec review complete:
 **Draft PR comment:** <link, "posted", or "not applicable">
 **GitHub status:** <Ready for Build | Technical Spec Needed | Needs Clarification | Closed | Deferred | unchanged>
 **Labels changed:** <added/removed/none>
+**BDD/live E2E readiness:** <ready | missing | blocked>
+**Resource policy readiness:** <ready | missing | blocked>
 **Blocking findings:** <none or list>
 **Open questions:** <none or list>
 **Unavailable writes:** <labels/project fields unavailable, or none>

--- a/.agents/skills/duumbi-triage/SKILL.md
+++ b/.agents/skills/duumbi-triage/SKILL.md
@@ -58,8 +58,7 @@ Start with:
 - `Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - PRD.md`
 - `Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - Glossary.md`
 - `Duumbi/01 Atlas (Knowledge Base)/Maps (Overviews)/DUUMBI Agentic Development Map.md`
-- `Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - Development Intake to Delivery Workflow.md`
-- active roadmap notes when choosing the next best engineering issue
+- `Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - Agentic Development Runbook.md`
 
 Load specific Dots, Maps, Works, source files, or GitHub items only when the source item needs them. Do not use archive notes as current guidance unless an active note explicitly points to them.
 
@@ -74,32 +73,20 @@ Accept one item or a bounded sweep:
 
 For sweeps, process items one by one. If the sweep is large, summarize the queue and ask the user which bounded batch to process first.
 
-## No Target Discovery Mode
+## Next-Issue Discovery Sweeps
 
-Use this mode only when the user asks for Stage 4 triage without a specific Inbox note, GitHub Issue, GitHub Discussion, or bounded source list.
+When the user asks for the next best engineering issue rather than naming one source item, treat the sweep as a discovery and selection task over raw and durable planning surfaces:
 
-Goal: propose exactly one next best engineering issue and route it to `Needs Human Acceptance`.
-
-Inspect:
-
-- Inbox notes under `Duumbi/00 Inbox (ToProcess)/`
-- GitHub Issues in intake, clarification, or `Todo` Project states
+- Inbox notes
+- GitHub Issues
 - GitHub Ideas Discussions
-- active DUUMBI Obsidian documentation, especially PRD, Glossary, Agentic Development Map, Development Intake to Delivery Workflow, and current roadmap notes
-- recent PRs, milestones, and directly relevant source files only as supporting evidence for duplicate risk, sequencing, feasibility, or whether work has already started
+- active Obsidian Atlas and roadmap notes
 
-Selection rules:
+Recent PRs, source files, milestones, and codebase inspection are supporting evidence only. Use them to verify duplicate risk, sequencing, feasibility, or whether work has already started. Do not define the sweep target as "recent PRs, the codebase, and open issues" because that biases triage toward already-active implementation work.
 
-- Prefer work that solves a concrete user, product, reliability, or developer-experience problem and is likely to deliver meaningful business value.
-- Prefer work that fits current roadmap sequencing and avoids starting lower-priority phases before active kill-criterion work is closed.
-- If selecting an existing GitHub Issue, it is eligible only when its verified DUUMBI Project Status is `Todo`.
-- Do not recommend an existing issue for development when its status is beyond `Todo`, including `Needs Human Acceptance`, `Spec Needed`, `Ready for Build`, `Cycle Authorization`, `In Progress`, `In Review`, `Blocked`, `Done`, `Deferred`, `Duplicate`, or `Closed`.
-- Treat issues beyond `Todo` only as related context, duplicate evidence, sequencing evidence, or proof that work has already started.
-- If suitable work is not already represented by an eligible `Todo` issue, create exactly one GitHub Issue in `hgahub/duumbi` with full description, clear scope, evidence, acceptance criteria, risks, and relevant links.
-- Connect the selected or newly created issue to the relevant milestone only when one is clearly applicable.
-- Route the selected or newly created issue to `Needs Human Acceptance`.
+If the recommendation should reuse an existing GitHub Issue as the next implementation candidate, only select issues whose DUUMBI Project Status is `Todo`. Do not select issues already in `Needs Human Acceptance`, `Spec Needed`, `Spec Review`, `Technical Spec Needed`, `Technical Spec Review`, `Ready for Build`, `Cycle Authorization`, `In Progress`, `In Review`, `Blocked`, `Done`, or any equivalent post-triage/post-acceptance state. If the strongest related issue has already moved beyond `Todo`, treat it as ineligible for next-issue discovery, record it as related context, and choose the best eligible `Todo` issue or create a new issue only when the work is not already represented.
 
-Do not mark it accepted, create product specs, create technical specs, create PRs, modify source code, start implementation, or recommend work already past `Todo` as the next development item.
+For an eligible existing `Todo` issue, update the canonical issue when useful, preserve source links, and route it to `Needs Human Acceptance`. For a new execution issue, create it with the GitHub Issue Contract and route it to `Needs Human Acceptance`.
 
 ## Triage Classification
 
@@ -126,8 +113,6 @@ Before creating or updating execution work, inspect GitHub for:
 - DUUMBI Project state when available
 
 Do not claim GitHub status unless verified from GitHub. If GitHub was not inspected, do not create an execution issue.
-
-In No Target Discovery Mode, do not select an existing issue unless its DUUMBI Project Status was verified as `Todo`. If the Project Status cannot be verified, treat the issue as ineligible for recommendation and either inspect another candidate or create a new proposed issue when justified.
 
 ## Write Rules
 
@@ -265,24 +250,6 @@ Triage complete:
 **Stage 5 recommendation:** <Needs Human Acceptance | Needs Clarification | Duplicate | Deferred | Rejected | Not applicable>
 **Open questions:** <none or list>
 **Assumptions:** <none or list>
-```
-
-In No Target Discovery Mode, report:
-
-```markdown
-Next issue discovery complete:
-
-**Recommended issue:** #<number>
-**Issue URL:** <url>
-**Why this is the next best engineering issue:** <short rationale>
-**Issue source:** <existing Todo issue | newly created issue>
-**Eligibility evidence:** <verified Todo status or newly created issue>
-**Evidence inspected:** <Inbox notes, GitHub Issues, GitHub Discussions, active docs, PRs, milestones, source files>
-**Related context not selected:** <issues beyond Todo, duplicates, started work, or none>
-**GitHub writes:** <created/updated issue, labels, Project fields, milestone, or none>
-**Obsidian writes:** <notes updated or created, or none>
-**Assumptions:** <none or list>
-**Open questions:** <none or list>
 ```
 
 ## Safety Rules


### PR DESCRIPTION
## Summary

- Syncs the DUUMBI workflow skills in `.agents/skills` from the updated copies that were mistakenly edited under `duumbi-vault`.
- Keeps `duumbi`-only skills (`collapsible-chat-block`, `jsonld-schema`) in place.

## Root Cause

The canonical DUUMBI skill files were updated in the vault checkout, but these skills belong under the main `duumbi` project.

## Validation

- Ran `git diff --check`.
- Compared the synced DUUMBI skill tree against the vault source; remaining differences are expected project-local skills and `.DS_Store`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced development workflow with structured behavior-driven development (BDD) scenario requirements in specifications
  * Refined resource management gates and approval processes for implementation cycles  
  * Expanded verification procedures to map BDD scenarios to test evidence
  * Updated technical specification templates with resource estimates and E2E testing plans
  * Improved issue discovery and triage workflow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hgahub/duumbi/pull/566?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->