### PR TITLE
chore: add global node_modules/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ opencode.json
 *.swp
 myproject/
 docs/.obsidian/
+node_modules/


### PR DESCRIPTION
The existing .gitignore only had `infra/node_modules/`. Added a global `node_modules/` pattern to cover `scripts/slack-approval-bridge/node_modules/` and any future Node.js subdirectories.

Co-Authored-By: Oz <oz-agent@warp.dev>