### PR TITLE
Add Spec Review Slack workflow (Stage 7 duumbi-spec-review)

### DIFF
--- a/.github/workflows/spec-review-request.yml
+++ b/.github/workflows/spec-review-request.yml
@@ -1,0 +1,341 @@
+name: Spec Review Request
+
+on:
+  issues:
+    types: [labeled]
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+    inputs:
+      issue_url:
+        description: GitHub issue URL to request product spec review for
+        required: true
+        type: string
+      issue_number:
+        description: GitHub issue number
+        required: true
+        type: number
+      status:
+        description: Product spec review status
+        required: false
+        default: Spec Review
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: spec-review-${{ github.event.issue.number || inputs.issue_number || github.event_name }}
+  cancel-in-progress: false
+
+jobs:
+  notify:
+    name: Notify Slack
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      issue_numbers: ${{ steps.request.outputs.issue_numbers }}
+      should_notify: ${{ steps.request.outputs.should_notify }}
+    steps:
+      - name: Validate request and build Slack payload
+        id: request
+        uses: actions/github-script@v9
+        env:
+          INPUT_ISSUE_URL: ${{ inputs.issue_url || '' }}
+          INPUT_ISSUE_NUMBER: ${{ inputs.issue_number || '' }}
+          INPUT_STATUS: ${{ inputs.status || '' }}
+        with:
+          script: |
+            const marker = "<!-- duumbi-spec-review-slack-notified -->";
+            const maxScheduledIssues = 10;
+            const ozEnvironmentName = "duumbi-vault-knowledge-env";
+            const ozEnvironmentId = "eKLEWjD4PNqFC6j0EcDEYA";
+            const status = String(process.env.INPUT_STATUS || "Spec Review").trim();
+            const sanitizePromptField = (value) => String(value ?? "")
+              .replace(/```/g, "'''")
+              .replace(/`/g, "'")
+              .replace(/[\r\n]+/g, " ")
+              .trim();
+            const sanitizeSlackField = (value) => sanitizePromptField(value)
+              .replace(/&/g, "&amp;")
+              .replace(/</g, "&lt;")
+              .replace(/>/g, "&gt;")
+              .replace(/@/g, "@\u200b");
+            const labelsFor = (issue) => issue.labels
+              .map((label) => typeof label === "string" ? label : label.name)
+              .filter(Boolean);
+            const issueUrlFor = (number) => `https://github.com/${context.repo.owner}/${context.repo.repo}/issues/${number}`;
+
+            const hasNotificationMarker = async (issueNumber) => {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                per_page: 100,
+              });
+              return comments.some((comment) => comment.body?.includes(marker));
+            };
+
+            const fetchIssue = async (issueNumber) => {
+              const { data: issue } = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+              });
+              return issue;
+            };
+
+            const validateIssueUrl = (issueUrl, issueNumber) => {
+              const issueMatch = issueUrl.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)$/);
+              if (!issueMatch) {
+                throw new Error(`Invalid issue_url: ${issueUrl}`);
+              }
+              if (issueMatch[1] !== context.repo.owner || issueMatch[2] !== context.repo.repo) {
+                throw new Error(`Issue URL must belong to ${context.repo.owner}/${context.repo.repo}: ${issueUrl}`);
+              }
+              if (Number.parseInt(issueMatch[3], 10) !== issueNumber) {
+                throw new Error(`issue_url and issue_number do not match: ${issueUrl} vs ${issueNumber}`);
+              }
+            };
+
+            const findSpecArtifact = async (issueNumber) => {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                per_page: 100,
+              });
+
+              const stage6Comment = comments.find((comment) =>
+                /Stage 6 Product Spec Draft/i.test(comment.body || "")
+              );
+
+              if (!stage6Comment) {
+                return "<missing: Stage 6 Product Spec Draft comment link>";
+              }
+
+              const body = stage6Comment.body || "";
+              const urlMatch = body.match(/https:\/\/github\.com\/[^\s)]+/i);
+              if (urlMatch) {
+                return urlMatch[0].replace(/[\]>.,;]+$/, "");
+              }
+
+              return stage6Comment.html_url;
+            };
+
+            const reviewPromptFor = (issueUrl, specArtifact) => [
+              "Run DUUMBI Stage 7 Product Spec Review with duumbi-spec-review.",
+              "",
+              `Target issue: ${issueUrl}`,
+              `Product spec artifact: ${specArtifact}`,
+              "Human decision: Approve",
+              "Reviewer source: Slack",
+              "Rationale: Reviewed and approved the PRODUCT spec; it is clear enough to proceed to technical specification.",
+              "",
+              "Goal: Review the product spec including BDD scenario clarity/testability, record the structured Stage 7 decision, set the issue to Technical Spec Needed, remove needs-spec, and add product-spec-approved and needs-tech-spec.",
+              "",
+              "If needed, fix the code review message so the decision is explicit and complete, and set the resolved flag.",
+              "Do not create a technical spec or implementation changes.",
+            ].join("\n");
+
+            const buildSlackMessage = (issue, triggeredBy, specArtifact) => {
+              const issueUrl = issue.html_url || issueUrlFor(issue.number);
+              const labelNames = labelsFor(issue);
+              const labels = labelNames.join(", ") || "none";
+              const title = sanitizeSlackField(issue.title);
+              const safeLabels = sanitizeSlackField(labels);
+              const safeTriggeredBy = sanitizeSlackField(triggeredBy);
+              const correlationId = `${context.runId}-${issue.number}`;
+              const reviewPrompt = reviewPromptFor(issueUrl, specArtifact);
+
+              return {
+                text: `DUUMBI issue #${issue.number} needs product spec review approval: ${title}`,
+                blocks: [
+                  {
+                    type: "section",
+                    text: {
+                      type: "mrkdwn",
+                      text: `*DUUMBI issue needs product spec review approval*\n*Issue:* <${issueUrl}|#${issue.number} ${title}>\n*Spec artifact:* <${specArtifact}|Stage 6 Product Spec Draft>\n*Trigger:* \`spec-review\` label\n*Status:* Spec Review\n*Labels:* ${safeLabels}\n*Triggered by:* ${safeTriggeredBy}\n*Correlation:* \`${correlationId}\``,
+                    },
+                  },
+                  {
+                    type: "section",
+                    text: {
+                      type: "mrkdwn",
+                      text: "*Reply in this thread with `@Oz approve: <short rationale>`*",
+                    },
+                  },
+                  {
+                    type: "section",
+                    text: {
+                      type: "mrkdwn",
+                      text: `When approving, Oz must run in the \`${ozEnvironmentName}\` environment with ID \`${ozEnvironmentId}\` and this prompt:\n\`\`\`text\n${reviewPrompt}\n\`\`\``,
+                    },
+                  },
+                ],
+              };
+            };
+
+            let issuesToNotify = [];
+            let triggeredBy = context.actor || "unknown";
+
+            if (context.eventName === "schedule") {
+              const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: "open",
+                labels: "spec-review",
+                per_page: 100,
+              });
+
+              for (const issue of openIssues) {
+                if (issue.pull_request) continue;
+                const labelNames = labelsFor(issue);
+                if (labelNames.includes("product-spec-approved") || labelNames.includes("needs-tech-spec")) continue;
+                if (await hasNotificationMarker(issue.number)) continue;
+                issuesToNotify.push(issue);
+                if (issuesToNotify.length >= maxScheduledIssues) {
+                  core.info(`Scheduled sweep capped at ${maxScheduledIssues} issues for this run.`);
+                  break;
+                }
+              }
+              triggeredBy = "scheduled sweep";
+            } else {
+              const payload = context.eventName === "workflow_dispatch"
+                ? {
+                    issue_url: process.env.INPUT_ISSUE_URL,
+                    issue_number: Number(process.env.INPUT_ISSUE_NUMBER || 0),
+                    status,
+                    triggered_by: context.actor,
+                  }
+                : {
+                    issue_url: context.payload.issue?.html_url,
+                    issue_number: Number(context.payload.issue?.number || 0),
+                    status: "Spec Review",
+                    triggered_by: context.payload.sender?.login || context.actor,
+                    label: context.payload.label?.name,
+                  };
+
+              if (context.eventName === "issues" && payload.label !== "spec-review") {
+                core.info(`Ignoring label "${payload.label}".`);
+                core.setOutput("should_notify", "false");
+                return;
+              }
+
+              if (payload.status !== "Spec Review") {
+                core.info(`Ignoring request because status is "${payload.status}".`);
+                core.setOutput("should_notify", "false");
+                return;
+              }
+
+              const issueNumber = payload.issue_number;
+              const issueUrl = String(payload.issue_url || "").trim();
+              if (!Number.isInteger(issueNumber) || issueNumber < 1) {
+                core.setFailed(`Invalid issue_number: ${payload.issue_number}`);
+                return;
+              }
+              try {
+                validateIssueUrl(issueUrl, issueNumber);
+              } catch (error) {
+                core.setFailed(error.message);
+                return;
+              }
+
+              issuesToNotify.push(await fetchIssue(issueNumber));
+              triggeredBy = String(payload.triggered_by || context.actor || "unknown");
+            }
+
+            if (issuesToNotify.length === 0) {
+              core.info("No unnotified issues need product spec review.");
+              core.setOutput("should_notify", "false");
+              return;
+            }
+
+            const slackMessages = [];
+            for (const issue of issuesToNotify) {
+              const specArtifact = await findSpecArtifact(issue.number);
+              slackMessages.push(buildSlackMessage(issue, triggeredBy, specArtifact));
+            }
+
+            core.setOutput("slack_messages", JSON.stringify(slackMessages));
+            core.setOutput("issue_numbers", JSON.stringify(issuesToNotify.map((issue) => issue.number)));
+            core.setOutput("should_notify", "true");
+
+      - name: Post Slack notifications
+        if: success() && steps.request.outputs.should_notify == 'true'
+        uses: actions/github-script@v9
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_REVIEW_CHANNEL_ID: ${{ secrets.SLACK_REVIEW_CHANNEL_ID }}
+          SLACK_MESSAGES: ${{ steps.request.outputs.slack_messages }}
+        with:
+          script: |
+            const token = process.env.SLACK_BOT_TOKEN;
+            const channel = process.env.SLACK_REVIEW_CHANNEL_ID;
+            const messages = JSON.parse(process.env.SLACK_MESSAGES || "[]");
+
+            if (!token) {
+              core.setFailed("SLACK_BOT_TOKEN is not configured.");
+              return;
+            }
+            if (!channel) {
+              core.setFailed("SLACK_REVIEW_CHANNEL_ID is not configured.");
+              return;
+            }
+
+            for (const message of messages) {
+              const response = await fetch("https://slack.com/api/chat.postMessage", {
+                method: "POST",
+                headers: {
+                  Authorization: `Bearer ${token}`,
+                  "Content-Type": "application/json; charset=utf-8",
+                },
+                body: JSON.stringify({
+                  channel,
+                  ...message,
+                }),
+              });
+              const body = await response.json();
+              if (!response.ok || !body.ok) {
+                core.setFailed(`Slack chat.postMessage failed: ${body.error || response.status}`);
+                return;
+              }
+              core.info(`Posted Slack notification ts=${body.ts}`);
+            }
+
+  mark-notified:
+    name: Mark notified issues
+    needs: notify
+    if: success() && needs.notify.outputs.should_notify == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Mark notified issues
+        uses: actions/github-script@v9
+        env:
+          ISSUE_NUMBERS: ${{ needs.notify.outputs.issue_numbers }}
+          MARKER: <!-- duumbi-spec-review-slack-notified -->
+        with:
+          script: |
+            const issueNumbers = JSON.parse(process.env.ISSUE_NUMBERS || "[]");
+            const marker = process.env.MARKER;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            for (const issueNumber of issueNumbers) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: [
+                  marker,
+                  "Product spec review Slack notification requested through Oz.",
+                  "",
+                  `Workflow run: ${runUrl}`,
+                  `Source event: ${context.eventName}`,
+                ].join("\n"),
+              });
+            }


