### PR TITLE
Send human acceptance notifications via Slack API

### DIFF
--- a/.github/workflows/human-acceptance-request.yml
+++ b/.github/workflows/human-acceptance-request.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   notify:
-    name: Ask Oz to notify Slack
+    name: Notify Slack
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -39,7 +39,7 @@ jobs:
       issue_numbers: ${{ steps.request.outputs.issue_numbers }}
       should_notify: ${{ steps.request.outputs.should_notify }}
     steps:
-      - name: Validate request and build Oz prompt
+      - name: Validate request and build Slack payload
         id: request
         uses: actions/github-script@v9
         env:
@@ -48,8 +48,6 @@ jobs:
           INPUT_STATUS: ${{ inputs.status || '' }}
         with:
           script: |
-            const fs = require("fs");
-
             const marker = "<!-- duumbi-human-acceptance-slack-notified -->";
             const maxScheduledIssues = 10;
             const ozEnvironmentName = "duumbi-vault-knowledge-env";
@@ -60,6 +58,11 @@ jobs:
               .replace(/`/g, "'")
               .replace(/[\r\n]+/g, " ")
               .trim();
+            const sanitizeSlackField = (value) => sanitizePromptField(value)
+              .replace(/&/g, "&amp;")
+              .replace(/</g, "&lt;")
+              .replace(/>/g, "&gt;")
+              .replace(/@/g, "@\u200b");
             const labelsFor = (issue) => issue.labels
               .map((label) => typeof label === "string" ? label : label.name)
               .filter(Boolean);
@@ -110,28 +113,42 @@ jobs:
               "Do not create product specs, technical specs, PRs, source-code changes, or implementation branches.",
             ].join("\n");
 
-            const buildIssuePrompt = (issue, triggeredBy) => {
+            const buildSlackMessage = (issue, triggeredBy) => {
               const issueUrl = issue.html_url || issueUrlFor(issue.number);
               const labelNames = labelsFor(issue);
               const labels = labelNames.join(", ") || "none";
+              const title = sanitizeSlackField(issue.title);
+              const safeLabels = sanitizeSlackField(labels);
+              const safeTriggeredBy = sanitizeSlackField(triggeredBy);
               const correlationId = `${context.runId}-${issue.number}`;
-              return [
-                `- DUUMBI issue needs human acceptance: #${issue.number} ${sanitizePromptField(issue.title)}`,
-                `- Issue: ${issueUrl}`,
-                "- Trigger: `needs-human-review` label",
-                "- Status: Needs Human Acceptance",
-                `- Labels: ${sanitizePromptField(labels)}`,
-                `- Triggered by: ${sanitizePromptField(triggeredBy)}`,
-                `- Correlation: ${correlationId}`,
-                "",
-                "Tell the reviewer to reply in Slack with:",
-                "@Oz accepted: <short rationale>",
-                "",
-                `When the reviewer accepts, Oz must run in the \`${ozEnvironmentName}\` environment with ID \`${ozEnvironmentId}\` and this prompt:`,
-                "```text",
-                acceptancePromptFor(issueUrl),
-                "```",
-              ].join("\n");
+              const acceptancePrompt = acceptancePromptFor(issueUrl);
+
+              return {
+                text: `DUUMBI issue #${issue.number} needs human acceptance: ${title}`,
+                blocks: [
+                  {
+                    type: "section",
+                    text: {
+                      type: "mrkdwn",
+                      text: `*DUUMBI issue needs human acceptance*\n*Issue:* <${issueUrl}|#${issue.number} ${title}>\n*Trigger:* \`needs-human-review\` label\n*Status:* Needs Human Acceptance\n*Labels:* ${safeLabels}\n*Triggered by:* ${safeTriggeredBy}\n*Correlation:* \`${correlationId}\``,
+                    },
+                  },
+                  {
+                    type: "section",
+                    text: {
+                      type: "mrkdwn",
+                      text: "*Reply in this thread with `@Oz accepted: <short rationale>`*",
+                    },
+                  },
+                  {
+                    type: "section",
+                    text: {
+                      type: "mrkdwn",
+                      text: `When accepting, Oz must run in the \`${ozEnvironmentName}\` environment with ID \`${ozEnvironmentId}\` and this prompt:\n\`\`\`text\n${acceptancePrompt}\n\`\`\``,
+                    },
+                  },
+                ],
+              };
             };
 
             let issuesToNotify = [];
@@ -215,36 +232,52 @@ jobs:
               return;
             }
 
