### PR TITLE
CI for #420: add Windows Rust checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,12 @@ env:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    name: check (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -50,10 +55,10 @@ jobs:
         if: steps.scope.outputs.run_rust_checks == 'true'
         run: cargo clippy --all-targets -- -D warnings
       - name: Install cargo-audit
-        if: steps.scope.outputs.run_rust_checks == 'true'
+        if: steps.scope.outputs.run_rust_checks == 'true' && matrix.os == 'ubuntu-latest'
         run: cargo install cargo-audit --locked
       - name: Dependency audit
-        if: steps.scope.outputs.run_rust_checks == 'true'
+        if: steps.scope.outputs.run_rust_checks == 'true' && matrix.os == 'ubuntu-latest'
         run: cargo audit
       - name: Build
         if: steps.scope.outputs.run_rust_checks == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,19 @@ jobs:
       - name: Test
         if: steps.scope.outputs.run_rust_checks == 'true'
         run: cargo test --all
+
+  check-complete:
+    name: check
+    runs-on: ubuntu-latest
+    needs: check
+    if: always()
+    steps:
+      - name: Verify matrix checks
+        shell: bash
+        run: |
+          if [[ "${{ needs.check.result }}" != "success" ]]; then
+            echo "Matrix check job finished with result: ${{ needs.check.result }}"
+            exit 1
+          fi
+
+          echo "All matrix check jobs passed."

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -2968,7 +2968,9 @@ mod tests {
         // of the developer/CI machine's global config.
         let _lock = crate::cli::TEST_ENV_LOCK.lock().expect("env lock");
         let home = TempDir::new().expect("home tempdir");
-        let _home = EnvGuard::set("HOME", home.path().to_str().expect("utf8 home"));
+        let home_path = home.path().to_str().expect("utf8 home");
+        let _home = EnvGuard::set("HOME", home_path);
+        let _userprofile = EnvGuard::set("USERPROFILE", home_path);
 
         let dir = TempDir::new().expect("tempdir");
         fs::create_dir_all(dir.path().join(".duumbi")).expect("duumbi dir");
@@ -3002,7 +3004,9 @@ mod tests {
     fn build_client_loads_credentials_file_without_file_key_storage() {
         let _lock = crate::cli::TEST_ENV_LOCK.lock().expect("env lock");
         let home = TempDir::new().expect("home tempdir");
-        let _home = EnvGuard::set("HOME", home.path().to_str().expect("utf8 home"));
+        let home_path = home.path().to_str().expect("utf8 home");
+        let _home = EnvGuard::set("HOME", home_path);
+        let _userprofile = EnvGuard::set("USERPROFILE", home_path);
         let _api_key = EnvGuard::remove("DUUMBI_TEST_REPL_KEYSTORE_API_KEY");
         crate::cli::keystore::store_api_key("DUUMBI_TEST_REPL_KEYSTORE_API_KEY", "secret")
             .expect("credential must store");

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -415,7 +415,7 @@ async fn handle_slash(
     let arg = parts.next().unwrap_or("").trim();
 
     let graph_path = app.workspace_root.join(".duumbi/graph/main.jsonld");
-    let output_path = app.workspace_root.join(".duumbi/build/output");
+    let output_path = crate::workspace::workspace_output_path(&app.workspace_root);
 
     match cmd {
         "/build" => {
@@ -1110,7 +1110,7 @@ async fn handle_ai_request(
     app.push_output("Building…", OutputStyle::Dim);
     let _ = terminal.draw(|frame| app.render(frame, textarea));
 
-    let output_path = workspace.join(".duumbi/build/output");
+    let output_path = crate::workspace::workspace_output_path(&workspace);
     match commands::build(&graph_path, &output_path) {
         Ok(()) => {
             app.push_output(
@@ -2138,7 +2138,7 @@ fn handle_clear(app: &mut ReplApp, arg: &str) {
 /// Prints workspace status into the output buffer.
 fn print_status_to_buffer(app: &mut ReplApp) {
     let graph_path = app.workspace_root.join(".duumbi/graph/main.jsonld");
-    let output_path = app.workspace_root.join(".duumbi/build/output");
+    let output_path = crate::workspace::workspace_output_path(&app.workspace_root);
     let history_count = snapshot::snapshot_count(&app.workspace_root).unwrap_or(0);
     let mut hints = Vec::new();
 
@@ -3357,7 +3357,11 @@ mod tests {
         write_main_graph(&dir, minimal_graph());
         let build_dir = dir.path().join(".duumbi").join("build");
         fs::create_dir_all(&build_dir).expect("build dir must be created");
-        fs::write(build_dir.join("output"), b"binary").expect("binary must be written");
+        fs::write(
+            crate::workspace::workspace_output_path(dir.path()),
+            b"binary",
+        )
+        .expect("binary must be written");
 
         let mut config = DuumbiConfig {
             workspace: Some(WorkspaceSection {
@@ -3435,7 +3439,7 @@ mod tests {
     fn status_rejects_directory_build_output() {
         let dir = TempDir::new().expect("tempdir");
         write_main_graph(&dir, minimal_graph());
-        fs::create_dir_all(dir.path().join(".duumbi/build/output"))
+        fs::create_dir_all(crate::workspace::workspace_output_path(dir.path()))
             .expect("output directory must be created");
         let mut app = status_test_app(
             &dir,
@@ -3458,7 +3462,8 @@ mod tests {
         write_main_graph(&dir, minimal_graph());
         let build_dir = dir.path().join(".duumbi").join("build");
         fs::create_dir_all(&build_dir).expect("build dir must be created");
-        fs::write(build_dir.join("output"), b"").expect("empty output must be written");
+        fs::write(crate::workspace::workspace_output_path(dir.path()), b"")
+            .expect("empty output must be written");
         let mut app = status_test_app(
             &dir,
             DuumbiConfig::default(),

--- a/src/compiler/lowering.rs
+++ b/src/compiler/lowering.rs
@@ -347,7 +347,8 @@ fn make_func_signature(
 
 /// Compiles a validated semantic graph to a native object file.
 ///
-/// Returns the raw bytes of the object file (Mach-O on macOS, ELF on Linux).
+/// Returns the raw bytes of the native object file (Mach-O on macOS, ELF on
+/// Linux, COFF on Windows).
 /// For multi-module programs use [`compile_program`] instead.
 #[must_use = "compilation errors should be handled"]
 pub fn compile_to_object(graph: &SemanticGraph) -> Result<Vec<u8>, CompileError> {
@@ -1945,9 +1946,11 @@ mod tests {
             && (obj_bytes[0..4] == [0xCF, 0xFA, 0xED, 0xFE]
                 || obj_bytes[0..4] == [0xFE, 0xED, 0xFA, 0xCF]);
         let is_elf = obj_bytes.len() >= 4 && obj_bytes[0..4] == [0x7F, 0x45, 0x4C, 0x46];
+        let is_coff = obj_bytes.len() >= 2
+            && matches!(&obj_bytes[0..2], [0x4C, 0x01] | [0x64, 0x86] | [0x64, 0xAA]);
         assert!(
-            is_macho || is_elf,
-            "Output should be a valid Mach-O or ELF object file"
+            is_macho || is_elf || is_coff,
+            "Output should be a valid Mach-O, ELF, or COFF object file"
         );
     }
 

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -5,7 +5,10 @@ use std::fs;
 use std::path::PathBuf;
 
 fn credentials_path() -> Option<PathBuf> {
-    dirs::home_dir().map(|home| home.join(".duumbi").join("credentials.toml"))
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .or_else(dirs::home_dir)
+        .map(|home| home.join(".duumbi").join("credentials.toml"))
 }
 
 fn load_all() -> HashMap<String, String> {

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 fn credentials_path() -> Option<PathBuf> {
     std::env::var_os("HOME")
         .map(PathBuf::from)
+        .filter(|home| !home.as_os_str().is_empty())
         .or_else(dirs::home_dir)
         .map(|home| home.join(".duumbi").join("credentials.toml"))
 }

--- a/src/intent/review.rs
+++ b/src/intent/review.rs
@@ -319,8 +319,10 @@ fn default_editor_command() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
     use crate::intent::save_intent;
     use crate::intent::spec::{IntentModules, IntentSpec, IntentStatus};
+    #[cfg(unix)]
     use std::fs;
 
     #[cfg(unix)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -521,7 +521,7 @@ fn resolve_output(explicit: Option<&Path>) -> Result<PathBuf> {
 
     let workspace_build = PathBuf::from(".duumbi/build");
     if workspace_build.exists() {
-        return Ok(workspace_build.join("output"));
+        return Ok(workspace::workspace_output_path(Path::new(".")));
     }
 
     Ok(PathBuf::from("output"))

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -114,7 +114,7 @@ pub fn graph_evidence(workspace: &Path) -> Result<GraphEvidence> {
 /// Builds the current workspace.
 #[must_use]
 pub fn build_workspace(workspace: &Path) -> BuildWorkflowResult {
-    let output = workspace.join(".duumbi/build/output");
+    let output = crate::workspace::workspace_output_path(workspace);
     match crate::workspace::build_workspace(workspace, &output, false) {
         Ok(path) => BuildWorkflowResult {
             ok: true,

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -79,6 +79,14 @@ pub struct BinaryRunOutput {
     pub stderr: String,
 }
 
+/// Returns the default native binary path for a workspace build.
+#[must_use]
+pub fn workspace_output_path(workspace_root: &Path) -> PathBuf {
+    workspace_root
+        .join(".duumbi/build")
+        .join(format!("output{}", std::env::consts::EXE_SUFFIX))
+}
+
 /// Compiles all modules in a workspace and links them into `output`.
 ///
 /// When `offline` is true, dependency resolution skips the cache and registry
@@ -152,7 +160,7 @@ pub fn build_workspace(
 
 /// Runs a compiled workspace binary, capturing stdout and stderr.
 pub fn run_workspace_binary(workspace_root: &Path, args: &[String]) -> Result<BinaryRunOutput> {
-    let output_path = workspace_root.join(".duumbi/build/output");
+    let output_path = workspace_output_path(workspace_root);
     if !output_path.exists() {
         anyhow::bail!(
             "No binary found at '{}'. Build first.",

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -159,6 +159,7 @@ pub fn build_workspace(
 }
 
 /// Runs a compiled workspace binary, capturing stdout and stderr.
+#[must_use = "the captured process output should be inspected"]
 pub fn run_workspace_binary(workspace_root: &Path, args: &[String]) -> Result<BinaryRunOutput> {
     let output_path = workspace_output_path(workspace_root);
     if !output_path.exists() {

--- a/tests/integration_phase1.rs
+++ b/tests/integration_phase1.rs
@@ -162,9 +162,12 @@ fn phase1_workspace_init_build_run() {
         .expect("invariant: cargo build must be runnable");
     assert!(build_status.status.success(), "cargo build failed");
 
-    let duumbi_bin = std::path::PathBuf::from("target/debug/duumbi")
-        .canonicalize()
-        .expect("invariant: duumbi binary must exist after build");
+    let duumbi_bin = std::path::PathBuf::from(format!(
+        "target/debug/duumbi{}",
+        std::env::consts::EXE_SUFFIX
+    ))
+    .canonicalize()
+    .expect("invariant: duumbi binary must exist after build");
 
     let tmp_dir = std::env::temp_dir().join("duumbi_workspace_test");
     let _ = std::fs::remove_dir_all(&tmp_dir);

--- a/tests/integration_phase1.rs
+++ b/tests/integration_phase1.rs
@@ -210,10 +210,11 @@ fn phase1_workspace_init_build_run() {
         String::from_utf8_lossy(&build_output.stderr)
     );
 
-    assert!(tmp_dir.join(".duumbi/build/output").exists());
+    let workspace_output = duumbi::workspace::workspace_output_path(&tmp_dir);
+    assert!(workspace_output.exists());
 
     // Run the compiled binary
-    let binary_output = Command::new(tmp_dir.join(".duumbi/build/output"))
+    let binary_output = Command::new(&workspace_output)
         .output()
         .expect("invariant: compiled binary must be runnable");
 

--- a/tests/integration_phase4.rs
+++ b/tests/integration_phase4.rs
@@ -104,9 +104,13 @@ fn phase4_two_module_program_compiles_to_two_objects() {
         let is_macho = bytes.len() >= 4
             && (bytes[0..4] == [0xCF, 0xFA, 0xED, 0xFE] || bytes[0..4] == [0xFE, 0xED, 0xFA, 0xCF]);
         let is_elf = bytes.len() >= 4 && bytes[0..4] == [0x7F, 0x45, 0x4C, 0x46];
+        let is_coff = bytes.len() >= 2
+            && (bytes[0..2] == [0x4C, 0x01]
+                || bytes[0..2] == [0x64, 0x86]
+                || bytes[0..2] == [0x64, 0xAA]);
         assert!(
-            is_macho || is_elf,
-            "object for '{mod_name}' must be valid Mach-O or ELF"
+            is_macho || is_elf || is_coff,
+            "object for '{mod_name}' must be valid Mach-O, ELF, or COFF"
         );
     }
 }

--- a/tests/integration_phase9a_stdlib.rs
+++ b/tests/integration_phase9a_stdlib.rs
@@ -127,7 +127,7 @@ fn string_load_parameter_is_not_double_freed_in_cross_module_demo() {
     fs::write(graph_dir.join("main.jsonld"), main_json).expect("write main");
     fs::write(graph_dir.join("string/utils.jsonld"), utils_json).expect("write utils");
 
-    let output = tmp.path().join(".duumbi/build/output");
+    let output = duumbi::workspace::workspace_output_path(tmp.path());
     build_workspace(tmp.path(), &output, false).expect("workspace must build");
     let run = run_workspace_binary(tmp.path(), &[]).expect("workspace must run");
 
@@ -266,7 +266,7 @@ fn string_concat_formats_bool_call_result() {
     fs::write(graph_dir.join("main.jsonld"), main_json).expect("write main");
     fs::write(graph_dir.join("string/utils.jsonld"), utils_json).expect("write utils");
 
-    let output = tmp.path().join(".duumbi/build/output");
+    let output = duumbi::workspace::workspace_output_path(tmp.path());
     build_workspace(tmp.path(), &output, false).expect("workspace must build");
     let run = run_workspace_binary(tmp.path(), &[]).expect("workspace must run");
 


### PR DESCRIPTION
Related to #420.

Workflow note: This is the Stage 10 implementation PR. It must not close the execution issue automatically. #420 remains open for Stage 11 review and Stage 12 closure verification.

## Summary

- Add a CI matrix for `ubuntu-latest` and `windows-latest` in `.github/workflows/ci.yml`.
- Preserve docs/spec-only skip behavior for pull requests that only change `docs/` or `specs/`.
- Keep `cargo audit` required for Rust-relevant PRs, but run it only on Ubuntu.
- Keep Windows CI non-advisory: no `continue-on-error`; Windows failures fail the PR.
- Apply narrow Windows CI bring-up fixes exposed by the new Windows runner:
  - gate Unix-only intent review test imports;
  - accept COFF object output in compiler and integration validation;
  - use platform-aware workspace output paths with `std::env::consts::EXE_SUFFIX`;
  - make REPL credential tests hermetic on Windows;
  - align user credential lookup with test-controlled `HOME`, while falling back when `HOME` is empty.
- Leave README Windows support claims, terminal color fallback behavior, release packaging, runtime assets, product specs, and technical specs unchanged.

## Specs

- Product spec: `specs/DUUMBI-420/PRODUCT.md`
- Technical spec: `specs/DUUMBI-420/TECHNICAL.md`

## Changed Files

- `.github/workflows/ci.yml`: Ubuntu/Windows CI matrix, docs/spec-only guard preserved, Ubuntu-only audit.
- `src/intent/review.rs`: Unix-only test imports are gated for Windows.
- `src/compiler/lowering.rs`, `tests/integration_phase4.rs`: native object validation accepts Mach-O, ELF, and Windows COFF.
- `src/workspace.rs`, `src/workflow.rs`, `src/main.rs`, `src/cli/repl.rs`: workspace build/run/status paths use platform-aware output names.
- `src/credentials.rs`: credential lookup uses non-empty `HOME` first, then `dirs::home_dir()`.
- `tests/integration_phase1.rs`, `tests/integration_phase9a_stdlib.rs`, `src/cli/repl.rs` tests: Windows-compatible binary paths and credential home setup.

## Ralph Cycle Evidence

### Cycle 1

Goal: add native Windows Rust checks to the main CI workflow while preserving docs/spec-only skip behavior and Ubuntu-only dependency audit.

Files changed:
- `.github/workflows/ci.yml`

Evidence:
- `git diff --check`: passed.
- Static workflow review: matrix includes `ubuntu-latest` and `windows-latest`; no `continue-on-error`; docs/spec-only guard remains; non-PR events still force Rust checks; cargo audit is Ubuntu-only; Windows path still runs fmt, clippy, build, and test.
- `actionlint .github/workflows/ci.yml`: not run locally because `actionlint` is unavailable in this environment. GitHub Actions syntax validation passed in PR CI.

Resource use:
- External LLM calls: 0.
- Estimated external LLM cost: USD 0.
- Resource gate: not triggered.

### CI Response / Narrow Bring-Up Fixes

The new Windows runner exposed platform assumptions required for baseline `cargo test --all` to pass. These fixes stayed within #420 because they were directly required by the approved live CI evidence plan:

- Windows clippy found Unix-only imports in an intent review test; imports were gated with `#[cfg(unix)]`.
- Windows object files are COFF, not Mach-O/ELF; compiler and integration object assertions now accept COFF.
- Windows binaries use `.exe`; workspace build/run/status paths and affected integration tests now use platform-aware output paths.
- Windows REPL credential tests needed hermetic home setup and credential lookup consistent with test-controlled `HOME`.

Follow-up review comments addressed:
- Empty `HOME` is now ignored before falling back to `dirs::home_dir()`.
- `run_workspace_binary(...) -> Result<_>` now has a descriptive `#[must_use]` attribute.

## Verification

Local checks after review-fix commit:
- `cargo fmt --check`: passed.
- `git diff --check`: passed.
- `cargo test build_client_loads_credentials_file_without_file_key_storage`: passed.
- `cargo test complete_tui_init_overwrites_only_duumbi_directory`: passed.
- `cargo clippy --all-targets -- -D warnings`: passed.

Prior live GitHub Actions evidence on this PR:
- `check (ubuntu-latest)`: passed.
- `check (windows-latest)`: passed, including `cargo test --all`.
- `coverage`: passed.
- `Docs AI Update Request`: passed.
- `Request Copilot Review`: passed.
- `CodeRabbit`: passed as a check; actionable comments have been addressed in the latest commit.

The latest commit must pass the same PR checks before Stage 11 can recommend a human merge decision.

## BDD / E2E Evidence

- Rust-relevant PR runs Ubuntu and Windows checks: proven by PR checks.
- Windows Rust failure blocks the PR: proven during bring-up by failing Windows checks before fixes; workflow has no allowed-failure path.
- Docs/spec-only skip behavior: preserved by static workflow review; separate evidence PR was not created because the technical spec allows static review when a throwaway PR is not reasonable.
- Changed-file detection unavailable: empty changed-file output falls back to `run_rust_checks=true`.
- Push to `main`: non-PR events force `run_rust_checks=true`; post-merge main evidence remains Stage 12 scope.
- Dependency audit required once: Ubuntu audit path remains present and passed in PR CI.
- Adjacent Phase 16 work remains separate: README, #422 terminal color behavior, #423 Windows docs, release packaging, runtime assets, product specs, and technical specs were not changed.

## Remaining Risk

- Post-merge `main` CI evidence is still Stage 12 closure scope.
- The repository has a pre-existing Dependabot security notice on the default branch; this PR does not change that dependency surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Windows support with platform-specific binary path handling and COFF object format recognition.

* **Bug Fixes**
  * Improved build output path resolution for consistent cross-platform builds.
  * Fixed credential path resolution to properly respect system home directory settings.

* **Chores**
  * Extended CI testing to run matrix builds on Windows and Linux.
  * Updated integration tests for platform-agnostic execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hgahub/duumbi/pull/571?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->