### PR TITLE
Add hourly human acceptance sweep

### DIFF
--- a/.github/workflows/human-acceptance-request.yml
+++ b/.github/workflows/human-acceptance-request.yml
@@ -23,7 +23,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 concurrency:
   group: human-acceptance-${{ github.event.issue.number || inputs.issue_number || github.event_name }}
@@ -33,6 +32,12 @@ jobs:
   notify:
     name: Ask Oz to notify Slack
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      issue_numbers: ${{ steps.request.outputs.issue_numbers }}
+      should_notify: ${{ steps.request.outputs.should_notify }}
     steps:
       - name: Validate request and build Oz prompt
         id: request
@@ -46,6 +51,7 @@ jobs:
             const fs = require("fs");
 
             const marker = "<!-- duumbi-human-acceptance-slack-notified -->";
+            const maxScheduledIssues = 10;
             const status = String(process.env.INPUT_STATUS || "Needs Human Acceptance").trim();
             const sanitizePromptField = (value) => String(value ?? "")
               .replace(/```/g, "'''")
@@ -56,7 +62,6 @@ jobs:
               .map((label) => typeof label === "string" ? label : label.name)
               .filter(Boolean);
             const issueUrlFor = (number) => `https://github.com/${context.repo.owner}/${context.repo.repo}/issues/${number}`;
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             const hasNotificationMarker = async (issueNumber) => {
               const comments = await github.paginate(github.rest.issues.listComments, {
@@ -151,6 +156,10 @@ jobs:
                   continue;
                 }
                 issuesToNotify.push(issue);
+                if (issuesToNotify.length >= maxScheduledIssues) {
+                  core.info(`Scheduled sweep capped at ${maxScheduledIssues} issues for this run.`);
+                  break;
+                }
               }
               triggeredBy = "scheduled sweep";
             } else {
@@ -211,6 +220,7 @@ jobs:
               "Do not use a Slack incoming webhook. Do not modify GitHub state. Do not run Stage 5 acceptance yet.",
               "",
               "Send one separate Slack notification/thread for each issue below, so the reviewer acceptance reply is unambiguous.",
+              `This workflow caps scheduled sweeps at ${maxScheduledIssues} issues per run to keep notifications bounded.`,
               "",
               ...issuePrompts.map((issuePrompt, index) => [
                 `Issue notification ${index + 1}:`,
@@ -223,11 +233,10 @@ jobs:
             fs.writeFileSync("oz-prompt.txt", ozPrompt, "utf8");
             core.setOutput("oz_prompt", ozPrompt);
             core.setOutput("issue_numbers", JSON.stringify(issuesToNotify.map((issue) => issue.number)));
-            core.setOutput("marker", marker);
             core.setOutput("should_notify", "true");
 
       - name: Notify reviewer through Oz
-        if: steps.request.outputs.should_notify == 'true'
+        if: success() && steps.request.outputs.should_notify == 'true'
         uses: warpdotdev/oz-agent-action@v1
         with:
           name: DUUMBI Human Acceptance Slack Notification
@@ -235,12 +244,20 @@ jobs:
           prompt: ${{ steps.request.outputs.oz_prompt }}
           warp_api_key: ${{ secrets.WARP_API_KEY }}
 
+  mark-notified:
+    name: Mark notified issues
+    needs: notify
+    if: success() && needs.notify.outputs.should_notify == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
       - name: Mark notified issues
-        if: steps.request.outputs.should_notify == 'true'
         uses: actions/github-script@v9
         env:
-          ISSUE_NUMBERS: ${{ steps.request.outputs.issue_numbers }}
-          MARKER: ${{ steps.request.outputs.marker }}
+          ISSUE_NUMBERS: ${{ needs.notify.outputs.issue_numbers }}
+          MARKER: <!-- duumbi-human-acceptance-slack-notified -->
         with:
           script: |
             const issueNumbers = JSON.parse(process.env.ISSUE_NUMBERS || "[]");

--- a/.github/workflows/human-acceptance-request.yml
+++ b/.github/workflows/human-acceptance-request.yml
@@ -3,6 +3,8 @@ name: Human Acceptance Request
 on:
   issues:
     types: [labeled]
+  schedule:
+    - cron: '*/15 * * * *'
   workflow_dispatch:
     inputs:
       issue_url:
@@ -21,10 +23,10 @@ on:
 
 permissions:
   contents: read
-  issues: read
+  issues: write
 
 concurrency:
-  group: human-acceptance-${{ github.event.issue.number || inputs.issue_number || github.run_id }}
+  group: human-acceptance-${{ github.event.issue.number || inputs.issue_number || github.event_name }}
   cancel-in-progress: false
 
 jobs:
@@ -43,73 +45,52 @@ jobs:
           script: |
             const fs = require("fs");
 
-            const payload = context.eventName === "workflow_dispatch"
-              ? {
-                  issue_url: process.env.INPUT_ISSUE_URL,
-                  issue_number: process.env.INPUT_ISSUE_NUMBER,
-                  status: process.env.INPUT_STATUS || "Needs Human Acceptance",
-                  triggered_by: context.actor,
-                }
-              : {
-                  issue_url: context.payload.issue?.html_url,
-                  issue_number: context.payload.issue?.number,
-                  status: "Needs Human Acceptance",
-                  triggered_by: context.payload.sender?.login || context.actor,
-                  label: context.payload.label?.name,
-                };
-
-            if (context.eventName === "issues" && payload.label !== "needs-human-review") {
-              core.info(`Ignoring label "${payload.label}".`);
-              core.setOutput("should_notify", "false");
-              return;
-            }
-
-            const status = String(payload.status || "").trim();
-            if (status !== "Needs Human Acceptance") {
-              core.info(`Ignoring request because status is "${status}".`);
-              core.setOutput("should_notify", "false");
-              return;
-            }
-
-            const issueNumber = Number(payload.issue_number || 0);
-            const issueUrl = String(payload.issue_url || "").trim();
-            if (!Number.isInteger(issueNumber) || issueNumber < 1) {
-              core.setFailed(`Invalid issue_number: ${payload.issue_number}`);
-              return;
-            }
-            const issueMatch = issueUrl.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)$/);
-            if (!issueMatch) {
-              core.setFailed(`Invalid issue_url: ${issueUrl}`);
-              return;
-            }
-            if (issueMatch[1] !== context.repo.owner || issueMatch[2] !== context.repo.repo) {
-              core.setFailed(`Issue URL must belong to ${context.repo.owner}/${context.repo.repo}: ${issueUrl}`);
-              return;
-            }
-            if (Number.parseInt(issueMatch[3], 10) !== issueNumber) {
-              core.setFailed(`issue_url and issue_number do not match: ${issueUrl} vs ${issueNumber}`);
-              return;
-            }
-
-            const { data: issue } = await github.rest.issues.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-            });
-
-            const labels = issue.labels
-              .map((label) => typeof label === "string" ? label : label.name)
-              .filter(Boolean)
-              .join(", ") || "none";
-            const triggeredBy = String(payload.triggered_by || context.actor || "unknown");
-            const correlationId = `${context.runId}-${issueNumber}`;
+            const marker = "<!-- duumbi-human-acceptance-slack-notified -->";
+            const status = String(process.env.INPUT_STATUS || "Needs Human Acceptance").trim();
             const sanitizePromptField = (value) => String(value ?? "")
               .replace(/```/g, "'''")
               .replace(/`/g, "'")
               .replace(/[\r\n]+/g, " ")
               .trim();
