### PR TITLE
feat(workflow): replace LLM-based approval with deterministic Slack buttons + GitHub Action

### DIFF
--- a/.agents/skills/duumbi-human-acceptance/SKILL.md
+++ b/.agents/skills/duumbi-human-acceptance/SKILL.md
@@ -53,6 +53,18 @@ Use this skill for:
 
 Do not process broad sweeps in this skill. Handle one issue and one explicit decision at a time.
 
+## Acceptance Fast Path
+
+When the prompt contains an explicit human decision (e.g. `Human decision: Accept`, or a Slack message like `accepted: issue: #N`) AND an issue number is identifiable, skip the full acceptance brief and execute the decision directly:
+
+1. `gh issue view <N> --json number,title,labels,body` — verify `needs-human-review` label is present
+2. Construct and post the Stage 5 Human Acceptance Decision Comment on the issue
+3. Update labels: remove `needs-human-review`, add `accepted` and `needs-spec`
+4. Attempt Project V2 status update to `Spec Needed`
+5. Report the final state
+
+Do NOT prepare an acceptance brief, inspect triage context, read unrelated skills, or re-fetch content already in context. Use `wait` mode for all `gh`/`git` commands.
+
 ## Context To Inspect
 
 Before preparing the brief or applying a decision, inspect:

--- a/.agents/skills/duumbi-human-acceptance/SKILL.md
+++ b/.agents/skills/duumbi-human-acceptance/SKILL.md
@@ -55,7 +55,7 @@ Do not process broad sweeps in this skill. Handle one issue and one explicit dec
 
 ## Acceptance Fast Path
 
-When the prompt contains an explicit human decision (e.g. `Human decision: Accept`, or a Slack message like `accepted: issue: #N`) AND an issue number is identifiable, skip the full acceptance brief and execute the decision directly:
+When the prompt contains an explicit **Accept** decision (e.g. `Human decision: Accept`, or a Slack message like `accepted: issue: #N`) AND an issue number is identifiable, skip the full acceptance brief and execute the Accept decision directly. For other decisions (Needs Clarification, Duplicate, Defer, Reject), use the full review flow below.
 
 1. `gh issue view <N> --json number,title,labels,body` — verify `needs-human-review` label is present
 2. Construct and post the Stage 5 Human Acceptance Decision Comment on the issue

--- a/.agents/skills/duumbi-spec-review/SKILL.md
+++ b/.agents/skills/duumbi-spec-review/SKILL.md
@@ -57,7 +57,7 @@ If the issue is not in `Spec Review` or the spec artifact is missing, stop and r
 
 ## Approval Fast Path
 
-When the prompt contains an explicit human decision (e.g. `Human decision: Approve`, or a Slack message like `approved: issue: #N`) AND an issue number is identifiable, skip the full review analysis and execute the decision directly:
+When the prompt contains an explicit **Approve** decision (e.g. `Human decision: Approve`, or a Slack message like `approved: issue: #N`) AND an issue number is identifiable, skip the full review analysis and execute the Approve decision directly. For other decisions (Request Changes, Needs Clarification, Reject), use the full review flow below.
 
 1. `gh issue view <N> --json number,title,labels,body` — verify `spec-review` label is present
 2. `gh issue view <N> --comments --json comments` — find the Stage 6 Product Spec Draft artifact link

--- a/.agents/skills/duumbi-spec-review/SKILL.md
+++ b/.agents/skills/duumbi-spec-review/SKILL.md
@@ -55,6 +55,20 @@ Use this skill for one issue that:
 
 If the issue is not in `Spec Review` or the spec artifact is missing, stop and report the missing gate.
 
+## Approval Fast Path
+
+When the prompt contains an explicit human decision (e.g. `Human decision: Approve`, or a Slack message like `approved: issue: #N`) AND an issue number is identifiable, skip the full review analysis and execute the decision directly:
+
+1. `gh issue view <N> --json number,title,labels,body` — verify `spec-review` label is present
+2. `gh issue view <N> --comments --json comments` — find the Stage 6 Product Spec Draft artifact link
+3. Construct and post the Stage 7 Decision Comment on the issue
+4. Post a short pointer comment on the draft PR (if identifiable)
+5. Update labels: remove `needs-spec` and `spec-review`, add `product-spec-approved` and `needs-tech-spec`
+6. Attempt Project V2 status update to `Technical Spec Needed`
+7. Report the final state
+
+Do NOT read the full PRODUCT.md, run the review checklist, read unrelated skills, or re-fetch content already in context. Use `wait` mode for all `gh`/`git` commands.
+
 ## Context To Inspect
 
 Before reviewing:

--- a/.agents/skills/duumbi-tech-spec-review/SKILL.md
+++ b/.agents/skills/duumbi-tech-spec-review/SKILL.md
@@ -60,7 +60,7 @@ If the issue is not in `Technical Spec Review`, the approved product spec is mis
 
 ## Approval Fast Path
 
-When the prompt contains an explicit human decision (e.g. `Human decision: Approve`, or a Slack message like `approved: issue: #N, PR: #M`) AND an issue number is identifiable, skip the full review analysis and execute the decision directly:
+When the prompt contains an explicit **Approve** decision (e.g. `Human decision: Approve`, or a Slack message like `approved: issue: #N, PR: #M`) AND an issue number is identifiable, skip the full review analysis and execute the Approve decision directly. For other decisions (Request Changes, Needs Clarification, Reject), use the full review flow below.
 
 1. `gh issue view <N> --json number,title,labels,body` — verify `technical-spec-review` label is present
 2. `gh issue view <N> --comments --json comments` — find the Stage 8 Technical Spec Draft artifact link and product spec link from existing comments (search for "Stage 8 Technical Spec Draft" and "Stage 6 Product Spec Draft")

--- a/.agents/skills/duumbi-tech-spec-review/SKILL.md
+++ b/.agents/skills/duumbi-tech-spec-review/SKILL.md
@@ -58,6 +58,28 @@ Use this skill for one issue that:
 
 If the issue is not in `Technical Spec Review`, the approved product spec is missing, or the technical spec draft PR is missing, stop and report the missing gate.
 
+## Approval Fast Path
+
+When the prompt contains an explicit human decision (e.g. `Human decision: Approve`, or a Slack message like `approved: issue: #N, PR: #M`) AND an issue number is identifiable, skip the full review analysis and execute the decision directly:
+
+1. `gh issue view <N> --json number,title,labels,body` — verify `technical-spec-review` label is present
+2. `gh issue view <N> --comments --json comments` — find the Stage 8 Technical Spec Draft artifact link and product spec link from existing comments (search for "Stage 8 Technical Spec Draft" and "Stage 6 Product Spec Draft")
+3. Construct and post the Stage 9 Decision Comment on the issue (use the Decision Comment template below)
+4. Post a short pointer comment on the tech spec PR (if identifiable from the artifact URL)
+5. Update labels: remove `needs-tech-spec` and `technical-spec-review`, add `tech-spec-approved`
+6. Attempt Project V2 status update to `Ready for Build` (if `GH_PROJECT_PAT` is available, use `GH_TOKEN=$GH_PROJECT_PAT gh api graphql`; otherwise skip and note in the report)
+7. Report the final state
+
+Do NOT:
+- Read the full TECHNICAL.md content (the human already reviewed and approved it)
+- Run the review checklist
+- Read unrelated skills (e.g. `duumbi-review-artifact`)
+- Use interact-mode subagents for simple `gh` or `git` commands
+- Fetch TECHNICAL.md more than once
+- List all repository labels
+
+This fast path applies when the decision is already explicit. If the prompt asks for a review (no decision present), use the full review flow below.
+
 ## Context To Inspect
 
 Before reviewing:
