### PR TITLE
Implement terminal color fallback policy for #422

### DIFF
--- a/src/cli/theme.rs
+++ b/src/cli/theme.rs
@@ -10,6 +10,8 @@
 //! Both honour `NO_COLOR`/`CLICOLOR` for graceful degradation on terminals
 //! that do not support truecolor.
 
+use std::io::IsTerminal as _;
+
 use owo_colors::OwoColorize;
 
 // ---------------------------------------------------------------------------
@@ -19,57 +21,57 @@ use owo_colors::OwoColorize;
 /// Renders text in red (errors, failures).
 #[must_use]
 pub fn error(text: &str) -> String {
-    format!("{}", text.red().bold())
+    style_if_color_enabled(text, |text| format!("{}", text.red().bold()))
 }
 
 /// Renders text in green (success, pass).
 #[must_use]
 pub fn success(text: &str) -> String {
-    format!("{}", text.green().bold())
+    style_if_color_enabled(text, |text| format!("{}", text.green().bold()))
 }
 
 /// Renders text in yellow (warnings).
 #[must_use]
 #[allow(dead_code)]
 pub fn warning(text: &str) -> String {
-    format!("{}", text.yellow())
+    style_if_color_enabled(text, |text| format!("{}", text.yellow()))
 }
 
 /// Renders text in cyan (informational highlights).
 #[must_use]
 pub fn info(text: &str) -> String {
-    format!("{}", text.cyan())
+    style_if_color_enabled(text, |text| format!("{}", text.cyan()))
 }
 
 /// Renders text in dim/grey (secondary information).
 #[must_use]
 pub fn dim(text: &str) -> String {
-    format!("{}", text.dimmed())
+    style_if_color_enabled(text, |text| format!("{}", text.dimmed()))
 }
 
 /// Renders text in bold (emphasis).
 #[must_use]
 pub fn bold(text: &str) -> String {
-    format!("{}", text.bold())
+    style_if_color_enabled(text, |text| format!("{}", text.bold()))
 }
 
 /// Renders a slash command name in bold cyan.
 #[cfg(test)]
 #[must_use]
 pub fn command(text: &str) -> String {
-    format!("{}", text.cyan().bold())
+    style_if_color_enabled(text, |text| format!("{}", text.cyan().bold()))
 }
 
 /// Renders an error code (e.g. "E001") in bold red.
 #[must_use]
 pub fn error_code(text: &str) -> String {
-    format!("{}", text.red().bold())
+    style_if_color_enabled(text, |text| format!("{}", text.red().bold()))
 }
 
 /// Renders a node ID in blue.
 #[must_use]
 pub fn node_id(text: &str) -> String {
-    format!("{}", text.blue())
+    style_if_color_enabled(text, |text| format!("{}", text.blue()))
 }
 
 /// Renders a check mark in green.