+            const labelsFor = (issue) => issue.labels
+              .map((label) => typeof label === "string" ? label : label.name)
+              .filter(Boolean);
+            const issueUrlFor = (number) => `https://github.com/${context.repo.owner}/${context.repo.repo}/issues/${number}`;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
-            const acceptancePrompt = [
+            const hasNotificationMarker = async (issueNumber) => {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                per_page: 100,
+              });
+              return comments.some((comment) => comment.body?.includes(marker));
+            };
+
+            const fetchIssue = async (issueNumber) => {
+              const { data: issue } = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+              });
+              return issue;
+            };
+
+            const validateIssueUrl = (issueUrl, issueNumber) => {
+              const issueMatch = issueUrl.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)$/);
+              if (!issueMatch) {
+                throw new Error(`Invalid issue_url: ${issueUrl}`);
+              }
+              if (issueMatch[1] !== context.repo.owner || issueMatch[2] !== context.repo.repo) {
+                throw new Error(`Issue URL must belong to ${context.repo.owner}/${context.repo.repo}: ${issueUrl}`);
+              }
+              if (Number.parseInt(issueMatch[3], 10) !== issueNumber) {
+                throw new Error(`issue_url and issue_number do not match: ${issueUrl} vs ${issueNumber}`);
+              }
+            };
+
+            const acceptancePromptFor = (issueUrl) => [
               "Run DUUMBI Stage 5 Human Acceptance with duumbi-human-acceptance.",
               "",
               `Target issue: ${issueUrl}`,
@@ -122,33 +103,127 @@ jobs:
               "Do not create product specs, technical specs, PRs, source-code changes, or implementation branches.",
             ].join("\n");
 