@@ -74,6 +96,13 @@ Before reviewing:
 - source code and tests only when needed to evaluate affected areas, constraints, invariants, verification, cycle boundaries, or implementation risk
 
 Do not claim GitHub status, source feasibility, affected areas, test coverage, or duplicate coverage unless verified.
+
+## Efficiency Rules
+
+- Use `wait` mode shell commands for non-interactive operations like `git show` and `gh` queries. Do NOT use `interact` mode for simple git/gh commands.
+- Batch independent queries in parallel when possible (e.g., issue view + PR view in a single tool call).
+- Read TECHNICAL.md at most once. Do not re-fetch content already in context.
+- Do not read skills unrelated to the current stage. If the issue label says `technical-spec-review`, use only `duumbi-tech-spec-review`.
 
 ## Review Checklist
 

--- a/.github/workflows/human-acceptance-request.yml
+++ b/.github/workflows/human-acceptance-request.yml
@@ -113,6 +113,8 @@ jobs:
               "Do not create product specs, technical specs, PRs, source-code changes, or implementation branches.",
             ].join("\n");
 
+            const workflowDispatchUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/stage-approval.yml`;
+
             const buildSlackMessage = (issue, triggeredBy) => {
               const issueUrl = issue.html_url || issueUrlFor(issue.number);
               const labelNames = labelsFor(issue);
@@ -121,7 +123,12 @@ jobs:
               const safeLabels = sanitizeSlackField(labels);
               const safeTriggeredBy = sanitizeSlackField(triggeredBy);
               const correlationId = `${context.runId}-${issue.number}`;
-              const acceptancePrompt = acceptancePromptFor(issueUrl);
+
+              const buttonValue = (decision) => JSON.stringify({
+                stage: "5",
+                issue_number: issue.number,
+                decision,
+              });
 
               return {
                 text: `DUUMBI issue #${issue.number} needs human acceptance: ${title}`,
@@ -134,18 +141,51 @@ jobs:
                     },
                   },
                   {
-                    type: "section",
-                    text: {
-                      type: "mrkdwn",
-                      text: "*Reply in this thread with `@Oz accepted: <short rationale>`*",
-                    },
+                    type: "actions",
+                    block_id: `human_acceptance_${issue.number}`,
+                    elements: [
+                      {
+                        type: "button",
+                        text: { type: "plain_text", text: "✅ Accept", emoji: true },
+                        style: "primary",
+                        action_id: "stage_approve",
+                        value: buttonValue("approve"),
+                        confirm: {
+                          title: { type: "plain_text", text: "Accept Issue" },
+                          text: { type: "mrkdwn", text: `Accept issue #${issue.number} for specification?\nThis will set the issue to *Spec Needed*.` },
+                          confirm: { type: "plain_text", text: "Accept" },
+                          deny: { type: "plain_text", text: "Cancel" },
+                        },
+                      },
+                      {
+                        type: "button",
+                        text: { type: "plain_text", text: "❓ Needs Clarification", emoji: true },
+                        action_id: "stage_needs_clarification",
+                        value: buttonValue("needs-clarification"),
+                      },
+                      {
+                        type: "button",
+                        text: { type: "plain_text", text: "🚫 Reject", emoji: true },
+                        style: "danger",
+                        action_id: "stage_reject",
+                        value: buttonValue("reject"),
+                        confirm: {
+                          title: { type: "plain_text", text: "Reject Issue" },
+                          text: { type: "mrkdwn", text: `Reject issue #${issue.number}? This will close the issue.` },
+                          confirm: { type: "plain_text", text: "Reject" },
+                          deny: { type: "plain_text", text: "Cancel" },
+                        },
+                      },
+                    ],
                   },
                   {
-                    type: "section",
-                    text: {
-                      type: "mrkdwn",
-                      text: `When accepting, Oz must run in the \`${ozEnvironmentName}\` environment with ID \`${ozEnvironmentId}\` and this prompt:\n\`\`\`text\n${acceptancePrompt}\n\`\`\``,
-                    },
+                    type: "context",
+                    elements: [
+                      {
+                        type: "mrkdwn",
+                        text: `Buttons require the <${workflowDispatchUrl}|Slack approval bridge>. Fallback: run <${workflowDispatchUrl}|Stage Approval> workflow manually (stage=5, issue=${issue.number}).`,
+                      },
+                    ],
                   },
                 ],
               };

--- a/.github/workflows/human-acceptance-request.yml
+++ b/.github/workflows/human-acceptance-request.yml
@@ -100,19 +100,6 @@ jobs:
               }
             };
 
-            const acceptancePromptFor = (issueUrl) => [
-              "Run DUUMBI Stage 5 Human Acceptance with duumbi-human-acceptance.",
-              "",
-              `Target issue: ${issueUrl}`,
-              "Human decision: Accept",
-              "Reviewer source: Slack",
-              "Rationale: <short human rationale>",
-              "",
-              "Goal: Record the structured Stage 5 decision, set the issue to Spec Needed, add accepted and needs-spec labels, and remove needs-human-review when available.",
-              "",
-              "Do not create product specs, technical specs, PRs, source-code changes, or implementation branches.",
-            ].join("\n");
-
             const workflowDispatchUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/stage-approval.yml`;
 
             const buildSlackMessage = (issue, triggeredBy) => {
@@ -183,7 +170,7 @@ jobs:
                     elements: [
                       {
                         type: "mrkdwn",
-                        text: `Buttons require the <${workflowDispatchUrl}|Slack approval bridge>. Fallback: run <${workflowDispatchUrl}|Stage Approval> workflow manually (stage=5, issue=${issue.number}).`,
+                        text: `Buttons are handled by the Slack approval bridge. Fallback: run <${workflowDispatchUrl}|Stage Approval> workflow manually (stage=5, issue=${issue.number}).`,
                       },
                     ],
                   },

--- a/.github/workflows/spec-review-request.yml
+++ b/.github/workflows/spec-review-request.yml
@@ -140,6 +140,8 @@ jobs:
               "Do not create a technical spec or implementation changes.",
             ].join("\n");
 
+            const workflowDispatchUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/stage-approval.yml`;
+
             const buildSlackMessage = (issue, triggeredBy, specArtifact) => {
               const issueUrl = issue.html_url || issueUrlFor(issue.number);
               const labelNames = labelsFor(issue);
@@ -148,7 +150,16 @@ jobs:
               const safeLabels = sanitizeSlackField(labels);
               const safeTriggeredBy = sanitizeSlackField(triggeredBy);
               const correlationId = `${context.runId}-${issue.number}`;
-              const reviewPrompt = reviewPromptFor(issueUrl, specArtifact);
+
+              const prMatch = specArtifact.match(/\/pull\/(\d+)/);
+              const prNum = prMatch ? Number(prMatch[1]) : 0;
+
+              const buttonValue = (decision) => JSON.stringify({
+                stage: "7",
+                issue_number: issue.number,
+                decision,
+                pr_number: prNum,
+              });
 
               return {
                 text: `DUUMBI issue #${issue.number} needs product spec review approval: ${title}`,
@@ -161,18 +172,44 @@ jobs:
                     },
                   },
                   {
-                    type: "section",
-                    text: {
-                      type: "mrkdwn",
-                      text: "*Reply in this thread with `@Oz approve: <short rationale>`*",
-                    },
+                    type: "actions",
+                    block_id: `spec_review_${issue.number}`,
+                    elements: [
+                      {
+                        type: "button",
+                        text: { type: "plain_text", text: "✅ Approve", emoji: true },
+                        style: "primary",
+                        action_id: "stage_approve",
+                        value: buttonValue("approve"),
+                        confirm: {
+                          title: { type: "plain_text", text: "Approve Product Spec" },
+                          text: { type: "mrkdwn", text: `Approve Stage 7 Product Spec Review for issue #${issue.number}?\nThis will set the issue to *Technical Spec Needed*.` },
+                          confirm: { type: "plain_text", text: "Approve" },
+                          deny: { type: "plain_text", text: "Cancel" },
+                        },
+                      },
+                      {
+                        type: "button",
+                        text: { type: "plain_text", text: "↩️ Request Changes", emoji: true },
+                        action_id: "stage_request_changes",
+                        value: buttonValue("request-changes"),
+                      },
+                      {
+                        type: "button",
+                        text: { type: "plain_text", text: "❓ Needs Clarification", emoji: true },
+                        action_id: "stage_needs_clarification",
+                        value: buttonValue("needs-clarification"),
+                      },
+                    ],
                   },
                   {
-                    type: "section",
-                    text: {
-                      type: "mrkdwn",
-                      text: `When approving, Oz must run in the \`${ozEnvironmentName}\` environment with ID \`${ozEnvironmentId}\` and this prompt:\n\`\`\`text\n${reviewPrompt}\n\`\`\``,
-                    },
+                    type: "context",
+                    elements: [
+                      {
+                        type: "mrkdwn",
+                        text: `Buttons require the <${workflowDispatchUrl}|Slack approval bridge>. Fallback: run <${workflowDispatchUrl}|Stage Approval> workflow manually (stage=7, issue=${issue.number}).`,
+                      },
+                    ],
                   },
                 ],
               };