@@ -82,6 +84,45 @@ pub fn check_mark() -> String {
 #[must_use]
 pub fn cross_mark() -> String {
     error("\u{2717}")
+}
+
+fn style_if_color_enabled<F>(text: &str, apply: F) -> String
+where
+    F: FnOnce(&str) -> String,
+{
+    if non_tui_color_enabled() {
+        apply(text)
+    } else {
+        text.to_string()
+    }
+}
+
+fn non_tui_color_enabled() -> bool {
+    let clicolor = std::env::var("CLICOLOR").ok();
+    let clicolor_force = std::env::var("CLICOLOR_FORCE").ok();
+    non_tui_color_enabled_from_env(
+        std::env::var_os("NO_COLOR").is_some(),
+        clicolor.as_deref(),
+        clicolor_force.as_deref(),
+        std::io::stderr().is_terminal(),
+    )
+}
+
+fn non_tui_color_enabled_from_env(
+    no_color: bool,
+    clicolor: Option<&str>,
+    clicolor_force: Option<&str>,
+    stream_is_terminal: bool,
+) -> bool {
+    if no_color || clicolor == Some("0") {
+        return false;
+    }
+
+    if clicolor_force.is_some_and(|value| !value.is_empty() && value != "0") {
+        return true;
+    }
+
+    stream_is_terminal
 }
 
 // ---------------------------------------------------------------------------
@@ -148,18 +189,33 @@ pub mod tui {
     }
 
     fn detect_truecolor() -> bool {
-        if std::env::var_os("NO_COLOR").is_some() {
+        let colorterm = std::env::var("COLORTERM").ok();
+        let term_program = std::env::var("TERM_PROGRAM").ok();
+        detect_truecolor_from_env(
+            std::env::var_os("NO_COLOR").is_some(),
+            colorterm.as_deref(),
+            term_program.as_deref(),
+        )
+    }
+
+    pub(super) fn detect_truecolor_from_env(
+        no_color: bool,
+        colorterm: Option<&str>,
+        term_program: Option<&str>,
+    ) -> bool {
+        if no_color {
             return false;
         }
-        match std::env::var("COLORTERM") {
-            Ok(v) => {
-                let lower = v.to_lowercase();
+
+        match colorterm {
+            Some(value) => {
+                let lower = value.to_lowercase();
                 lower.contains("truecolor") || lower.contains("24bit")
             }
-            Err(_) => {
+            None => {
                 // Common modern terminals (kitty, wezterm, alacritty, vscode)
                 // export `TERM_PROGRAM` even without COLORTERM.
-                std::env::var("TERM_PROGRAM").is_ok()
+                term_program.is_some()
             }
         }
     }
@@ -581,6 +637,25 @@ mod tests {
     }
 
     #[test]
+    fn non_tui_color_policy_honors_no_color_and_capture() {
+        assert!(!non_tui_color_enabled_from_env(true, None, Some("1"), true));
+        assert!(!non_tui_color_enabled_from_env(
+            false,
+            Some("0"),
+            Some("1"),
+            true
+        ));
+        assert!(!non_tui_color_enabled_from_env(false, None, None, false));
+        assert!(non_tui_color_enabled_from_env(
+            false,
+            None,
+            Some("1"),
+            false
+        ));
+        assert!(non_tui_color_enabled_from_env(false, None, None, true));
+    }
+
+    #[test]
     fn check_and_cross_contain_unicode() {
         // The raw strings contain the Unicode characters (possibly wrapped in ANSI)
         let cm = check_mark();
@@ -649,6 +724,28 @@ mod tests {
         assert_eq!(tui::fallback(tui::HAIRLINE_DIM), Color::Gray);
         assert_eq!(tui::fallback(tui::TOKEN_STRING), Color::Green);
         assert_eq!(tui::fallback(tui::TOKEN_URL), Color::Yellow);
+    }
+
+    #[test]
+    fn truecolor_detection_is_deterministic_from_env_snapshot() {
+        assert!(!tui::detect_truecolor_from_env(
+            true,
+            Some("truecolor"),
+            Some("vscode")
+        ));
+        assert!(!tui::detect_truecolor_from_env(false, None, None));
+        assert!(tui::detect_truecolor_from_env(
+            false,
+            Some("truecolor"),
+            None
+        ));
+        assert!(tui::detect_truecolor_from_env(false, Some("24bit"), None));
+        assert!(tui::detect_truecolor_from_env(false, None, Some("vscode")));
+        assert!(!tui::detect_truecolor_from_env(
+            false,
+            Some("256color"),
+            None
+        ));
     }
 
     #[test]

--- a/src/cli/theme.rs
+++ b/src/cli/theme.rs
@@ -7,8 +7,12 @@
 //! - The [`tui`] submodule returns `ratatui::Style` values for the full-screen
 //!   REPL, using the brand-aligned dark palette (rust + parchment + blue ink).
 //!
-//! Both honour `NO_COLOR`/`CLICOLOR` for graceful degradation on terminals
-//! that do not support truecolor.
+//! Non-TUI helpers disable ANSI styling when `NO_COLOR` is set,
+//! `CLICOLOR=0` is set, or stderr is not a terminal. `CLICOLOR_FORCE` with a
+//! non-empty, non-zero value re-enables ANSI styling for captured output unless
+//! `NO_COLOR` or `CLICOLOR=0` explicitly disable it. TUI helpers use truecolor
+//! only when the environment advertises support and otherwise fall back to
+//! named ANSI colors.
 
 use std::io::IsTerminal as _;
 
@@ -118,6 +122,8 @@ fn non_tui_color_enabled_from_env(
         return false;
     }
 
+    // `CLICOLOR_FORCE` intentionally overrides captured-output detection, but
+    // not the explicit opt-out variables handled above.
     if clicolor_force.is_some_and(|value| !value.is_empty() && value != "0") {
         return true;
     }
@@ -198,6 +204,13 @@ pub mod tui {
         )
     }
 
+    /// Determines whether truecolor (24-bit) styling should be enabled from
+    /// environment snapshots.
+    ///
+    /// `no_color` is the explicit opt-out flag, `colorterm` is the sampled
+    /// `COLORTERM` value, and `term_program` is the sampled `TERM_PROGRAM`
+    /// value. Returns `true` when the environment indicates truecolor support.
+    #[must_use]
     pub(super) fn detect_truecolor_from_env(
         no_color: bool,
         colorterm: Option<&str>,

--- a/tests/integration_phase16_color.rs
+++ b/tests/integration_phase16_color.rs
@@ -1,0 +1,67 @@
+//! Phase 16 terminal color fallback integration tests.
+
+use std::path::Path;
+use std::process::Command;
+
+fn duumbi_check_output(no_color: bool) -> std::process::Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_duumbi"));
+    command
+        .args([
+            "check",
+            Path::new("tests")
+                .join("fixtures")
+                .join("fibonacci.jsonld")
+                .to_str()
+                .expect("invariant: fixture path must be valid UTF-8"),
+        ])
+        .env_remove("CLICOLOR")
+        .env_remove("CLICOLOR_FORCE");
+
+    if no_color {
+        command.env("NO_COLOR", "1");
+    } else {
+        command.env_remove("NO_COLOR");
+    }
+
+    command
+        .output()
+        .expect("invariant: duumbi binary must be runnable")
+}
+
+fn contains_ansi_escape(output: &str) -> bool {
+    output.contains("\x1b[")
+}
+
+#[test]
+fn no_color_check_output_has_no_ansi_escapes() {
+    let output = duumbi_check_output(true);
+    assert!(
+        output.status.success(),
+        "duumbi check should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Validation passed"));
+    assert!(
+        !contains_ansi_escape(&stderr),
+        "NO_COLOR output must not contain ANSI escapes: {stderr:?}"
+    );
+}
+
+#[test]
+fn captured_check_output_has_no_raw_ansi_escapes() {
+    let output = duumbi_check_output(false);
+    assert!(
+        output.status.success(),
+        "duumbi check should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Validation passed"));
+    assert!(
+        !contains_ansi_escape(&stderr),
+        "captured output must not contain ANSI escapes: {stderr:?}"
+    );
+}


### PR DESCRIPTION
Related to #422

## Summary
- Route non-TUI CLI theme helpers through terminal-aware color policy.
- Honor NO_COLOR, CLICOLOR=0, CLICOLOR_FORCE, and captured stderr behavior for plain CLI output.
- Add deterministic unit coverage plus integration coverage for the representative duumbi check path.

## Workflow note
This implementation PR must not close the execution issue. Stage 12 closure should happen only after review, merge, and explicit closure coordination.

## Spec links
- Product spec: #575
- Technical spec: #579

## Ralph Cycle Evidence
- Branch: codex/duumbi-422-color-fallback
- Commit: 6002c77
- Files changed: src/cli/theme.rs, tests/integration_phase16_color.rs
- External LLM calls: none
- Estimated external cost: USD 0

## BDD-to-test mapping
- Scenario: NO_COLOR disables ANSI styling for representative non-TUI output -> tests/integration_phase16_color.rs::no_color_check_output_has_no_ansi_escapes
- Scenario: captured output does not leak raw ANSI escapes -> tests/integration_phase16_color.rs::captured_check_output_has_no_raw_ansi_escapes
- Scenario: color policy remains deterministic for environment snapshots -> src/cli/theme.rs::tests::non_tui_color_policy_honors_no_color_and_capture
- Scenario: TUI truecolor detection remains isolated and deterministic -> src/cli/theme.rs::tests::truecolor_detection_is_deterministic_from_env_snapshot

## Checks run locally
- cargo fmt --check
- cargo test cli::theme::
- cargo test --test integration_phase16_color
- cargo clippy --all-targets -- -D warnings
- cargo test --all

## Live CI evidence
- check (ubuntu-latest): success
- check (windows-latest): success
- coverage: success
- Docs AI Update Request: success
- Request Copilot Review: success
- CodeRabbit: success

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal color output to properly respect the NO_COLOR environment variable and detect terminal color capabilities based on environment settings.
  * Improved color handling logic for better compatibility across different terminal environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hgahub/duumbi/pull/582?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->