+            const buildIssuePrompt = (issue, triggeredBy) => {
+              const issueUrl = issue.html_url || issueUrlFor(issue.number);
+              const labelNames = labelsFor(issue);
+              const labels = labelNames.join(", ") || "none";
+              const correlationId = `${context.runId}-${issue.number}`;
+              return [
+                `- DUUMBI issue needs human acceptance: #${issue.number} ${sanitizePromptField(issue.title)}`,
+                `- Issue: ${issueUrl}`,
+                "- Trigger: `needs-human-review` label",
+                "- Status: Needs Human Acceptance",
+                `- Labels: ${sanitizePromptField(labels)}`,
+                `- Triggered by: ${sanitizePromptField(triggeredBy)}`,
+                `- Correlation: ${correlationId}`,
+                "",
+                "Tell the reviewer to reply in Slack with:",
+                "@Oz accepted: <short rationale>",
+                "",
+                "When the reviewer accepts, Oz must run in `duumbi-vault-knowledge-env` with this prompt:",
+                "```text",
+                acceptancePromptFor(issueUrl),
+                "```",
+              ].join("\n");
+            };
+
+            let issuesToNotify = [];
+            let triggeredBy = context.actor || "unknown";
+
+            if (context.eventName === "schedule") {
+              const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: "open",
+                labels: "needs-human-review",
+                per_page: 100,
+              });
+
+              for (const issue of openIssues) {
+                if (issue.pull_request) {
+                  continue;
+                }
+                const labelNames = labelsFor(issue);
+                if (labelNames.includes("accepted") || labelNames.includes("needs-spec")) {
+                  continue;
+                }
+                if (await hasNotificationMarker(issue.number)) {
+                  continue;
+                }
+                issuesToNotify.push(issue);
+              }
+              triggeredBy = "scheduled sweep";
+            } else {
+              const payload = context.eventName === "workflow_dispatch"
+                ? {
+                    issue_url: process.env.INPUT_ISSUE_URL,
+                    issue_number: Number(process.env.INPUT_ISSUE_NUMBER || 0),
+                    status,
+                    triggered_by: context.actor,
+                  }
+                : {
+                    issue_url: context.payload.issue?.html_url,
+                    issue_number: Number(context.payload.issue?.number || 0),
+                    status: "Needs Human Acceptance",
+                    triggered_by: context.payload.sender?.login || context.actor,
+                    label: context.payload.label?.name,
+                  };
+
+              if (context.eventName === "issues" && payload.label !== "needs-human-review") {
+                core.info(`Ignoring label "${payload.label}".`);
+                core.setOutput("should_notify", "false");
+                return;
+              }
+
+              if (payload.status !== "Needs Human Acceptance") {
+                core.info(`Ignoring request because status is "${payload.status}".`);
+                core.setOutput("should_notify", "false");
+                return;
+              }
+
+              const issueNumber = payload.issue_number;
+              const issueUrl = String(payload.issue_url || "").trim();
+              if (!Number.isInteger(issueNumber) || issueNumber < 1) {
+                core.setFailed(`Invalid issue_number: ${payload.issue_number}`);
+                return;
+              }
+              try {
+                validateIssueUrl(issueUrl, issueNumber);
+              } catch (error) {
+                core.setFailed(error.message);
+                return;
+              }
+
+              issuesToNotify.push(await fetchIssue(issueNumber));
+              triggeredBy = String(payload.triggered_by || context.actor || "unknown");
+            }
+
+            if (issuesToNotify.length === 0) {
+              core.info("No unnotified issues need human acceptance.");
+              core.setOutput("should_notify", "false");
+              return;
+            }
+
+            const issuePrompts = issuesToNotify.map((issue) => buildIssuePrompt(issue, triggeredBy));
             const ozPrompt = [
               "Notify the DUUMBI human reviewer in Slack using the configured Warp/Oz Slack integration.",
               "",
               "Do not use a Slack incoming webhook. Do not modify GitHub state. Do not run Stage 5 acceptance yet.",
               "",
-              "Slack notification content:",
-              `- DUUMBI issue needs human acceptance: #${issueNumber} ${sanitizePromptField(issue.title)}`,
-              `- Issue: ${issueUrl}`,
-              "- Trigger: `needs-human-review` label",
-              `- Status: ${sanitizePromptField(status)}`,
-              `- Labels: ${sanitizePromptField(labels)}`,
-              `- Triggered by: ${sanitizePromptField(triggeredBy)}`,
-              `- Correlation: ${correlationId}`,
+              "Send one separate Slack notification/thread for each issue below, so the reviewer acceptance reply is unambiguous.",
               "",
-              "Tell the reviewer to reply in Slack with:",
-              "@Oz accepted: <short rationale>",
-              "",
-              "When the reviewer accepts, Oz must run in `duumbi-vault-knowledge-env` with this prompt:",
-              "```text",
-              acceptancePrompt,
-              "```",
+              ...issuePrompts.map((issuePrompt, index) => [
+                `Issue notification ${index + 1}:`,
+                issuePrompt,
+              ].join("\n")),
               "",
               "If the Slack destination is ambiguous, use the configured DUUMBI/Warp default review destination. If no Slack destination is configured, report that clearly in the Oz run output.",
-            ].join("\n");
+            ].join("\n\n");
 
             fs.writeFileSync("oz-prompt.txt", ozPrompt, "utf8");
             core.setOutput("oz_prompt", ozPrompt);