-            const issuePrompts = issuesToNotify.map((issue) => buildIssuePrompt(issue, triggeredBy));
-            const ozPrompt = [
-              "Notify the DUUMBI human reviewer in Slack using the configured Warp/Oz Slack integration.",
-              "",
-              "Do not use a Slack incoming webhook. Do not modify GitHub state. Do not run Stage 5 acceptance yet.",
-              `Use the Oz environment \`${ozEnvironmentName}\` with environment ID \`${ozEnvironmentId}\` when routing this Slack notification and any later acceptance run.`,
-              "",
-              "Send one separate Slack notification/thread for each issue below, so the reviewer acceptance reply is unambiguous.",
-              `This workflow caps scheduled sweeps at ${maxScheduledIssues} issues per run to keep notifications bounded.`,
-              "",
-              ...issuePrompts.map((issuePrompt, index) => [
-                `Issue notification ${index + 1}:`,
-                issuePrompt,
-              ].join("\n")),
-              "",
-              "If the Slack destination is ambiguous, use the configured DUUMBI/Warp default review destination. If no Slack destination is configured, report that clearly in the Oz run output.",
-            ].join("\n\n");
-
-            fs.writeFileSync("oz-prompt.txt", ozPrompt, "utf8");
-            core.setOutput("oz_prompt", ozPrompt);
+            const slackMessages = issuesToNotify.map((issue) => buildSlackMessage(issue, triggeredBy));
+            core.setOutput("slack_messages", JSON.stringify(slackMessages));
             core.setOutput("issue_numbers", JSON.stringify(issuesToNotify.map((issue) => issue.number)));
             core.setOutput("should_notify", "true");
 
-      - name: Notify reviewer through Oz
+      - name: Post Slack notifications
         if: success() && steps.request.outputs.should_notify == 'true'
-        uses: warpdotdev/oz-agent-action@v1
+        uses: actions/github-script@v9
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_REVIEW_CHANNEL_ID: ${{ secrets.SLACK_REVIEW_CHANNEL_ID }}
+          SLACK_MESSAGES: ${{ steps.request.outputs.slack_messages }}
         with:
-          name: DUUMBI Human Acceptance Slack Notification
-          prompt: ${{ steps.request.outputs.oz_prompt }}
-          warp_api_key: ${{ secrets.WARP_API_KEY }}
+          script: |
+            const token = process.env.SLACK_BOT_TOKEN;
+            const channel = process.env.SLACK_REVIEW_CHANNEL_ID;
+            const messages = JSON.parse(process.env.SLACK_MESSAGES || "[]");
+
+            if (!token) {
+              core.setFailed("SLACK_BOT_TOKEN is not configured.");
+              return;
+            }
+            if (!channel) {
+              core.setFailed("SLACK_REVIEW_CHANNEL_ID is not configured.");
+              return;
+            }
+
+            for (const message of messages) {
+              const response = await fetch("https://slack.com/api/chat.postMessage", {
+                method: "POST",
+                headers: {
+                  Authorization: `Bearer ${token}`,
+                  "Content-Type": "application/json; charset=utf-8",
+                },
+                body: JSON.stringify({
+                  channel,
+                  ...message,
+                }),
+              });
+              const body = await response.json();
+              if (!response.ok || !body.ok) {
+                core.setFailed(`Slack chat.postMessage failed: ${body.error || response.status}`);
+                return;
+              }
+              core.info(`Posted Slack notification ts=${body.ts}`);
+            }
 
   mark-notified:
     name: Mark notified issues

--- a/docs/automation/human-acceptance-slack-gate.md
+++ b/docs/automation/human-acceptance-slack-gate.md
@@ -1,10 +1,10 @@
 # DUUMBI Human Acceptance Slack Gate
 
 The Human Acceptance Slack Gate connects the DUUMBI Stage 4 triage label
-`needs-human-review` to the configured Warp/Oz Slack integration. This version
-intentionally uses only GitHub Actions, Slack, and Warp/Oz. It does not require
-a separate server, webhook bridge, Slack Incoming Webhook, GitHub App receiver,
-or Project v2 event listener.
+`needs-human-review` to a Slack review notification from GitHub Actions. This
+version intentionally uses only GitHub Actions, Slack, and Warp/Oz. It does not
+require a separate server, webhook bridge, Slack Incoming Webhook, GitHub App
+receiver, or Project v2 event listener.
 
 The durable Stage 5 decision remains the GitHub issue comment and Project/label
 updates performed by `duumbi-human-acceptance`.
@@ -17,22 +17,21 @@ updates performed by `duumbi-human-acceptance`.
    `issues.labeled` event when the added label is `needs-human-review`.
 4. The workflow also runs hourly as a scheduled sweep for open
    `needs-human-review` issues that were not already notified.
-5. The read-only notification job starts `warpdotdev/oz-agent-action` with
-   `WARP_API_KEY`.
-6. Oz uses the configured Warp/Oz Slack integration to notify the DUUMBI
-   reviewer. The workflow prompt names the `duumbi-vault-knowledge-env`
-   environment and its environment ID `eKLEWjD4PNqFC6j0EcDEYA`; it does not pass
-   that value as an Oz agent profile.
-7. After Oz succeeds, a separate marker job writes an operational marker comment
-   to the issue so future scheduled sweeps do not send duplicate notifications.
+5. The read-only notification job posts one Slack message per issue with the
+   Slack Web API `chat.postMessage`.
+6. The Slack message tells the reviewer to reply in-thread with
+   `@Oz accepted: <short rationale>`.
+7. After Slack posting succeeds, a separate marker job writes an operational
+   marker comment to the issue so future scheduled sweeps do not send duplicate
+   notifications.
 8. The reviewer replies in Slack with:
 
 ```text
 @Oz accepted: <short rationale>
 ```
 
