### PR TITLE
docs(windows): document native Windows requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,12 @@ Traditional compilers transform text → AST → machine code. DUUMBI skips the 
 
 ## Install
 
-**Requirements:** Rust stable (1.80+), a C compiler on `$PATH` (`cc` / Xcode CLT / `gcc`).
+**Requirements:**
+
+- Rust stable 1.80+ through `rustup`.
+- macOS: Xcode Command Line Tools or an equivalent C compiler/linker.
+- Linux: `build-essential` or an equivalent C compiler/linker.
+- Windows native: Windows 10 version 1903+ on `x86_64-pc-windows-msvc`, the stable MSVC Rust toolchain, Visual Studio Build Tools or equivalent MSVC C++ tools, Windows SDK, and a usable linker/C compiler environment.
 
 ```bash
 git clone git@github.com:hgahub/duumbi.git
@@ -116,7 +121,9 @@ cargo fmt
 | macOS | aarch64 (Apple Silicon) | Primary |
 | macOS | x86_64 | CI-tested |
 | Linux | x86_64 | CI-tested |
-| Windows | — | Not supported |
+| Windows | x86_64-pc-windows-msvc | Native target; MSVC tools required |
+
+Native Windows builds use the MSVC Rust target and do not require WSL2. The current Windows support boundary does not cover ARM64 Windows, MinGW, Cygwin, GNU Windows toolchains, installers, packaging, or release signing.
 
 ---
 

--- a/sites/docs/src/getting-started/installation.md
+++ b/sites/docs/src/getting-started/installation.md
@@ -3,7 +3,10 @@
 ## Prerequisites
 
 - Rust toolchain (`rustup` recommended): [rustup.rs](https://rustup.rs)
-- A C compiler for linking: `cc` on PATH (Xcode CLT on macOS, `build-essential` on Debian/Ubuntu)
+- A C compiler and linker:
+  - macOS: Xcode Command Line Tools or equivalent
+  - Linux: `build-essential` or equivalent
+  - Windows native: Windows 10 version 1903+ on `x86_64-pc-windows-msvc`, the stable MSVC Rust toolchain, Visual Studio Build Tools or equivalent MSVC C++ tools, Windows SDK, and a usable linker/C compiler environment
 
 ## Install from crates.io
 
@@ -33,5 +36,6 @@ duumbi --version
 | macOS | aarch64 (Apple Silicon) | Primary |
 | macOS | x86_64 | CI-tested |
 | Linux | x86_64 | CI-tested |
+| Windows | x86_64-pc-windows-msvc | Native target; MSVC tools required |
 
-Windows is not supported in the current release.
+Native Windows builds use the MSVC Rust target and do not require WSL2. The current Windows support boundary does not cover ARM64 Windows, MinGW, Cygwin, GNU Windows toolchains, installers, packaging, or release signing.


### PR DESCRIPTION
Related to #423

## Workflow Note

This PR must not close the execution issue. Issue #423 must remain open for Stage 11 review and later closure evidence.

## Summary

- Update `README.md` Windows requirements and supported-platforms guidance.
- Update `sites/docs/src/getting-started/installation.md` with matching native Windows setup guidance.
- Document Windows 10 version 1903+, `x86_64-pc-windows-msvc`, stable MSVC Rust, Visual Studio Build Tools or equivalent MSVC C++ tools, Windows SDK/linker setup, WSL2 not required, and unsupported Windows variants.

## Specs

- Product spec: `specs/DUUMBI-423/PRODUCT.md` via PR #578
- Technical spec: `specs/DUUMBI-423/TECHNICAL.md` via PR #581

## Ralph Cycle Evidence

Cycle 1 completed as a low-budget documentation-only Ralph cycle.

Changed files:
- `README.md`
- `sites/docs/src/getting-started/installation.md`

Checks run:
- `git diff --check`: passed
- `git diff --name-only`: limited to the two approved docs files
- stale Windows-negative scan: no matches
- Windows requirements scan: found required Windows version, MSVC target, MSVC prerequisites, Windows SDK, WSL2 boundary, and unsupported-target terms in both docs surfaces
- `mdbook build sites/docs`: not run because `mdbook` is not installed locally; no tooling was installed during the cycle

## Boundary Evidence

- #420 remains the Windows CI baseline; no CI files changed under this PR.
- #422 remains the terminal color fallback implementation/evidence source; no terminal behavior files or tests changed under this PR.
- This PR changes only Windows requirements documentation and does not modify Rust source, tests, CI, generated artifacts, runtime assets, product specs, or technical specs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guides with platform-specific system requirements for macOS, Linux, and Windows.
  * Clarified Windows support details and build constraints, specifying MSVC toolchain requirements and native-build expectations.
  * Explicitly documented unsupported Windows configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hgahub/duumbi/pull/589?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->