+            core.setOutput("issue_numbers", JSON.stringify(issuesToNotify.map((issue) => issue.number)));
+            core.setOutput("marker", marker);
             core.setOutput("should_notify", "true");
 
       - name: Notify reviewer through Oz
@@ -159,3 +234,30 @@ jobs:
           profile: duumbi-vault-knowledge-env
           prompt: ${{ steps.request.outputs.oz_prompt }}
           warp_api_key: ${{ secrets.WARP_API_KEY }}
+
+      - name: Mark notified issues
+        if: steps.request.outputs.should_notify == 'true'
+        uses: actions/github-script@v9
+        env:
+          ISSUE_NUMBERS: ${{ steps.request.outputs.issue_numbers }}
+          MARKER: ${{ steps.request.outputs.marker }}
+        with:
+          script: |
+            const issueNumbers = JSON.parse(process.env.ISSUE_NUMBERS || "[]");
+            const marker = process.env.MARKER;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            for (const issueNumber of issueNumbers) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: [
+                  marker,
+                  "Human acceptance Slack notification requested through Oz.",
+                  "",
+                  `Workflow run: ${runUrl}`,
+                  `Source event: ${context.eventName}`,
+                ].join("\n"),
+              });
+            }

--- a/.github/workflows/human-acceptance-request.yml
+++ b/.github/workflows/human-acceptance-request.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types: [labeled]
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '0 * * * *'
   workflow_dispatch:
     inputs:
       issue_url:

--- a/docs/automation/human-acceptance-slack-gate.md
+++ b/docs/automation/human-acceptance-slack-gate.md
@@ -15,7 +15,7 @@ updates performed by `duumbi-human-acceptance`.
 2. Stage 4 adds the existing `needs-human-review` label to the issue.
 3. `.github/workflows/human-acceptance-request.yml` runs on the GitHub
    `issues.labeled` event when the added label is `needs-human-review`.
-4. The workflow also runs every 15 minutes as a scheduled sweep for open
+4. The workflow also runs hourly as a scheduled sweep for open
    `needs-human-review` issues that were not already notified.
 5. The workflow starts `warpdotdev/oz-agent-action` with `WARP_API_KEY`.
 6. Oz runs with the `duumbi-vault-knowledge-env` profile and uses the configured