-9. Warp/Oz Slack integration runs in the `duumbi-vault-knowledge-env`
-   environment and executes:
+9. The inbound Warp/Oz Slack integration handles the reviewer reply and runs in
+   the `duumbi-vault-knowledge-env` environment:
 
 ```text
 Run DUUMBI Stage 5 Human Acceptance with duumbi-human-acceptance.
@@ -75,10 +74,17 @@ The marker is operational state only. It is not the Stage 5 decision record.
 
 ### GitHub Actions
 
-- `WARP_API_KEY`: Warp/Oz API key used by `warpdotdev/oz-agent-action`.
+- `SLACK_BOT_TOKEN`: Slack bot token with permission to post in the review
+  channel.
+- `SLACK_REVIEW_CHANNEL_ID`: Slack channel ID where review notifications should
+  be posted, for example the ID of `#duumbi-ops`.
 
-No `SLACK_WEBHOOK_URL` is required. Slack delivery is handled by the configured
-Warp/Oz Slack integration, visible in Slack under Apps -> Warp.
+No `SLACK_WEBHOOK_URL` is required. The workflow uses the Slack Web API directly
+from GitHub Actions. The Slack bot must be invited to the target review channel.
+
+The Warp/Oz Slack integration, visible in Slack under Apps -> Warp, remains
+required for the reviewer reply path: a human replies with
+`@Oz accepted: <short rationale>`, and that inbound Slack mention starts Oz.
 
 `duumbi-vault-knowledge-env` is an Oz environment, not an agent profile. Its
 environment ID is:
@@ -87,13 +93,12 @@ environment ID is:
 eKLEWjD4PNqFC6j0EcDEYA
 ```
 
-Do not pass the environment name through the action's `profile` input. That
+Do not pass the environment name through the Oz action's `profile` input. That
 input expects an agent profile and fails with `Agent profile "... " not found`
 when given the environment name.
 
-The Oz notification job uses `issues: read`. A separate marker job uses
-`issues: write` only after the Oz notification job succeeds, so Oz does not run
-with an issue-write-capable `GITHUB_TOKEN`.
+The Slack notification job uses `issues: read`. A separate marker job uses
+`issues: write` only after Slack posting succeeds.
 
 ## Manual Test
 
@@ -103,23 +108,23 @@ Run the workflow from GitHub Actions with:
 - `issue_number`: the matching issue number.
 - `status`: `Needs Human Acceptance`.
 
-Expected result: the workflow starts an Oz run, and Oz notifies the configured
-DUUMBI reviewer through Slack, then writes the notification marker comment. If
-`status` is any other value, the workflow exits without starting Oz.
+Expected result: the workflow posts a Slack notification to
+`SLACK_REVIEW_CHANNEL_ID`, then writes the notification marker comment. If
+`status` is any other value, the workflow exits without posting Slack.
 
 ## End-to-End Test
 
 1. Add the `needs-human-review` label to a test issue.
 2. Confirm that GitHub Actions runs `Human Acceptance Request`.
-3. Confirm that the workflow starts an Oz run.
-4. Confirm that the Warp app posts or delivers the Slack notification.
-5. Reply in Slack with:
+3. Confirm that the workflow posts a Slack notification.
+4. Reply in the Slack notification thread with:
 
 ```text
 @Oz accepted: <short rationale>
 ```
 
-6. Confirm that Oz routes the acceptance run to `duumbi-vault-knowledge-env`.
+6. Confirm that inbound Oz routes the acceptance run to
+   `duumbi-vault-knowledge-env`.
 7. Confirm that the issue receives the notification marker comment.
 8. Confirm that the issue receives a Stage 5 decision comment, is moved to
    `Spec Needed`, gets `accepted` and `needs-spec`, and loses
@@ -130,7 +135,8 @@ DUUMBI reviewer through Slack, then writes the notification marker comment. If
 1. Create or select an open test issue with `needs-human-review`.
 2. Ensure it does not contain the notification marker comment.
 3. Wait for the next hourly scheduled run.
-4. Confirm that Oz starts and a notification marker comment is added.
+4. Confirm that a Slack notification is posted and a notification marker comment
+   is added.
 5. Confirm that a later scheduled run skips the same issue because the marker is
    present.
 6. If more than 10 unnotified issues exist, confirm that only 10 are processed in


### PR DESCRIPTION
Fixes the current Human Acceptance Request delivery gap.\n\nRoot cause observed from the latest Oz run:\n- The Warp/Oz Slack integration is inbound-only.\n- Oz cannot proactively create outbound Slack notifications from a GitHub-triggered agent run.\n\nChanges:\n- remove the Oz action from the notification path\n- post review notifications from GitHub Actions through Slack Web API `chat.postMessage`\n- require GitHub secrets `SLACK_BOT_TOKEN` and `SLACK_REVIEW_CHANNEL_ID`\n- keep inbound Oz for reviewer replies: `@Oz accepted: <short rationale>`\n- keep marker comments only after Slack posting succeeds\n- update docs to match the real Slack/Oz capability boundary\n\nValidation run:\n- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/human-acceptance-request.yml")'