--- a/.github/workflows/spec-review-request.yml
+++ b/.github/workflows/spec-review-request.yml
@@ -125,21 +125,6 @@ jobs:
               return stage6Comment.html_url;
             };
 
-            const reviewPromptFor = (issueUrl, specArtifact) => [
-              "Run DUUMBI Stage 7 Product Spec Review with duumbi-spec-review.",
-              "",
-              `Target issue: ${issueUrl}`,
-              `Product spec artifact: ${specArtifact}`,
-              "Human decision: Approve",
-              "Reviewer source: Slack",
-              "Rationale: Reviewed and approved the PRODUCT spec; it is clear enough to proceed to technical specification.",
-              "",
-              "Goal: Review the product spec including BDD scenario clarity/testability, record the structured Stage 7 decision, set the issue to Technical Spec Needed, remove needs-spec, and add product-spec-approved and needs-tech-spec.",
-              "",
-              "If needed, fix the code review message so the decision is explicit and complete, and set the resolved flag.",
-              "Do not create a technical spec or implementation changes.",
-            ].join("\n");
-
             const workflowDispatchUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/stage-approval.yml`;
 
             const buildSlackMessage = (issue, triggeredBy, specArtifact) => {
@@ -207,7 +192,7 @@ jobs:
                     elements: [
                       {
                         type: "mrkdwn",
-                        text: `Buttons require the <${workflowDispatchUrl}|Slack approval bridge>. Fallback: run <${workflowDispatchUrl}|Stage Approval> workflow manually (stage=7, issue=${issue.number}).`,
+                        text: `Buttons are handled by the Slack approval bridge. Fallback: run <${workflowDispatchUrl}|Stage Approval> workflow manually (stage=7, issue=${issue.number}).`,
                       },
                     ],
                   },

--- a/.github/workflows/stage-approval.yml
+++ b/.github/workflows/stage-approval.yml
@@ -68,7 +68,7 @@ jobs:
             const stage = String(raw.stage);
             const issueNumber = Number(raw.issue_number);
             const decision = String(raw.decision);
-            const rationale = raw.rationale || 'Approved via Stage Approval workflow.';
+            const rationale = raw.rationale || `Recorded via Stage Approval workflow (decision: ${decision}).`;
             let prNumber = Number(raw.pr_number || 0);
             const reviewer = raw.reviewer || context.actor;
             const { owner, repo } = context.repo;
@@ -282,6 +282,16 @@ jobs:
               }
             }
 
+            // ── Close issue on reject ────────────────────────────────
+            if (decision === 'reject') {
+              try {
+                await github.rest.issues.update({ owner, repo, issue_number: issueNumber, state: 'closed' });
+                core.info(`Issue #${issueNumber} closed.`);
+              } catch (err) {
+                core.warning(`Close issue failed: ${err.message}`);
+              }
+            }
+
             // ── Update labels ───────────────────────────────────────
             const currentLabels = new Set(labels);
             for (const rm of dc.remove) {
@@ -380,8 +390,14 @@ jobs:
             }
 
             // ── Notify Slack ────────────────────────────────────────
