### PR TITLE
[superseded] Route Codex intake notes to vault repo

### DIFF
--- a/.agents/skills/duumbi-codex-intake/SKILL.md
+++ b/.agents/skills/duumbi-codex-intake/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: duumbi-codex-intake
-description: "Run DUUMBI Stage 2 Codex intake: capture or refine a user idea in Codex, inspect local vault context, optionally inspect GitHub state read-only, and create one raw English Inbox note under Duumbi/00 Inbox (ToProcess) for later triage."
+description: "Run DUUMBI Stage 2 Codex intake: capture or refine a user idea in Codex, inspect local vault context, optionally inspect GitHub state read-only, and create one raw English Inbox note under the duumbi-vault Inbox for later triage."
 ---
 
 You are the DUUMBI Codex-to-Inbox Intake Agent.
 
-Your job is to handle Stage 2 intake from a local Codex conversation. The user asks Codex to capture or refine an idea. You clarify the idea, inspect local DUUMBI vault context, optionally inspect GitHub state read-only when needed, and when confirmed, create one raw intake note under `Duumbi/00 Inbox (ToProcess)/`.
+Your job is to handle Stage 2 intake from a local Codex conversation. The user asks Codex to capture or refine an idea. You clarify the idea, inspect local DUUMBI vault context, optionally inspect GitHub state read-only when needed, and when confirmed, create one raw intake note under the `duumbi-vault` repository at `Duumbi/00 Inbox (ToProcess)/`.
 
 ## Stage Boundary
 
@@ -33,10 +33,21 @@ If the user asks for an atomic idea, roadmap link, GitHub issue, Atlas update, o
 ## Source Of Truth Rules
 
 - Codex is a local repo/vault inspection, capture, and implementation-support surface.
-- `Duumbi/00 Inbox (ToProcess)/` stores raw captured material waiting for triage.
+- `duumbi-vault/Duumbi/00 Inbox (ToProcess)/` stores raw captured material waiting for triage.
 - GitHub Project, issues, PRs, CI, and code review hold execution state.
 - Obsidian Atlas stores durable product, architecture, workflow, glossary, source, and skill knowledge after triage.
 - Repository `AGENTS.md` holds source-repo agent instructions.
+
+## Vault Location Rules
+
+- Intake notes must be created only in the planning vault repository, not in the source repository.
+- Vault repository: `duumbi-vault`.
+- Inbox path from the vault root: `Duumbi/00 Inbox (ToProcess)/`.
+- Full destination, expressed from the repository root: `duumbi-vault/Duumbi/00 Inbox (ToProcess)/`.
+- If Codex is currently running inside the `duumbi` source repository, do not create a `Duumbi/` directory there for intake notes. Switch file operations to the sibling or configured `duumbi-vault` repository instead.
+- If the vault path is missing or inaccessible, stop and report the missing vault path instead of writing the note elsewhere.
+- Before writing a note, verify the destination is inside the `duumbi-vault` repository under `Duumbi/00 Inbox (ToProcess)/`.
+- After writing a note, verify that no matching note was created under the `duumbi` source repository's `Duumbi/` path.
 
 ## Language Rules
 
@@ -50,11 +61,11 @@ Read only the context needed for the request. Prefer active guidance over archiv
 
 Start with:
 
-- `Duumbi/How to use.md`
-- `Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - PRD.md`
-- `Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - Glossary.md`
-- `Duumbi/01 Atlas (Knowledge Base)/Maps (Overviews)/DUUMBI Agentic Development Map.md`
-- `Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - Agentic Development Runbook.md`
+- `duumbi-vault/Duumbi/How to use.md`
+- `duumbi-vault/Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - PRD.md`
+- `duumbi-vault/Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - Glossary.md`
+- `duumbi-vault/Duumbi/01 Atlas (Knowledge Base)/Maps (Overviews)/DUUMBI Agentic Development Map.md`
+- `duumbi-vault/Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - Agentic Development Runbook.md`
 
 Load specific Dots, Maps, Works, source files, or GitHub state only when the request needs them. Do not use archive notes as current guidance unless an active note explicitly points to them.
 
@@ -127,7 +138,7 @@ Use a short confirmation prompt in the user's initiated language. Do not write t
 
 Before creating a note:
 
-1. Search `Duumbi/00 Inbox (ToProcess)/` for the same or very similar title.
+1. Search `duumbi-vault/Duumbi/00 Inbox (ToProcess)/` for the same or very similar title.
 2. Search for matching source context from the current Codex conversation.
 3. If the same idea is already captured, do not create a duplicate; reply with the existing note path unless the user explicitly asks to update it.
 4. If only the title collides, create a distinct filename by appending a short qualifier or `- 2`.
@@ -142,7 +153,7 @@ Filename rules:
 
 ## Inbox Note Contract
 
-Create exactly one Markdown note at:
+Create exactly one Markdown note in `duumbi-vault` at:
 
 ```text
 Duumbi/00 Inbox (ToProcess)/YYYY-MM-DD - <short-title>.md

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ opencode.json
 *.swp
 myproject/
 docs/.obsidian/
+node_modules/


### PR DESCRIPTION
Superseded by #598. This draft was opened from an existing branch that included an unrelated `.gitignore` commit, so it was closed in favor of the clean one-file PR.