### PR TITLE
Stage 2 intake: capture GitHub Actions LLM usage metrics idea

### DIFF
--- a/Duumbi/00 Inbox (ToProcess)/2026-05-22 - GitHub Actions LLM Usage Metrics.md
+++ b/Duumbi/00 Inbox (ToProcess)/2026-05-22 - GitHub Actions LLM Usage Metrics.md
@@ -1,0 +1,48 @@
+# 2026-05-22 - GitHub Actions LLM Usage Metrics
+
+## Source
+- Source: Codex
+- Surface: Codex
+- Conversation context: Slack thread in `C08SK7E6R7T` (`p1779433792156479`), user asked to use `duumbi-codex-intake` skill and capture an idea.
+- Submitted by: `<@U4SMDRG9M>`
+
+## Raw input
+Collect metrics in GitHub Actions about LLM call consumption and run times so later workflow executions can be optimized.
+
+## Interpreted intent
+The user proposes adding observability for CI usage of LLM calls (for example token/credit consumption, request counts, and per-step or per-job timing) inside GitHub Actions. The goal is to make future optimization decisions based on measured cost and latency rather than assumptions.
+
+## Classification
+feature proposal
+
+## Clarifications
+### Answered
+- Capture requested explicitly via `duumbi-codex-intake` skill usage request.
+
+### Open
+- Which LLM usage dimensions should be mandatory first (tokens, cost estimate, request count, latency percentile, failures)?
+- Should metrics remain in GitHub artifacts/logs only, or be exported to an external dashboard/store?
+- What optimization target should triage prioritize first: cost reduction, faster runtime, or reliability?
+
+## Relevant DUUMBI context
+- `AGENTS.md` (repository guidance and stage/UX constraints for DUUMBI workflows).
+- Skill instructions: `.agents/skills/duumbi-codex-intake/SKILL.md`.
+
+## Related GitHub context
+Not inspected; triage should verify GitHub state later.
+
+## Initial routing recommendation
+GitHub issue
+
+## Requested follow-up
+- Capture this as an idea for later triage and potential implementation planning.
+
+## Notes
+- Facts:
+  - User requested Stage 2 capture with the `duumbi-codex-intake` skill.
+  - User idea targets GitHub Actions telemetry for LLM usage and runtime.
+- Assumptions:
+  - The proposal applies to DUUMBI automation flows that invoke LLM-backed steps.
+  - Existing CI does not yet provide sufficient cost/runtime observability.
+- Recommendations:
+  - Stage 4 triage should convert this into a scoped GitHub issue with explicit metric definitions and acceptance criteria.

--- a/Duumbi/00 Inbox (ToProcess)/2026-05-22 - GitHub Actions LLM Usage Metrics.md
+++ b/Duumbi/00 Inbox (ToProcess)/2026-05-22 - GitHub Actions LLM Usage Metrics.md
@@ -3,8 +3,8 @@
 ## Source
 - Source: Codex
 - Surface: Codex
-- Conversation context: Slack thread in `C08SK7E6R7T` (`p1779433792156479`), user asked to use `duumbi-codex-intake` skill and capture an idea.
-- Submitted by: `<@U4SMDRG9M>`
+- Conversation context: Slack thread (internal), user asked to use `duumbi-codex-intake` skill and capture an idea.
+- Submitted by: internal Slack user
 
 ## Raw input
 Collect metrics in GitHub Actions about LLM call consumption and run times so later workflow executions can be optimized.


### PR DESCRIPTION
### Motivation
- Capture a user-proposed feature to gather LLM usage and runtime metrics from GitHub Actions so future CI runs can be optimized with data rather than assumptions.
- Record the idea in the DUUMBI Inbox (Stage 2 Codex intake) with relevant context and clarifying questions so triage can scope implementation work.

### Description
- Add one Stage 2 Inbox note at `Duumbi/00 Inbox (ToProcess)/2026-05-22 - GitHub Actions LLM Usage Metrics.md` containing source, raw input, interpreted intent, classification, clarifications, relevant context, and an initial routing recommendation of `GitHub issue`.
- The note marks GitHub state as `Not inspected` and lists open questions about which metrics to collect, storage/export targets, and optimization priority.
- The change is content-only (Inbox capture) and does not modify code, CI, or other repository behavior.

### Testing
- No automated tests were applicable for this content-only change; the note is intended for triage rather than runtime behavior.
- Verified the new file was created and inspected its contents to ensure the captured note matches the intended intake format and content.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a100158417083339918871db390a566)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a proposal document outlining observability and metrics for LLM usage in GitHub Actions, including suggested metric dimensions (inputs, intents, classifications, answered vs. open clarifications), storage/export considerations, initial routing recommendation to open an issue, follow-up request for triage, and assumptions for Stage 4 planning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hgahub/duumbi/pull/592?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->