@@ -50,7 +50,7 @@ without an external webhook receiver. The no-server contract is therefore:
 
 - Project v2 Status may still be the human workflow state of record.
 - The GitHub Action trigger is the issue label `needs-human-review`.
-- A scheduled sweep runs every 15 minutes and catches open `needs-human-review`
+- A scheduled sweep runs hourly and catches open `needs-human-review`
   issues that have not yet received the notification marker.
 - Stage 4 must keep adding `needs-human-review` whenever it routes an issue to
   `Needs Human Acceptance`.
@@ -111,7 +111,7 @@ DUUMBI reviewer through Slack, then writes the notification marker comment. If
 
 1. Create or select an open test issue with `needs-human-review`.
 2. Ensure it does not contain the notification marker comment.
-3. Wait for the next 15-minute scheduled run.
+3. Wait for the next hourly scheduled run.
 4. Confirm that Oz starts and a notification marker comment is added.
 5. Confirm that a later scheduled run skips the same issue because the marker is
    present.

--- a/docs/automation/human-acceptance-slack-gate.md
+++ b/docs/automation/human-acceptance-slack-gate.md
@@ -14,18 +14,21 @@ updates performed by `duumbi-human-acceptance`.
 1. Stage 4 triage routes a GitHub issue to human acceptance.
 2. Stage 4 adds the existing `needs-human-review` label to the issue.
 3. `.github/workflows/human-acceptance-request.yml` runs on the GitHub
-   `issues.labeled` event.
-4. The workflow ignores every label except `needs-human-review`.
+   `issues.labeled` event when the added label is `needs-human-review`.
+4. The workflow also runs every 15 minutes as a scheduled sweep for open
+   `needs-human-review` issues that were not already notified.
 5. The workflow starts `warpdotdev/oz-agent-action` with `WARP_API_KEY`.
 6. Oz runs with the `duumbi-vault-knowledge-env` profile and uses the configured
    Warp/Oz Slack integration to notify the DUUMBI reviewer.
-7. The reviewer replies in Slack with:
+7. After Oz succeeds, the workflow writes an operational marker comment to the
+   issue so future scheduled sweeps do not send duplicate notifications.
+8. The reviewer replies in Slack with:
 
 ```text
 @Oz accepted: <short rationale>
 ```
 
-8. Warp/Oz Slack integration runs in `duumbi-vault-knowledge-env` and executes:
+9. Warp/Oz Slack integration runs in `duumbi-vault-knowledge-env` and executes:
 
 ```text
 Run DUUMBI Stage 5 Human Acceptance with duumbi-human-acceptance.
@@ -47,10 +50,20 @@ without an external webhook receiver. The no-server contract is therefore:
 
 - Project v2 Status may still be the human workflow state of record.
 - The GitHub Action trigger is the issue label `needs-human-review`.
+- A scheduled sweep runs every 15 minutes and catches open `needs-human-review`
+  issues that have not yet received the notification marker.
 - Stage 4 must keep adding `needs-human-review` whenever it routes an issue to
   `Needs Human Acceptance`.
 
 This matches the current DUUMBI Stage 4 skill contract.
+
+The notification marker is a GitHub issue comment containing:
+
+```html
+<!-- duumbi-human-acceptance-slack-notified -->
+```
+
+The marker is operational state only. It is not the Stage 5 decision record.
 
 ## Required Secrets
 
@@ -61,6 +74,9 @@ This matches the current DUUMBI Stage 4 skill contract.
 No `SLACK_WEBHOOK_URL` is required. Slack delivery is handled by the configured
 Warp/Oz Slack integration, visible in Slack under Apps -> Warp.
 
+The workflow needs `issues: write` permission so it can write the notification
+marker comment after Oz successfully starts the Slack notification flow.
+
 ## Manual Test
 
 Run the workflow from GitHub Actions with:
@@ -70,8 +86,8 @@ Run the workflow from GitHub Actions with:
 - `status`: `Needs Human Acceptance`.
 
 Expected result: the workflow starts an Oz run, and Oz notifies the configured
-DUUMBI reviewer through Slack. If `status` is any other value, the workflow exits
-without starting Oz.
+DUUMBI reviewer through Slack, then writes the notification marker comment. If
+`status` is any other value, the workflow exits without starting Oz.
 
 ## End-to-End Test
 
@@ -86,6 +102,16 @@ without starting Oz.
 ```
 
 6. Confirm that Oz runs in `duumbi-vault-knowledge-env`.