+            const decisionEmoji = {
+              approve: '✅', 'request-changes': '✏️',
+              'needs-clarification': '❓', reject: '🚫',
+            }[decision] || 'ℹ️';
+            const slackEscape = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+            const safeTitle = slackEscape(issue.title).slice(0, 60);
             const summary = [
-              `✅ Stage ${stage} *${dc.label}* — <${issueUrl}|#${issueNumber} ${issue.title.slice(0, 60)}>`,
+              `${decisionEmoji} Stage ${stage} *${dc.label}* — <${issueUrl}|#${issueNumber} ${safeTitle}>`,
               `• Decision comment: ${posted.html_url}`,
               prCommentUrl ? `• PR comment: ${prCommentUrl}` : null,
               `• Labels: +[${dc.add.join(', ')}] −[${dc.remove.join(', ')}]`,

--- a/.github/workflows/stage-approval.yml
+++ b/.github/workflows/stage-approval.yml
@@ -1,0 +1,438 @@
+name: Stage Approval
+
+on:
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: 'DUUMBI stage (5 = Human Acceptance, 7 = Spec Review, 9 = Tech Spec Review)'
+        required: true
+        type: choice
+        options: ['5', '7', '9']
+      issue_number:
+        description: 'GitHub issue number'
+        required: true
+        type: number
+      decision:
+        description: 'Approval decision'
+        required: true
+        type: choice
+        options: ['approve', 'request-changes', 'needs-clarification', 'reject']
+      rationale:
+        description: 'Short rationale for the decision'
+        required: false
+        type: string
+        default: ''
+      pr_number:
+        description: 'Associated PR number (stages 7/9, 0 to auto-detect)'
+        required: false
+        type: number
+        default: 0
+  repository_dispatch:
+    types: [stage-approval]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: stage-approval-${{ github.event.inputs.issue_number || github.event.client_payload.issue_number || 'dispatch' }}
+  cancel-in-progress: false
+
+jobs:
+  execute:
+    name: Execute approval
+    runs-on: ubuntu-latest
+    steps:
+      - name: Execute decision
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        env:
+          GH_PROJECT_PAT: ${{ secrets.GH_PROJECT_PAT }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_REVIEW_CHANNEL_ID: ${{ secrets.SLACK_REVIEW_CHANNEL_ID }}
+          INPUT_SLACK_RESPONSE_URL: ${{ github.event.client_payload.slack_response_url || '' }}
+        with:
+          script: |
+            // ── Inputs ──────────────────────────────────────────────
+            const raw = context.eventName === 'repository_dispatch'
+              ? context.payload.client_payload
+              : {
+                  stage: String(context.payload.inputs.stage),
+                  issue_number: Number(context.payload.inputs.issue_number),
+                  decision: String(context.payload.inputs.decision),
+                  rationale: String(context.payload.inputs.rationale || ''),
+                  pr_number: Number(context.payload.inputs.pr_number || 0),
+                  reviewer: context.actor,
+                };
+
+            const stage = String(raw.stage);
+            const issueNumber = Number(raw.issue_number);
+            const decision = String(raw.decision);
+            const rationale = raw.rationale || 'Approved via Stage Approval workflow.';
+            let prNumber = Number(raw.pr_number || 0);
+            const reviewer = raw.reviewer || context.actor;
+            const { owner, repo } = context.repo;
+            const issueUrl = `https://github.com/${owner}/${repo}/issues/${issueNumber}`;
+            const today = new Date().toISOString().split('T')[0];
+
+            core.info(`Stage ${stage} | ${decision} | issue #${issueNumber}`);
+
+            // ── Stage decision matrix ───────────────────────────────
+            const matrix = {
+              '5': {
+                title: 'Stage 5 Human Acceptance Decision',
+                approve: {
+                  label: 'Accept',
+                  add: ['accepted', 'needs-spec'],
+                  remove: ['needs-human-review'],
+                  projectStatus: 'Spec Needed',
+                  nextState: 'Spec Needed',
+                  nextStage: 'Stage 6 Spec Preparation',
+                },
+                'needs-clarification': {
+                  label: 'Needs Clarification',
+                  add: ['needs-clarification'],
+                  remove: [],
+                  projectStatus: 'Needs Clarification',
+                  nextState: 'Needs Clarification',
+                  nextStage: 'Needs Clarification',
+                },
+                reject: {
+                  label: 'Reject',
+                  add: [],
+                  remove: ['needs-human-review'],
+                  projectStatus: 'Closed',
+                  nextState: 'Closed',
+                  nextStage: 'Closed',
+                },
+              },
+              '7': {
+                title: 'Stage 7 Product Spec Review Decision',
+                approve: {
+                  label: 'Approve',
+                  add: ['product-spec-approved', 'needs-tech-spec'],
+                  remove: ['needs-spec', 'spec-review'],
+                  projectStatus: 'Technical Spec Needed',
+                  nextState: 'Technical Spec Needed',
+                  nextStage: 'Stage 8 Technical Specification Preparation',
+                },
+                'request-changes': {
+                  label: 'Request Changes',
+                  add: ['needs-spec'],
+                  remove: ['spec-review'],
+                  projectStatus: 'Spec Needed',
+                  nextState: 'Spec Needed',
+                  nextStage: 'Stage 6 Spec Preparation',
+                },
+                'needs-clarification': {
+                  label: 'Needs Clarification',
+                  add: ['needs-clarification'],
+                  remove: ['spec-review'],
+                  projectStatus: 'Needs Clarification',
+                  nextState: 'Needs Clarification',
+                  nextStage: 'Needs Clarification',
+                },
+                reject: {
+                  label: 'Reject / No Longer Needed',
+                  add: [],
+                  remove: ['needs-spec', 'spec-review'],
+                  projectStatus: 'Closed',
+                  nextState: 'Closed',
+                  nextStage: 'Closed',
+                },
+              },
+              '9': {
+                title: 'Stage 9 Technical Spec Review Decision',
+                approve: {
+                  label: 'Approve',
+                  add: ['tech-spec-approved'],
+                  remove: ['needs-tech-spec', 'technical-spec-review'],
+                  projectStatus: 'Ready for Build',
+                  nextState: 'Ready for Build',
+                  nextStage: 'Stage 10 Ralph-Cycle Implementation',
+                },
+                'request-changes': {
+                  label: 'Request Changes',
+                  add: ['needs-tech-spec'],
+                  remove: ['technical-spec-review'],
+                  projectStatus: 'Technical Spec Needed',
+                  nextState: 'Technical Spec Needed',
+                  nextStage: 'Stage 8 Technical Specification Preparation',
+                },
+                'needs-clarification': {
+                  label: 'Needs Clarification',
+                  add: ['needs-clarification'],
+                  remove: ['technical-spec-review'],
+                  projectStatus: 'Needs Clarification',
+                  nextState: 'Needs Clarification',
+                  nextStage: 'Needs Clarification',
+                },
+                reject: {
+                  label: 'Reject / No Longer Needed',
+                  add: [],
+                  remove: ['needs-tech-spec', 'technical-spec-review'],
+                  projectStatus: 'Closed',
+                  nextState: 'Closed',
+                  nextStage: 'Closed',
+                },
+              },
+            };
+
+            const stageConfig = matrix[stage];
+            if (!stageConfig) { core.setFailed(`Unknown stage: ${stage}`); return; }
+            const dc = stageConfig[decision];
+            if (!dc) { core.setFailed(`"${decision}" not supported for Stage ${stage}`); return; }
+
+            // ── Fetch issue ─────────────────────────────────────────
+            const { data: issue } = await github.rest.issues.get({
+              owner, repo, issue_number: issueNumber,
+            });
+            const labels = issue.labels.map(l => (typeof l === 'string' ? l : l.name)).filter(Boolean);
+
+            // ── Find artifacts from existing comments ───────────────
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: issueNumber, per_page: 100,
+            });
+
+            const extractUrls = (text) =>
+              (text.match(/https:\/\/github\.com\/[^\s)>\]]+/gi) || [])
+                .map(u => u.replace(/[\]>.,;:]+$/, ''));
+
+            const findComment = (pattern) =>
+              [...comments].reverse().find(c => pattern.test(c.body || ''));
+
+            let techSpecArtifact = '';
+            let productSpecArtifact = '';
+
+            if (stage === '9') {
+              const s8 = findComment(/Stage 8 Technical Spec Draft/i);
+              if (s8) {
+                const urls = extractUrls(s8.body || '');
+                techSpecArtifact = urls[0] || s8.html_url;
+                productSpecArtifact = urls[1] || '';
+              }
+              if (!productSpecArtifact) {
+                const s6 = findComment(/Stage 6 Product Spec Draft/i);
+                if (s6) productSpecArtifact = extractUrls(s6.body || '')[0] || s6.html_url;
+              }
+              if (!prNumber && techSpecArtifact) {
+                const m = techSpecArtifact.match(/\/pull\/(\d+)/);
+                if (m) prNumber = Number(m[1]);
+              }
+            } else if (stage === '7') {
+              const s6 = findComment(/Stage 6 Product Spec Draft/i);
+              if (s6) productSpecArtifact = extractUrls(s6.body || '')[0] || s6.html_url;
+              if (!prNumber && productSpecArtifact) {
+                const m = productSpecArtifact.match(/\/pull\/(\d+)/);
+                if (m) prNumber = Number(m[1]);
+              }
+            }
+
+            // ── Build decision comment ──────────────────────────────
+            const lines = [`## ${stageConfig.title}`, ''];
+            lines.push(`**Decision:** ${dc.label}`);
+            lines.push(`**Reviewer source:** ${reviewer}`);
+
+            if (stage === '5') {
+              lines.push(`**Rationale:** ${rationale}`);
+              lines.push(`**Stage 4 recommendation considered:** yes`);
+              lines.push(`**Remaining open questions:** none`);
+              lines.push(`**Canonical duplicate:** none`);
+              lines.push(`**Review date:** ${today}`);
+            } else if (stage === '7') {
+              lines.push(`**Spec artifact:** ${productSpecArtifact || 'not found'}`);
+              lines.push(`**Rationale:** ${rationale}`);
+              lines.push(`**Blocking findings:** none`);
+              lines.push(`**Non-blocking findings:** none`);
+              lines.push(`**Remaining open questions:** none`);
+            } else if (stage === '9') {
+              lines.push(`**Technical spec:** ${techSpecArtifact || 'not found'}`);
+              lines.push(`**Product spec:** ${productSpecArtifact || 'not found'}`);
+              lines.push(`**Rationale:** ${rationale}`);
+              lines.push(`**Blocking findings:** none`);
+              lines.push(`**Non-blocking findings:** none`);
+              lines.push(`**Remaining open questions:** none`);
+            }
+            lines.push(`**Next state:** ${dc.nextState}`);
+
+            // ── Post decision comment ───────────────────────────────
+            const { data: posted } = await github.rest.issues.createComment({
+              owner, repo, issue_number: issueNumber, body: lines.join('\n'),
+            });
+            core.info(`Decision comment: ${posted.html_url}`);
+
+            // ── Post PR pointer comment (stages 7/9) ────────────────
+            let prCommentUrl = '';
+            if (prNumber && (stage === '7' || stage === '9')) {
+              try {
+                const { data: prc } = await github.rest.issues.createComment({
+                  owner, repo, issue_number: prNumber,
+                  body: [
+                    `## ${stageConfig.title}`,
+                    '',
+                    `**Decision:** ${dc.label}`,
+                    `**Issue:** ${issueUrl}`,
+                    `**Decision comment:** ${posted.html_url}`,
+                  ].join('\n'),
+                });
+                prCommentUrl = prc.html_url;
+                core.info(`PR comment: ${prCommentUrl}`);
+              } catch (err) {
+                core.warning(`PR #${prNumber} comment failed: ${err.message}`);
+              }
+            }
+
+            // ── Update labels ───────────────────────────────────────
+            const currentLabels = new Set(labels);
+            for (const rm of dc.remove) {
+              if (currentLabels.has(rm)) {
+                try {
+                  await github.rest.issues.removeLabel({ owner, repo, issue_number: issueNumber, name: rm });
+                  core.info(`Label removed: ${rm}`);
+                } catch (err) {
+                  core.warning(`Remove label "${rm}": ${err.message}`);
+                }
+              }
+            }
+            for (const add of dc.add) {
+              if (!currentLabels.has(add)) {
+                try {
+                  await github.rest.issues.addLabels({ owner, repo, issue_number: issueNumber, labels: [add] });
+                  core.info(`Label added: ${add}`);
+                } catch (err) {
+                  core.warning(`Add label "${add}": ${err.message}`);
+                }
+              }
+            }
+
+            // ── Project V2 status update ────────────────────────────
+            let projectUpdated = false;
+            const projectPat = process.env.GH_PROJECT_PAT;
+            if (projectPat && dc.projectStatus) {
+              try {
+                const gql = async (query, variables) => {
+                  const res = await fetch('https://api.github.com/graphql', {
+                    method: 'POST',
+                    headers: {
+                      Authorization: `bearer ${projectPat}`,
+                      'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({ query, variables }),
+                  });
+                  const json = await res.json();
+                  if (json.errors) throw new Error(json.errors.map(e => e.message).join('; '));
+                  return json.data;
+                };
+
+                // Find project items for the issue
+                const itemsData = await gql(`
+                  query($owner: String!, $repo: String!, $number: Int!) {
+                    repository(owner: $owner, name: $repo) {
+                      issue(number: $number) {
+                        projectItems(first: 10) {
+                          nodes { id project { id title } }
+                        }
+                      }
+                    }
+                  }`, { owner, repo, number: issueNumber });
+
+                const items = itemsData.repository?.issue?.projectItems?.nodes || [];
+                for (const item of items) {
+                  // Find the Status field and target option
+                  const fieldsData = await gql(`
+                    query($pid: ID!) {
+                      node(id: $pid) {
+                        ... on ProjectV2 {
+                          fields(first: 30) {
+                            nodes {
+                              ... on ProjectV2SingleSelectField { id name options { id name } }
+                            }
+                          }
+                        }
+                      }
+                    }`, { pid: item.project.id });
+
+                  const statusField = fieldsData.node?.fields?.nodes?.find(f => f.name === 'Status');
+                  if (!statusField) continue;
+
+                  const opt = statusField.options.find(o => o.name === dc.projectStatus);
+                  if (!opt) {
+                    core.warning(`Status option "${dc.projectStatus}" not found in "${item.project.title}".`);
+                    continue;
+                  }
+
+                  await gql(`
+                    mutation($pid: ID!, $iid: ID!, $fid: ID!, $oid: String!) {
+                      updateProjectV2ItemFieldValue(input: {
+                        projectId: $pid, itemId: $iid, fieldId: $fid,
+                        value: { singleSelectOptionId: $oid }
+                      }) { projectV2Item { id } }
+                    }`, { pid: item.project.id, iid: item.id, fid: statusField.id, oid: opt.id });
+
+                  projectUpdated = true;
+                  core.info(`Project "${item.project.title}" → ${dc.projectStatus}`);
+                }
+              } catch (err) {
+                core.warning(`Project V2 update failed: ${err.message}`);
+              }
+            } else if (!projectPat) {
+              core.info('GH_PROJECT_PAT not set — skipping Project V2 update.');
+            }
+
+            // ── Notify Slack ────────────────────────────────────────
+            const summary = [
+              `✅ Stage ${stage} *${dc.label}* — <${issueUrl}|#${issueNumber} ${issue.title.slice(0, 60)}>`,
+              `• Decision comment: ${posted.html_url}`,
+              prCommentUrl ? `• PR comment: ${prCommentUrl}` : null,
+              `• Labels: +[${dc.add.join(', ')}] −[${dc.remove.join(', ')}]`,
+              `• Project: ${projectUpdated ? dc.projectStatus : '_not updated_'}`,
+              `• Next: ${dc.nextStage}`,
+            ].filter(Boolean).join('\n');
+
+            // Reply in Slack thread via response_url (from button click)
+            const slackResponseUrl = process.env.INPUT_SLACK_RESPONSE_URL;
+            if (slackResponseUrl) {
+              try {
+                await fetch(slackResponseUrl, {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ text: summary, replace_original: false }),
+                });
+              } catch (err) {
+                core.warning(`Slack response_url failed: ${err.message}`);
+              }
+            }
+
+            // Post to review channel
+            const slackToken = process.env.SLACK_BOT_TOKEN;
+            const slackChannel = process.env.SLACK_REVIEW_CHANNEL_ID;
+            if (slackToken && slackChannel) {
+              try {
+                const res = await fetch('https://slack.com/api/chat.postMessage', {
+                  method: 'POST',
+                  headers: {
+                    Authorization: `Bearer ${slackToken}`,
+                    'Content-Type': 'application/json; charset=utf-8',
+                  },
+                  body: JSON.stringify({ channel: slackChannel, text: summary }),
+                });
+                const body = await res.json();
+                if (!body.ok) core.warning(`Slack: ${body.error}`);
+              } catch (err) {
+                core.warning(`Slack notification failed: ${err.message}`);
+              }
+            }
+
+            // ── Workflow summary ─────────────────────────────────────
+            core.summary
+              .addHeading(`Stage ${stage} ${dc.label} — #${issueNumber}`, 2)
+              .addTable([
+                [{data: 'Field', header: true}, {data: 'Value', header: true}],
+                ['Decision', dc.label],
+                ['Comment', posted.html_url],
+                ['Labels added', dc.add.join(', ') || 'none'],
+                ['Labels removed', dc.remove.join(', ') || 'none'],
+                ['Project V2', projectUpdated ? dc.projectStatus : 'not updated'],
+                ['Next stage', dc.nextStage],
+              ])
+              .write();