### PR DESCRIPTION
### Motivation
- Add a Stage 7 product spec review notification flow that mirrors the existing Human Acceptance workflow but triggers on the `spec-review` label and drives `duumbi-spec-review` (Stage 7) instead of Stage 5.
- Ensure Oz receives a Stage 7 prompt that includes the Stage 6 product spec artifact link so an explicit human approval in Slack can cause the agent to write the structured Stage 7 decision and update issue state/labels.

### Description
- Adds a new GitHub Action workflow at `.github/workflows/spec-review-request.yml` that triggers on the `spec-review` label, a scheduled sweep, and `workflow_dispatch` with `Spec Review` status.
- Builds and posts Slack notifications instructing reviewers to reply with `@Oz approve: <short rationale>` and embeds a Stage 7 prompt that tells Oz to run `duumbi-spec-review`, set Project Status to `Technical Spec Needed`, remove `needs-spec`, and add `product-spec-approved` and `needs-tech-spec` (while not creating technical specs or implementation changes).
- Extracts the Stage 6 product spec artifact by scanning issue comments for a comment containing `Stage 6 Product Spec Draft` and prefers an explicit GitHub URL in that comment (falls back to the comment URL if no URL found).
- Adds an idempotent notification marker (`<!-- duumbi-spec-review-slack-notified -->`) to avoid duplicate Slack alerts during scheduled sweeps.

### Testing
- Validated the workflow YAML by parsing it with Ruby using `YAML.load_file('.github/workflows/spec-review-request.yml')`, which succeeded.
- Inspected the created workflow file contents with a paginated file listing (`nl`) to verify the embedded prompt, `spec-review` trigger, artifact-finding logic, and marker were present.
- Attempted to parse with Python `PyYAML` but the environment lacked `PyYAML` (`ModuleNotFoundError`), so that check was not run (environment issue, not a workflow syntax failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d9d2c23e48333ae58af7f70a9b623)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflow for spec review requests that notifies Slack when issues require review and marks them as notified to prevent duplicate alerts.
  * Supports manual triggering, hourly scheduled runs, and label-based activation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hgahub/duumbi/pull/576?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->