### PR TITLE
Clarify Project v2 human acceptance updates

### DIFF
--- a/.agents/skills/duumbi-human-acceptance/SKILL.md
+++ b/.agents/skills/duumbi-human-acceptance/SKILL.md
@@ -65,6 +65,24 @@ Before preparing the brief or applying a decision, inspect:
 
 Do not claim duplicate, accepted, blocked, deferred, closed, or in-progress status unless verified from GitHub.
 
+## Project V2 Status Verification
+
+GitHub issue sidebar project membership is a GitHub Projects v2 item. Before
+reporting that an issue has no project item, verify it with GitHub data that can
+see Projects v2, for example `gh issue view <number> --json projectItems` or an
+equivalent GraphQL query.
+
+If `projectItems` shows a project item:
+
+- treat the project item as present, even if another API path did not find it
+- update the Status field on that Project v2 item when the target status option
+  exists
+- if the status update fails, report it as a Project v2 permission/API update
+  failure, not as "no project item attached"
+
+Only report "no project item attached" when a Projects v2-capable read verifies
+that no relevant project item exists.
+
 ## Acceptance Brief
 
 If no explicit human decision is present, prepare a brief and stop before writing status or label changes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,16 +32,18 @@ jobs:
           git fetch --no-tags --depth=1 origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
           changed_files="$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD)"
 
+          rust_relevant_pattern='^(src/|tests/|crates/|runtime/|Cargo\.toml$|Cargo\.lock$|\.cargo/|rust-toolchain(\.toml)?$|rustfmt\.toml$|clippy\.toml$|\.github/workflows/(ci|coverage)\.yml$)'
+
           if [[ -z "$changed_files" ]]; then
             echo "run_rust_checks=true" >> "$GITHUB_OUTPUT"
-          elif printf '%s\n' "$changed_files" | grep -Ev '^(docs/|specs/)' >/dev/null; then
+          elif printf '%s\n' "$changed_files" | grep -E "$rust_relevant_pattern" >/dev/null; then
             echo "run_rust_checks=true" >> "$GITHUB_OUTPUT"
           else
             echo "run_rust_checks=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Documentation-only check
         if: steps.scope.outputs.run_rust_checks == 'false'
-        run: echo "Only docs/specs changed; Rust checks are not required for this PR."
+        run: echo "No Rust-relevant files changed; Rust checks are not required for this PR."
       - uses: dtolnay/rust-toolchain@stable
         if: steps.scope.outputs.run_rust_checks == 'true'
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,10 +3,33 @@ name: Coverage
 on:
   push:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'crates/**'
+      - 'runtime/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.cargo/**'
+      - 'rust-toolchain'
+      - 'rust-toolchain.toml'
+      - 'rustfmt.toml'
+      - 'clippy.toml'
+      - '.github/workflows/coverage.yml'
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - 'specs/**'
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'crates/**'
+      - 'runtime/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.cargo/**'
+      - 'rust-toolchain'
+      - 'rust-toolchain.toml'
+      - 'rustfmt.toml'
+      - 'clippy.toml'
+      - '.github/workflows/coverage.yml'
 
 env:
   CARGO_TERM_COLOR: always

--- a/docs/automation/human-acceptance-slack-gate.md
+++ b/docs/automation/human-acceptance-slack-gate.md
@@ -130,6 +130,16 @@ Expected result: the workflow posts a Slack notification to
    `Spec Needed`, gets `accepted` and `needs-spec`, and loses
    `needs-human-review` when that label is present.
 
+If labels update but the Project status does not, verify the issue's Projects v2
+item with:
+
+```sh
+gh issue view <number> --repo hgahub/duumbi --json projectItems
+```
+
+If `projectItems` contains `Duumbi project`, the item exists and the failure is a
+Project v2 status-update permission/API issue, not missing project membership.
+
 ## Scheduled Sweep Test
 
 1. Create or select an open test issue with `needs-human-review`.


### PR DESCRIPTION
## Summary
- Document that Project v2 membership must be verified with a Projects v2-capable read before reporting no project item
- Clarify troubleshooting when labels update but Project status does not
- Treat Project status update failures as permission/API update failures when the item exists

## Test Plan
- Documentation/skill-only change; no runtime tests run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Project V2 verification procedures, specifying how to confirm project item presence and distinguish between missing attachments versus permission or API failures for status updates
  * Added troubleshooting guide for cases where issue label updates fail to trigger Project v2 status synchronization, with verification instructions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hgahub/duumbi/pull/574?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->