--- a/.github/workflows/technical-spec-review-request.yml
+++ b/.github/workflows/technical-spec-review-request.yml
@@ -152,6 +152,8 @@ jobs:
               "Do not request a Ralph cycle or start implementation.",
             ].join("\n");
 
+            const workflowDispatchUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/stage-approval.yml`;
+
             const buildSlackMessage = (issue, triggeredBy, artifacts) => {
               const issueUrl = issue.html_url || issueUrlFor(issue.number);
               const labelNames = labelsFor(issue);
@@ -160,7 +162,6 @@ jobs:
               const safeLabels = sanitizeSlackField(labels);
               const safeTriggeredBy = sanitizeSlackField(triggeredBy);
               const correlationId = `${context.runId}-${issue.number}`;
-              const reviewPrompt = reviewPromptFor(issueUrl, artifacts.technicalSpecArtifact, artifacts.productSpecArtifact);
 
               const technicalSpecLine = artifacts.technicalSpecArtifact.startsWith("http")
                 ? `<${artifacts.technicalSpecArtifact}|Stage 8 Technical Spec Draft>`
@@ -168,6 +169,17 @@ jobs:
               const productSpecLine = artifacts.productSpecArtifact.startsWith("http")
                 ? `<${artifacts.productSpecArtifact}|Product Spec Artifact>`
                 : artifacts.productSpecArtifact;
+
+              // Find associated PR number from tech spec artifact URL
+              const prMatch = artifacts.technicalSpecArtifact.match(/\/pull\/(\d+)/);
+              const prNum = prMatch ? Number(prMatch[1]) : 0;
+
+              const buttonValue = (decision) => JSON.stringify({
+                stage: "9",
+                issue_number: issue.number,
+                decision,
+                pr_number: prNum,
+              });
 
               return {
                 text: `DUUMBI issue #${issue.number} needs technical spec review approval: ${title}`,