-7. Confirm that the issue receives a Stage 5 decision comment, is moved to
+7. Confirm that the issue receives the notification marker comment.
+8. Confirm that the issue receives a Stage 5 decision comment, is moved to
    `Spec Needed`, gets `accepted` and `needs-spec`, and loses
    `needs-human-review` when that label is present.
+
+## Scheduled Sweep Test
+
+1. Create or select an open test issue with `needs-human-review`.
+2. Ensure it does not contain the notification marker comment.
+3. Wait for the next 15-minute scheduled run.
+4. Confirm that Oz starts and a notification marker comment is added.
+5. Confirm that a later scheduled run skips the same issue because the marker is
+   present.

--- a/docs/automation/human-acceptance-slack-gate.md
+++ b/docs/automation/human-acceptance-slack-gate.md
@@ -17,11 +17,12 @@ updates performed by `duumbi-human-acceptance`.
    `issues.labeled` event when the added label is `needs-human-review`.
 4. The workflow also runs hourly as a scheduled sweep for open
    `needs-human-review` issues that were not already notified.
-5. The workflow starts `warpdotdev/oz-agent-action` with `WARP_API_KEY`.
+5. The read-only notification job starts `warpdotdev/oz-agent-action` with
+   `WARP_API_KEY`.
 6. Oz runs with the `duumbi-vault-knowledge-env` profile and uses the configured
    Warp/Oz Slack integration to notify the DUUMBI reviewer.
-7. After Oz succeeds, the workflow writes an operational marker comment to the
-   issue so future scheduled sweeps do not send duplicate notifications.
+7. After Oz succeeds, a separate marker job writes an operational marker comment
+   to the issue so future scheduled sweeps do not send duplicate notifications.
 8. The reviewer replies in Slack with:
 
 ```text
@@ -52,6 +53,8 @@ without an external webhook receiver. The no-server contract is therefore:
 - The GitHub Action trigger is the issue label `needs-human-review`.
 - A scheduled sweep runs hourly and catches open `needs-human-review`
   issues that have not yet received the notification marker.
+- A scheduled sweep processes at most 10 issues per run to keep the Oz prompt
+  and Slack notifications bounded.
 - Stage 4 must keep adding `needs-human-review` whenever it routes an issue to
   `Needs Human Acceptance`.
 
@@ -74,8 +77,9 @@ The marker is operational state only. It is not the Stage 5 decision record.
 No `SLACK_WEBHOOK_URL` is required. Slack delivery is handled by the configured
 Warp/Oz Slack integration, visible in Slack under Apps -> Warp.
 
-The workflow needs `issues: write` permission so it can write the notification
-marker comment after Oz successfully starts the Slack notification flow.
+The Oz notification job uses `issues: read`. A separate marker job uses
+`issues: write` only after the Oz notification job succeeds, so Oz does not run
+with an issue-write-capable `GITHUB_TOKEN`.
 
 ## Manual Test
 
@@ -115,3 +119,5 @@ DUUMBI reviewer through Slack, then writes the notification marker comment. If
 4. Confirm that Oz starts and a notification marker comment is added.
 5. Confirm that a later scheduled run skips the same issue because the marker is
    present.
+6. If more than 10 unnotified issues exist, confirm that only 10 are processed in
+   one hourly run and the rest remain eligible for later sweeps.


### PR DESCRIPTION
Adds an hourly scheduled sweep to the DUUMBI Human Acceptance Request workflow.\n\nChanges:\n- keeps the existing `issues.labeled` and manual triggers\n- adds hourly `schedule` trigger\n- scans open `needs-human-review` issues\n- skips issues already accepted or moved to spec\n- writes a marker comment after Oz notification so scheduled runs do not duplicate reminders\n- updates docs for the hourly sweep and marker comment\n\nValidation run:\n- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/human-acceptance-request.yml")'