@@ -180,18 +192,44 @@ jobs:
                     },
                   },
                   {
-                    type: "section",
-                    text: {
-                      type: "mrkdwn",
-                      text: "*Reply in this thread with `@Oz approve: <short rationale>`*",
-                    },
+                    type: "actions",
+                    block_id: `tech_spec_review_${issue.number}`,
+                    elements: [
+                      {
+                        type: "button",
+                        text: { type: "plain_text", text: "✅ Approve", emoji: true },
+                        style: "primary",
+                        action_id: "stage_approve",
+                        value: buttonValue("approve"),
+                        confirm: {
+                          title: { type: "plain_text", text: "Approve Technical Spec" },
+                          text: { type: "mrkdwn", text: `Approve Stage 9 Technical Spec Review for issue #${issue.number}?\nThis will set the issue to *Ready for Build*.` },
+                          confirm: { type: "plain_text", text: "Approve" },
+                          deny: { type: "plain_text", text: "Cancel" },
+                        },
+                      },
+                      {
+                        type: "button",
+                        text: { type: "plain_text", text: "↩️ Request Changes", emoji: true },
+                        action_id: "stage_request_changes",
+                        value: buttonValue("request-changes"),
+                      },
+                      {
+                        type: "button",
+                        text: { type: "plain_text", text: "❓ Needs Clarification", emoji: true },
+                        action_id: "stage_needs_clarification",
+                        value: buttonValue("needs-clarification"),
+                      },
+                    ],
                   },
                   {
-                    type: "section",
-                    text: {
-                      type: "mrkdwn",
-                      text: `When approving, Oz must run in the \`${ozEnvironmentName}\` environment with ID \`${ozEnvironmentId}\` and this prompt:\n\`\`\`text\n${reviewPrompt}\n\`\`\``,
-                    },
+                    type: "context",
+                    elements: [
+                      {
+                        type: "mrkdwn",
+                        text: `Buttons require the <${workflowDispatchUrl}|Slack approval bridge>. Fallback: run <${workflowDispatchUrl}|Stage Approval> workflow manually (stage=9, issue=${issue.number}).`,
+                      },
+                    ],
                   },
                 ],
               };

--- a/.github/workflows/technical-spec-review-request.yml
+++ b/.github/workflows/technical-spec-review-request.yml
@@ -136,22 +136,6 @@ jobs:
               };
             };
 
-            const reviewPromptFor = (issueUrl, technicalSpecArtifact, productSpecArtifact) => [
-              "Run DUUMBI Stage 9 Technical Spec Review with duumbi-tech-spec-review.",
-              "",
-              `Target issue: ${issueUrl}`,
-              `Technical spec artifact: ${technicalSpecArtifact}`,
-              `Product spec artifact: ${productSpecArtifact}`,
-              "Human decision: Approve",
-              "Reviewer source: Slack",
-              "Rationale: Reviewed and approved the technical specification; it is sufficiently bounded for Stage 10 Ralph-cycle implementation.",
-              "",
-              "Goal: Review BDD-to-test mapping, live E2E feasibility, and Ralph Cycle resource policy; record the structured Stage 9 decision, set the issue to Ready for Build, remove needs-tech-spec, and add tech-spec-approved.",
-              "",
-              "After an `@Oz approve: <short rationale>` reply, fix the code review message if needed so the decision is explicit and complete, then set the resolved flag.",
-              "Do not request a Ralph cycle or start implementation.",
-            ].join("\n");
-
             const workflowDispatchUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/stage-approval.yml`;
 
             const buildSlackMessage = (issue, triggeredBy, artifacts) => {
@@ -227,7 +211,7 @@ jobs:
                     elements: [
                       {
                         type: "mrkdwn",
-                        text: `Buttons require the <${workflowDispatchUrl}|Slack approval bridge>. Fallback: run <${workflowDispatchUrl}|Stage Approval> workflow manually (stage=9, issue=${issue.number}).`,
+                        text: `Buttons are handled by the Slack approval bridge. Fallback: run <${workflowDispatchUrl}|Stage Approval> workflow manually (stage=9, issue=${issue.number}).`,
                       },
                     ],
                   },

--- a/scripts/slack-approval-bridge/README.md
+++ b/scripts/slack-approval-bridge/README.md
@@ -10,7 +10,7 @@ credits to ~30 seconds / 0 credits.
 
 ## Architecture
 
-```
+```text
 Slack button click
   → Slack sends interaction payload to Azure Function URL
     → Function verifies Slack signing secret

--- a/scripts/slack-approval-bridge/README.md
+++ b/scripts/slack-approval-bridge/README.md
@@ -1,0 +1,76 @@
+# Slack Approval Bridge
+
+Azure Function that bridges Slack interactive button clicks to the
+`stage-approval.yml` GitHub Actions workflow via `repository_dispatch`.
+
+Clicking **Approve**, **Request Changes**, or **Needs Clarification** in a
+DUUMBI Slack notification triggers a deterministic GitHub Action instead of
+an LLM-based Oz agent — reducing approval execution from ~3 hours / ~108
+credits to ~30 seconds / 0 credits.
+
+## Architecture
+
+```
+Slack button click
+  → Slack sends interaction payload to Azure Function URL
+    → Function verifies Slack signing secret
+      → Function POSTs repository_dispatch to GitHub
+        → stage-approval.yml runs deterministically
+          → Posts decision comment, updates labels, updates Project V2
+            → Notifies Slack with result
+```
+
+## Infrastructure
+
+The Azure Function App is provisioned via Pulumi in the
+[duumbi-infra](https://github.com/hgahub/duumbi-infra) repository
+(`stack-platform.ts`). The infra creates:
+
+- Azure Function App (Consumption plan, Node.js 20, West Europe)
+- App Settings: `SLACK_SIGNING_SECRET`, `GITHUB_TOKEN`, `GITHUB_REPO`
+- DNS CNAME: `slack-bridge.duumbi.dev` → Function App hostname (optional)
+
+Secrets are managed via Doppler → Azure Key Vault (existing pipeline).
+
+## Local Development
+
+```sh
+cd scripts/slack-approval-bridge
+npm install
+func start
+```
+
+Use ngrok or Slack's socket mode to test locally.
+
+## Deployment
+
+Deployment is handled via `func azure functionapp publish`:
+
+```sh
+cd scripts/slack-approval-bridge
+npm install --production
+func azure functionapp publish func-duumbi-slack-bridge
+```
+
+Or via GitHub Actions CI (configure in `duumbi-infra`).
+
+## Slack App Configuration
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps) → DUUMBI app
+2. **Interactivity & Shortcuts** → toggle **On**
+3. Set **Request URL** to the Function URL (e.g. `https://func-duumbi-slack-bridge.azurewebsites.net/api/slack-approval`)
+4. Save Changes
+
+## App Settings
+
+| Setting | Source | Purpose |
+|---|---|---|
+| `SLACK_SIGNING_SECRET` | Slack app → Basic Information → Signing Secret | Verify Slack requests |
+| `GITHUB_TOKEN` | GitHub → Settings → PATs | Trigger `repository_dispatch` |
+| `GITHUB_REPO` | Static: `hgahub/duumbi` | Target repository |
+
+## Fallback
+
+If the function is unavailable, the Slack notification includes a link to
+the `stage-approval.yml` manual dispatch page where approvals can be
+triggered directly from the GitHub Actions UI.

--- a/scripts/slack-approval-bridge/host.json
+++ b/scripts/slack-approval-bridge/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/scripts/slack-approval-bridge/package-lock.json
+++ b/scripts/slack-approval-bridge/package-lock.json
@@ -1,0 +1,49 @@
+{
+  "name": "duumbi-slack-approval-bridge",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "duumbi-slack-approval-bridge",
+      "version": "1.0.0",
+      "dependencies": {
+        "@azure/functions": "^4.6.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@azure/functions": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.16.0.tgz",
+      "integrity": "sha512-cwLld7tRi1VLYNdm1evgS9n8ABP/e+0uLjRO++OjM/kigERG80OfFRRMbag/vpXUzCtda83lDiuCvcwPlxgwZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/functions-extensions-base": "0.3.0",
+        "cookie": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      }
+    },
+    "node_modules/@azure/functions-extensions-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
+      "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    }
+  }
+}

--- a/scripts/slack-approval-bridge/package.json
+++ b/scripts/slack-approval-bridge/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "duumbi-slack-approval-bridge",
+  "version": "1.0.0",
+  "description": "Azure Function: Slack interactive buttons → GitHub repository_dispatch for DUUMBI stage approvals",
+  "main": "src/functions/*.js",
+  "scripts": {
+    "start": "func start",
+    "test": "echo \"No tests configured\" && exit 0"
+  },
+  "dependencies": {
+    "@azure/functions": "^4.6.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/scripts/slack-approval-bridge/src/functions/slackApproval.js
+++ b/scripts/slack-approval-bridge/src/functions/slackApproval.js
@@ -27,7 +27,15 @@ app.http("slack-approval", {
     }
 
     const params = new URLSearchParams(body);
-    const payload = JSON.parse(params.get("payload"));
+    let payload;
+    try {
+      payload = JSON.parse(params.get("payload") || "{}");
+    } catch {
+      return { status: 400, jsonBody: { text: "Invalid Slack payload." } };
+    }
+    if (!payload || typeof payload !== "object") {
+      return { status: 400, jsonBody: { text: "Invalid Slack payload." } };
+    }
 
     if (payload.type !== "block_actions") {
       return { jsonBody: { text: "Unsupported interaction type." } };
@@ -47,10 +55,36 @@ app.http("slack-approval", {
 
     const user = payload.user;
     const reviewer = `Slack (${user.name || user.real_name || user.id})`;
+    const decisionLabel = String(actionData.decision || "unknown").replace(/-/g, " ");
+    const fallbackRationale = `${decisionLabel.charAt(0).toUpperCase() + decisionLabel.slice(1)} by ${reviewer}`;
 
-    // Trigger GitHub repository_dispatch
+    // Acknowledge Slack immediately (must respond within 3 seconds)
+    // Then dispatch to GitHub asynchronously.
+    const responseUrl = payload.response_url;
     const githubRepo = process.env.GITHUB_REPO || "hgahub/duumbi";
-    const dispatchRes = await fetch(
+    const clientPayload = {
+      stage: actionData.stage,
+      issue_number: actionData.issue_number,
+      decision: actionData.decision,
+      rationale: actionData.rationale || fallbackRationale,
+      pr_number: actionData.pr_number || 0,
+      reviewer,
+      slack_response_url: responseUrl,
+    };
+
+    // Fire-and-forget: dispatch to GitHub + post Slack thread update
+    dispatchAsync(githubRepo, clientPayload, responseUrl, actionData, user, context);
+
+    // Return 200 immediately so Slack doesn't retry
+    return { status: 200, body: "" };
+  },
+});
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+async function dispatchAsync(githubRepo, clientPayload, responseUrl, actionData, user, context) {
+  try {
+    const res = await fetch(
       `https://api.github.com/repos/${githubRepo}/dispatches`,
       {
         method: "POST",
@@ -61,41 +95,28 @@ app.http("slack-approval", {
           "Content-Type": "application/json",
           "User-Agent": "duumbi-slack-approval-bridge/1.0",
         },
-        body: JSON.stringify({
-          event_type: "stage-approval",
-          client_payload: {
-            stage: actionData.stage,
-            issue_number: actionData.issue_number,
-            decision: actionData.decision,
-            rationale: actionData.rationale || `Approved by ${reviewer}`,
-            pr_number: actionData.pr_number || 0,
-            reviewer,
-            slack_response_url: payload.response_url,
-          },
-        }),
+        body: JSON.stringify({ event_type: "stage-approval", client_payload: clientPayload }),
       },
     );
 
-    if (!dispatchRes.ok) {
-      const errText = await dispatchRes.text();
-      context.error("GitHub dispatch failed:", dispatchRes.status, errText);
-
-      if (payload.response_url) {
-        await fetch(payload.response_url, {
+    if (!res.ok) {
+      const errText = await res.text();
+      context.error("GitHub dispatch failed:", res.status, errText);
+      if (responseUrl) {
+        await fetch(responseUrl, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             replace_original: false,
-            text: `⚠️ Approval workflow trigger failed (HTTP ${dispatchRes.status}). Please use the manual workflow dispatch as fallback.`,
+            text: `⚠️ Approval workflow trigger failed (HTTP ${res.status}). Please use the manual workflow dispatch as fallback.`,
           }),
         });
       }
-      return { jsonBody: { text: "Dispatch failed." } };
+      return;
     }
 
-    // Acknowledge in Slack thread
-    if (payload.response_url) {
-      await fetch(payload.response_url, {
+    if (responseUrl) {
+      await fetch(responseUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -104,24 +125,26 @@ app.http("slack-approval", {
         }),
       });
     }
-
-    // Slack expects a 200 within 3 seconds for interactions
-    return { status: 200, body: "" };
-  },
-});
-
-// ── Helpers ──────────────────────────────────────────────────────
+  } catch (err) {
+    context.error("dispatchAsync error:", err);
+  }
+}
 
 function verifySlackSignature(body, timestamp, signature, signingSecret) {
   if (!timestamp || !signature || !signingSecret) return false;
 
-  // Reject requests older than 5 minutes
+  // Reject non-numeric or stale timestamps (>5 minutes)
+  const ts = Number(timestamp);
+  if (!Number.isFinite(ts)) return false;
   const now = Math.floor(Date.now() / 1000);
-  if (Math.abs(now - Number(timestamp)) > 300) return false;
+  if (Math.abs(now - ts) > 300) return false;
 
   const baseString = `v0:${timestamp}:${body}`;
   const computed =
     "v0=" + crypto.createHmac("sha256", signingSecret).update(baseString).digest("hex");
 
-  return crypto.timingSafeEqual(Buffer.from(computed), Buffer.from(signature));
+  const a = Buffer.from(computed);
+  const b = Buffer.from(signature);
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(a, b);
 }

--- a/scripts/slack-approval-bridge/src/functions/slackApproval.js
+++ b/scripts/slack-approval-bridge/src/functions/slackApproval.js
@@ -1,0 +1,127 @@
+const { app } = require("@azure/functions");
+const crypto = require("node:crypto");
+
+/**
+ * Slack Approval Bridge — Azure Function
+ *
+ * Bridges Slack interactive button clicks → GitHub repository_dispatch
+ * so that stage approvals execute deterministically via GitHub Actions
+ * instead of spawning an LLM-based Oz agent.
+ *
+ * App Settings (configure in Azure Function App):
+ *   SLACK_SIGNING_SECRET  — Slack app signing secret
+ *   GITHUB_TOKEN          — GitHub PAT with repo scope
+ *   GITHUB_REPO           — "owner/repo" (e.g. "hgahub/duumbi")
+ */
+
+app.http("slack-approval", {
+  methods: ["POST"],
+  authLevel: "anonymous",
+  handler: async (request, context) => {
+    const body = await request.text();
+    const timestamp = request.headers.get("X-Slack-Request-Timestamp");
+    const signature = request.headers.get("X-Slack-Signature");
+
+    if (!verifySlackSignature(body, timestamp, signature, process.env.SLACK_SIGNING_SECRET)) {
+      return { status: 401, body: "Invalid signature" };
+    }
+
+    const params = new URLSearchParams(body);
+    const payload = JSON.parse(params.get("payload"));
+
+    if (payload.type !== "block_actions") {
+      return { jsonBody: { text: "Unsupported interaction type." } };
+    }
+
+    const action = payload.actions?.[0];
+    if (!action) {
+      return { jsonBody: { text: "No action found." } };
+    }
+
+    let actionData;
+    try {
+      actionData = JSON.parse(action.value);
+    } catch {
+      return { jsonBody: { text: "Invalid action payload." } };
+    }
+
+    const user = payload.user;
+    const reviewer = `Slack (${user.name || user.real_name || user.id})`;
+
+    // Trigger GitHub repository_dispatch
+    const githubRepo = process.env.GITHUB_REPO || "hgahub/duumbi";
+    const dispatchRes = await fetch(
+      `https://api.github.com/repos/${githubRepo}/dispatches`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+          "Content-Type": "application/json",
+          "User-Agent": "duumbi-slack-approval-bridge/1.0",
+        },
+        body: JSON.stringify({
+          event_type: "stage-approval",
+          client_payload: {
+            stage: actionData.stage,
+            issue_number: actionData.issue_number,
+            decision: actionData.decision,
+            rationale: actionData.rationale || `Approved by ${reviewer}`,
+            pr_number: actionData.pr_number || 0,
+            reviewer,
+            slack_response_url: payload.response_url,
+          },
+        }),
+      },
+    );
+
+    if (!dispatchRes.ok) {
+      const errText = await dispatchRes.text();
+      context.error("GitHub dispatch failed:", dispatchRes.status, errText);
+
+      if (payload.response_url) {
+        await fetch(payload.response_url, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            replace_original: false,
+            text: `⚠️ Approval workflow trigger failed (HTTP ${dispatchRes.status}). Please use the manual workflow dispatch as fallback.`,
+          }),
+        });
+      }
+      return { jsonBody: { text: "Dispatch failed." } };
+    }
+
+    // Acknowledge in Slack thread
+    if (payload.response_url) {
+      await fetch(payload.response_url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          replace_original: false,
+          text: `⏳ Stage ${actionData.stage} *${actionData.decision}* triggered by <@${user.id}> — GitHub Actions workflow running…`,
+        }),
+      });
+    }
+
+    // Slack expects a 200 within 3 seconds for interactions
+    return { status: 200, body: "" };
+  },
+});
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function verifySlackSignature(body, timestamp, signature, signingSecret) {
+  if (!timestamp || !signature || !signingSecret) return false;
+
+  // Reject requests older than 5 minutes
+  const now = Math.floor(Date.now() / 1000);
+  if (Math.abs(now - Number(timestamp)) > 300) return false;
+
+  const baseString = `v0:${timestamp}:${body}`;
+  const computed =
+    "v0=" + crypto.createHmac("sha256", signingSecret).update(baseString).digest("hex");
+
+  return crypto.timingSafeEqual(Buffer.from(computed), Buffer.from(signature));
+}


### PR DESCRIPTION
## Summary

Replace the Oz agent-based approval flow (Stage 5/7/9) with a deterministic
GitHub Actions workflow triggered by Slack interactive buttons.

**Root cause**: A Stage 9 approval for issue #423 consumed 107.66 credits and
3+ hours because the Slack→Oz bridge lost the structured prompt context, forcing
the agent to explore from scratch (44 LLM roundtrips, redundant reads, wrong
initial hypotheses).

**Fix**: Deterministic state machine — no LLM involved for approval execution.

## Changes

### New: `stage-approval.yml`
- `workflow_dispatch` + `repository_dispatch` triggered
- Stage 5/7/9 decision matrix (approve, request-changes, needs-clarification, reject)
- Posts structured decision comments, updates labels, attempts Project V2 update via `GH_PROJECT_PAT`, notifies Slack

### New: `scripts/slack-approval-bridge/`
- Azure Function (v4 model) bridging Slack button clicks → GitHub `repository_dispatch`
- Slack signature verification, GitHub API dispatch, thread acknowledgement
- Infra (Function App) to be provisioned in `duumbi-infra` via Pulumi (separate PR)

### Modified: Notification workflows
- `technical-spec-review-request.yml`: `@Oz approve` prompt block → interactive buttons
- `spec-review-request.yml`: same for Stage 7
- `human-acceptance-request.yml`: same for Stage 5
- Each includes confirm dialogs and a fallback link to manual dispatch

### Modified: Skills (fallback for direct Oz triggers)
- `duumbi-tech-spec-review`: Approval Fast Path + Efficiency Rules sections
- `duumbi-spec-review`: Approval Fast Path
- `duumbi-human-acceptance`: Acceptance Fast Path

## Expected Impact
- Runtime: 3h → ~30s
- Credits: 108 → 0
- LLM roundtrips: 44 → 0
- Project V2 status: now actually updated (via `GH_PROJECT_PAT`)

## Deployment Steps
1. Add `GH_PROJECT_PAT` GitHub secret (classic PAT with `repo` + `project` scope)
2. Provision Azure Function App in `duumbi-infra` (separate PR)
3. Deploy function code: `func azure functionapp publish func-duumbi-slack-bridge`
4. Configure Slack Interactivity Request URL → function endpoint
5. Without the bridge deployed, buttons appear but the fallback link to `stage-approval.yml` manual dispatch works immediately

---
[Oz conversation](https://app.warp.dev/conversation/c02b7e93-d761-46d8-ab2e-184250f24268) · [Plan](https://app.warp.dev/drive/notebook/j9AbIUSi1QNhyPnkvw2iQ3)

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added interactive approval buttons in Slack for human decisions at multiple workflow stages (Accept, Reject, Needs Clarification options)
  * Implemented Slack approval bridge integration enabling direct decision submissions from Slack to GitHub Actions workflows
  * Added streamlined approval fast paths that execute when explicit decisions are provided with issue numbers

* **Chores**
  * Added GitHub Actions workflows and Azure Functions infrastructure for approval routing and automation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hgahub/duumbi/pull/590?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->