### PR TITLE
Implement traced build telemetry config surface for #583

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -96,6 +96,7 @@ pub(crate) fn build_with_options(input: &Path, output: &Path, options: BuildOpti
         return build_workspace_program(&workspace_root, output, options);
     }
 
+    validate_single_file_trace_config(options.telemetry)?;
     let semantic_graph = parse_and_validate(input)?;
 
     let obj_bytes = lowering::compile_to_object_with_telemetry(&semantic_graph, options.telemetry)
@@ -186,7 +187,30 @@ fn telemetry_artifact_dir(workspace_root: &Path) -> Result<PathBuf> {
         .config
         .telemetry
         .unwrap_or_default();
-    Ok(section.effective_artifact_dir(workspace_root))
+    let resolved = section
+        .resolve_for_trace(workspace_root)
+        .context("Invalid telemetry config")?;
+    Ok(resolved.artifact_dir)
+}
+
+fn validate_single_file_trace_config(
+    telemetry: crate::telemetry::TelemetryBuildMode,
+) -> Result<()> {
+    if !telemetry.is_trace() {
+        return Ok(());
+    }
+
+    let workspace_root =
+        std::env::current_dir().context("Failed to resolve current directory for telemetry")?;
+    let section = crate::config::load_effective_config(&workspace_root)
+        .context("Failed to load telemetry config")?
+        .config
+        .telemetry
+        .unwrap_or_default();
+    section
+        .resolve_for_trace(&workspace_root)
+        .context("Invalid telemetry config")?;
+    Ok(())
 }
 
 /// Validates a graph file without compiling.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -127,7 +127,7 @@ pub enum Commands {
         #[arg(short, long)]
         output: Option<PathBuf>,
 
-        /// Compile with local telemetry trace instrumentation.
+        /// Select local traced build telemetry instrumentation.
         #[arg(long)]
         trace: bool,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1037,6 +1037,12 @@ fn merge_telemetry_fields(
     if overlay.enabled.is_some() {
         base.enabled = overlay.enabled;
     }
+    if overlay.sampling_mode.is_some() {
+        base.sampling_mode = overlay.sampling_mode.clone();
+    }
+    if overlay.sample_rate.is_some() {
+        base.sample_rate = overlay.sample_rate;
+    }
     if overlay.artifact_dir.is_some() {
         base.artifact_dir = overlay.artifact_dir.clone();
     }
@@ -1430,6 +1436,8 @@ path = "custom-performance.jsonl"
             r#"
 [telemetry]
 enabled = true
+sampling-mode = "probabilistic"
+sample-rate = 0.25
 artifact-dir = "custom-telemetry"
 capture-values = false
 "#,
@@ -1439,6 +1447,8 @@ capture-values = false
         let telemetry = cfg.telemetry.expect("telemetry section");
 
         assert!(telemetry.effective_enabled());
+        assert_eq!(telemetry.configured_sampling_mode(), "probabilistic");
+        assert_eq!(telemetry.configured_sample_rate(), 0.25);
         assert_eq!(
             telemetry.configured_artifact_dir(),
             Path::new("custom-telemetry")
@@ -1458,6 +1468,8 @@ capture-values = false
         };
         let workspace = DuumbiConfig {
             telemetry: Some(crate::telemetry::TelemetrySection {
+                sampling_mode: Some("probabilistic".to_string()),
+                sample_rate: Some(0.5),
                 capture_values: Some(true),
                 ..crate::telemetry::TelemetrySection::default()
             }),
@@ -1472,6 +1484,8 @@ capture-values = false
             telemetry.artifact_dir.as_deref(),
             Some(Path::new("user-telemetry"))
         );
+        assert_eq!(telemetry.sampling_mode.as_deref(), Some("probabilistic"));
+        assert_eq!(telemetry.sample_rate, Some(0.5));
         assert_eq!(telemetry.capture_values, Some(true));
     }
 

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -775,8 +775,8 @@ pub enum TelemetryValidationError {
         /// Human-readable reason.
         reason: String,
     },
-    /// Value capture is outside #583 traced build config validation.
-    #[error("telemetry capture-values is out of scope for #583 and must remain false")]
+    /// Value capture is not supported yet.
+    #[error("telemetry capture-values is not supported yet and must remain false")]
     CaptureValuesUnsupported,
 }
 
@@ -868,10 +868,11 @@ impl TelemetrySection {
         }
 
         let sampling_mode = TelemetrySamplingMode::parse(self.configured_sampling_mode())?;
-        let (artifact_dir, artifact_dir_overridden) = match env_override {
-            Some(value) => (PathBuf::from(value), true),
-            None => (self.configured_artifact_dir().to_path_buf(), false),
-        };
+        let (artifact_dir, artifact_dir_overridden) =
+            match env_override.filter(|value| !value.is_empty()) {
+                Some(value) => (PathBuf::from(value), true),
+                None => (self.configured_artifact_dir().to_path_buf(), false),
+            };
         let artifact_dir = resolve_artifact_dir(workspace_root, &artifact_dir)?;
 
         Ok(ResolvedTelemetryConfig {
@@ -897,10 +898,10 @@ fn resolve_artifact_dir(
 
     if configured
         .components()
-        .any(|component| matches!(component, Component::ParentDir))
+        .any(|component| matches!(component, Component::ParentDir | Component::Prefix(_)))
     {
         return Err(TelemetryValidationError::InvalidArtifactDir {
-            reason: "parent directory traversal is not allowed".to_string(),
+            reason: "parent directory traversal and path prefixes are not allowed".to_string(),
         });
     }
 
@@ -1339,6 +1340,44 @@ mod tests {
             ),
             override_dir
         );
+    }
+
+    #[test]
+    fn telemetry_empty_env_override_falls_back_to_config() {
+        let workspace = TempDir::new().expect("invariant: temp dir creation must succeed");
+        let section = TelemetrySection {
+            artifact_dir: Some(PathBuf::from("config-telemetry")),
+            ..TelemetrySection::default()
+        };
+
+        let resolved = section
+            .resolve_for_trace_with_env(workspace.path(), Some(OsString::new()))
+            .expect("empty env override should be treated as unset");
+
+        assert_eq!(
+            resolved.artifact_dir,
+            workspace.path().join("config-telemetry")
+        );
+        assert!(!resolved.artifact_dir_overridden);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn telemetry_trace_validation_rejects_windows_path_prefixes() {
+        let workspace = TempDir::new().expect("invariant: temp dir creation must succeed");
+        let section = TelemetrySection {
+            artifact_dir: Some(PathBuf::from(r"C:telemetry")),
+            ..TelemetrySection::default()
+        };
+
+        let err = section
+            .resolve_for_trace(workspace.path())
+            .expect_err("Windows path prefixes must fail");
+
+        assert!(matches!(
+            err,
+            TelemetryValidationError::InvalidArtifactDir { .. }
+        ));
     }
 
     #[test]

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 use std::ffi::OsString;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -687,7 +687,7 @@ impl BuildOptions {
 }
 
 /// Optional local telemetry settings from the `[telemetry]` config section.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct TelemetrySection {
     /// Whether telemetry is enabled by config.
@@ -697,6 +697,14 @@ pub struct TelemetrySection {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
 
+    /// Sampling mode name for traced telemetry.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sampling_mode: Option<String>,
+
+    /// Sampling rate in the inclusive range `0.0..=1.0`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sample_rate: Option<f64>,
+
     /// Local directory for telemetry artifacts.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub artifact_dir: Option<PathBuf>,
@@ -704,6 +712,72 @@ pub struct TelemetrySection {
     /// Whether traced runs may capture argument or value snapshots.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub capture_values: Option<bool>,
+}
+
+/// Supported telemetry sampling modes after validation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TelemetrySamplingMode {
+    /// Stable sampling decisions suitable for tests and reproducible runs.
+    Deterministic,
+    /// Probability-based sampling using `sample-rate`.
+    Probabilistic,
+}
+
+impl TelemetrySamplingMode {
+    fn parse(value: &str) -> Result<Self, TelemetryValidationError> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "deterministic" => Ok(Self::Deterministic),
+            "probabilistic" => Ok(Self::Probabilistic),
+            other => Err(TelemetryValidationError::UnsupportedSamplingMode {
+                value: other.to_string(),
+            }),
+        }
+    }
+}
+
+/// Effective telemetry config after traced-build validation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedTelemetryConfig {
+    /// Enables runtime telemetry emission for trace-capable binaries.
+    pub enabled: bool,
+    /// Validated sampling mode.
+    pub sampling_mode: TelemetrySamplingMode,
+    /// Validated sample rate.
+    pub sample_rate: f64,
+    /// Resolved local artifact directory.
+    pub artifact_dir: PathBuf,
+    /// Whether the artifact dir came from `DUUMBI_TELEMETRY_DIR`.
+    pub artifact_dir_overridden: bool,
+    /// Whether argument or value snapshots may be captured.
+    pub capture_values: bool,
+}
+
+/// Telemetry config validation failure.
+#[derive(Debug, Error, PartialEq)]
+pub enum TelemetryValidationError {
+    /// Unsupported sampling mode.
+    #[error(
+        "telemetry sampling-mode '{value}' is unsupported; expected 'deterministic' or 'probabilistic'"
+    )]
+    UnsupportedSamplingMode {
+        /// Invalid sampling mode value.
+        value: String,
+    },
+    /// Invalid sample rate.
+    #[error("telemetry sample-rate must be between 0.0 and 1.0 inclusive; got {value}")]
+    InvalidSampleRate {
+        /// Invalid sample rate value.
+        value: f64,
+    },
+    /// Invalid artifact directory.
+    #[error("telemetry artifact-dir is invalid: {reason}")]
+    InvalidArtifactDir {
+        /// Human-readable reason.
+        reason: String,
+    },
+    /// Value capture is outside #583 traced build config validation.
+    #[error("telemetry capture-values is out of scope for #583 and must remain false")]
+    CaptureValuesUnsupported,
 }
 
 impl TelemetrySection {
@@ -717,6 +791,18 @@ impl TelemetrySection {
     #[must_use]
     pub fn effective_capture_values(&self) -> bool {
         self.capture_values.unwrap_or(false)
+    }
+
+    /// Returns the configured sampling mode before validation.
+    #[must_use]
+    pub fn configured_sampling_mode(&self) -> &str {
+        self.sampling_mode.as_deref().unwrap_or("deterministic")
+    }
+
+    /// Returns the configured sampling rate before validation.
+    #[must_use]
+    pub fn configured_sample_rate(&self) -> f64 {
+        self.sample_rate.unwrap_or(0.0)
     }
 
     /// Returns the configured artifact directory before env overrides.
@@ -751,6 +837,77 @@ impl TelemetrySection {
         } else {
             workspace_root.join(path)
         }
+    }
+
+    /// Resolves and validates telemetry config for a traced build.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TelemetryValidationError`] when local telemetry config is
+    /// invalid for traced build behavior.
+    #[must_use = "telemetry validation errors should be handled"]
+    pub fn resolve_for_trace(
+        &self,
+        workspace_root: &Path,
+    ) -> Result<ResolvedTelemetryConfig, TelemetryValidationError> {
+        self.resolve_for_trace_with_env(workspace_root, std::env::var_os(TELEMETRY_DIR_ENV))
+    }
+
+    fn resolve_for_trace_with_env(
+        &self,
+        workspace_root: &Path,
+        env_override: Option<OsString>,
+    ) -> Result<ResolvedTelemetryConfig, TelemetryValidationError> {
+        if self.effective_capture_values() {
+            return Err(TelemetryValidationError::CaptureValuesUnsupported);
+        }
+
+        let sample_rate = self.configured_sample_rate();
+        if !sample_rate.is_finite() || !(0.0..=1.0).contains(&sample_rate) {
+            return Err(TelemetryValidationError::InvalidSampleRate { value: sample_rate });
+        }
+
+        let sampling_mode = TelemetrySamplingMode::parse(self.configured_sampling_mode())?;
+        let (artifact_dir, artifact_dir_overridden) = match env_override {
+            Some(value) => (PathBuf::from(value), true),
+            None => (self.configured_artifact_dir().to_path_buf(), false),
+        };
+        let artifact_dir = resolve_artifact_dir(workspace_root, &artifact_dir)?;
+
+        Ok(ResolvedTelemetryConfig {
+            enabled: self.effective_enabled(),
+            sampling_mode,
+            sample_rate,
+            artifact_dir,
+            artifact_dir_overridden,
+            capture_values: self.effective_capture_values(),
+        })
+    }
+}
+
+fn resolve_artifact_dir(
+    workspace_root: &Path,
+    configured: &Path,
+) -> Result<PathBuf, TelemetryValidationError> {
+    if configured.as_os_str().is_empty() {
+        return Err(TelemetryValidationError::InvalidArtifactDir {
+            reason: "path is empty".to_string(),
+        });
+    }
+
+    if configured
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err(TelemetryValidationError::InvalidArtifactDir {
+            reason: "parent directory traversal is not allowed".to_string(),
+        });
+    }
+
+    if configured.is_absolute() {
+        Ok(configured.to_path_buf())
+    } else {
+        Ok(workspace_root.join(configured))
     }
 }
 
@@ -861,6 +1018,8 @@ mod tests {
 
         assert!(!section.effective_enabled());
         assert!(!section.effective_capture_values());
+        assert_eq!(section.configured_sampling_mode(), "deterministic");
+        assert_eq!(section.configured_sample_rate(), 0.0);
         assert_eq!(
             section.configured_artifact_dir(),
             Path::new(DEFAULT_ARTIFACT_DIR)
@@ -1180,6 +1339,95 @@ mod tests {
             ),
             override_dir
         );
+    }
+
+    #[test]
+    fn telemetry_trace_validation_accepts_conservative_defaults() {
+        let workspace = TempDir::new().expect("invariant: temp dir creation must succeed");
+
+        let resolved = TelemetrySection::default()
+            .resolve_for_trace(workspace.path())
+            .expect("default telemetry config should be valid");
+
+        assert!(!resolved.enabled);
+        assert_eq!(resolved.sampling_mode, TelemetrySamplingMode::Deterministic);
+        assert_eq!(resolved.sample_rate, 0.0);
+        assert_eq!(
+            resolved.artifact_dir,
+            workspace.path().join(DEFAULT_ARTIFACT_DIR)
+        );
+        assert!(!resolved.capture_values);
+    }
+
+    #[test]
+    fn telemetry_trace_validation_rejects_invalid_sample_rate() {
+        let workspace = TempDir::new().expect("invariant: temp dir creation must succeed");
+        let section = TelemetrySection {
+            sample_rate: Some(2.0),
+            ..TelemetrySection::default()
+        };
+
+        let err = section
+            .resolve_for_trace(workspace.path())
+            .expect_err("invalid sample-rate must fail");
+
+        assert_eq!(
+            err,
+            TelemetryValidationError::InvalidSampleRate { value: 2.0 }
+        );
+    }
+
+    #[test]
+    fn telemetry_trace_validation_rejects_unsupported_sampling_mode() {
+        let workspace = TempDir::new().expect("invariant: temp dir creation must succeed");
+        let section = TelemetrySection {
+            sampling_mode: Some("always".to_string()),
+            ..TelemetrySection::default()
+        };
+
+        let err = section
+            .resolve_for_trace(workspace.path())
+            .expect_err("unsupported sampling mode must fail");
+
+        assert_eq!(
+            err,
+            TelemetryValidationError::UnsupportedSamplingMode {
+                value: "always".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn telemetry_trace_validation_rejects_parent_artifact_dir() {
+        let workspace = TempDir::new().expect("invariant: temp dir creation must succeed");
+        let section = TelemetrySection {
+            artifact_dir: Some(PathBuf::from("../outside")),
+            ..TelemetrySection::default()
+        };
+
+        let err = section
+            .resolve_for_trace(workspace.path())
+            .expect_err("parent traversal must fail");
+
+        assert!(matches!(
+            err,
+            TelemetryValidationError::InvalidArtifactDir { .. }
+        ));
+    }
+
+    #[test]
+    fn telemetry_trace_validation_rejects_capture_values() {
+        let workspace = TempDir::new().expect("invariant: temp dir creation must succeed");
+        let section = TelemetrySection {
+            capture_values: Some(true),
+            ..TelemetrySection::default()
+        };
+
+        let err = section
+            .resolve_for_trace(workspace.path())
+            .expect_err("capture-values must fail");
+
+        assert_eq!(err, TelemetryValidationError::CaptureValuesUnsupported);
     }
 
     fn test_graph() -> crate::graph::SemanticGraph {

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -898,18 +898,27 @@ fn resolve_artifact_dir(
 
     if configured
         .components()
-        .any(|component| matches!(component, Component::ParentDir | Component::Prefix(_)))
+        .any(|component| matches!(component, Component::ParentDir))
     {
         return Err(TelemetryValidationError::InvalidArtifactDir {
-            reason: "parent directory traversal and path prefixes are not allowed".to_string(),
+            reason: "parent directory traversal is not allowed".to_string(),
         });
     }
 
     if configured.is_absolute() {
-        Ok(configured.to_path_buf())
-    } else {
-        Ok(workspace_root.join(configured))
+        return Ok(configured.to_path_buf());
     }
+
+    if configured
+        .components()
+        .any(|component| matches!(component, Component::Prefix(_)))
+    {
+        return Err(TelemetryValidationError::InvalidArtifactDir {
+            reason: "relative path prefixes are not allowed".to_string(),
+        });
+    }
+
+    Ok(workspace_root.join(configured))
 }
 
 fn entries_for_graph(graph: &SemanticGraph) -> Vec<TraceMapEntry> {
@@ -1359,6 +1368,22 @@ mod tests {
             workspace.path().join("config-telemetry")
         );
         assert!(!resolved.artifact_dir_overridden);
+    }
+
+    #[test]
+    fn telemetry_absolute_env_override_is_accepted() {
+        let workspace = TempDir::new().expect("invariant: temp dir creation must succeed");
+        let override_dir = workspace.path().join("absolute-telemetry");
+
+        let resolved = TelemetrySection::default()
+            .resolve_for_trace_with_env(
+                workspace.path(),
+                Some(override_dir.as_os_str().to_os_string()),
+            )
+            .expect("absolute env override should be accepted");
+
+        assert_eq!(resolved.artifact_dir, override_dir);
+        assert!(resolved.artifact_dir_overridden);
     }
 
     #[cfg(windows)]

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -29,6 +29,12 @@ pub enum WorkspaceBuildErrorKind {
 /// Error produced while building a workspace binary.
 #[derive(Debug, Error)]
 pub enum WorkspaceBuildError {
+    /// Runtime config could not be loaded for traced build validation.
+    #[error("Failed to load telemetry config: {0}")]
+    Config(#[source] crate::config::ConfigError),
+    /// Telemetry config is invalid for a traced build.
+    #[error("Invalid telemetry config: {0}")]
+    TelemetryConfig(#[source] crate::telemetry::TelemetryValidationError),
     /// Program loading, graph construction, or validation failed.
     #[error("Graph construction failed: {0}")]
     Graph(#[source] deps::DepsError),
@@ -63,6 +69,7 @@ impl WorkspaceBuildError {
     #[must_use]
     pub fn kind(&self) -> WorkspaceBuildErrorKind {
         match self {
+            Self::Config(_) | Self::TelemetryConfig(_) => WorkspaceBuildErrorKind::Compilation,
             Self::Graph(_) => WorkspaceBuildErrorKind::Graph,
             Self::Compilation(_) | Self::CompilationInternal { .. } | Self::BuildIo { .. } => {
                 WorkspaceBuildErrorKind::Compilation
@@ -117,6 +124,8 @@ pub fn build_workspace_with_options(
         })?;
     }
 
+    let telemetry_config = validate_trace_config(workspace_root, options.telemetry)?;
+
     let program = deps::load_program_with_deps_opts(workspace_root, options.offline)
         .map_err(WorkspaceBuildError::Graph)?;
 
@@ -170,22 +179,38 @@ pub fn build_workspace_with_options(
         .map_err(WorkspaceBuildError::Link)?;
 
     if options.telemetry.is_trace() {
-        let section = crate::config::load_effective_config(workspace_root)
-            .map_err(|source| WorkspaceBuildError::CompilationInternal {
-                message: format!("Failed to load telemetry config: {source}"),
-            })?
-            .config
-            .telemetry
-            .unwrap_or_default();
-        let telemetry_dir = section.effective_artifact_dir(workspace_root);
         let trace_map = crate::telemetry::TraceMap::from_program(&program)
             .map_err(WorkspaceBuildError::Telemetry)?;
+        let telemetry_dir = telemetry_config
+            .as_ref()
+            .expect("invariant: trace config is present when telemetry mode is trace")
+            .artifact_dir
+            .clone();
         crate::telemetry::write_trace_map(&trace_map, &telemetry_dir)
             .map_err(WorkspaceBuildError::Telemetry)?;
     }
 
     let _ = fs::remove_dir_all(&tmp_dir);
     Ok(output.to_path_buf())
+}
+
+fn validate_trace_config(
+    workspace_root: &Path,
+    telemetry: crate::telemetry::TelemetryBuildMode,
+) -> std::result::Result<Option<crate::telemetry::ResolvedTelemetryConfig>, WorkspaceBuildError> {
+    if !telemetry.is_trace() {
+        return Ok(None);
+    }
+
+    let section = crate::config::load_effective_config(workspace_root)
+        .map_err(WorkspaceBuildError::Config)?
+        .config
+        .telemetry
+        .unwrap_or_default();
+    section
+        .resolve_for_trace(workspace_root)
+        .map(Some)
+        .map_err(WorkspaceBuildError::TelemetryConfig)
 }
 
 /// Runs a compiled workspace binary, capturing stdout and stderr.

--- a/tests/integration_phase1.rs
+++ b/tests/integration_phase1.rs
@@ -4,6 +4,22 @@
 
 use std::process::Command;
 
+fn duumbi_bin() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_duumbi"))
+}
+
+fn native_output_path(path: &std::path::Path) -> std::path::PathBuf {
+    if path.exists() || std::env::consts::EXE_SUFFIX.is_empty() {
+        return path.to_path_buf();
+    }
+
+    std::path::PathBuf::from(format!(
+        "{}{}",
+        path.display(),
+        std::env::consts::EXE_SUFFIX
+    ))
+}
+
 /// Helper: compile a fixture and return the output binary path.
 fn compile_fixture(fixture: &str, output_name: &str) -> std::path::PathBuf {
     let tmp_dir = std::env::temp_dir().join("duumbi_phase1_tests");
@@ -30,6 +46,152 @@ fn compile_fixture(fixture: &str, output_name: &str) -> std::path::PathBuf {
     );
 
     output_binary
+}
+
+#[test]
+fn phase1_build_help_lists_trace_flag() {
+    let output = Command::new(duumbi_bin())
+        .args(["build", "--help"])
+        .output()
+        .expect("invariant: duumbi help must be runnable");
+
+    assert!(
+        output.status.success(),
+        "duumbi build --help failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--trace"));
+    assert!(stdout.contains("local traced build"));
+}
+
+#[test]
+fn phase1_trace_single_file_build_accepts_defaults() {
+    let tmp = tempfile::TempDir::new().expect("invariant: temp dir");
+    let output_binary = tmp.path().join("hello-traced");
+
+    let output = Command::new(duumbi_bin())
+        .args([
+            "build",
+            "--trace",
+            "tests/fixtures/hello.jsonld",
+            "-o",
+            &output_binary.to_string_lossy(),
+        ])
+        .output()
+        .expect("invariant: duumbi build must be runnable");
+
+    assert!(
+        output.status.success(),
+        "duumbi build --trace failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(native_output_path(&output_binary).exists());
+    assert!(!tmp.path().join(".duumbi/telemetry/traces.jsonl").exists());
+    assert!(
+        !tmp.path()
+            .join(".duumbi/telemetry/crash_dump.jsonl")
+            .exists()
+    );
+}
+
+#[test]
+fn phase1_config_semantic_errors_only_block_trace_builds() {
+    let tmp = tempfile::TempDir::new().expect("invariant: temp dir");
+    let duumbi_dir = tmp.path().join(".duumbi");
+    std::fs::create_dir_all(&duumbi_dir).expect("invariant: .duumbi must be creatable");
+    std::fs::write(
+        duumbi_dir.join("config.toml"),
+        r#"
+[telemetry]
+sample-rate = 2.0
+"#,
+    )
+    .expect("invariant: config must be writable");
+
+    let fixture =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/hello.jsonld");
+    let default_binary = tmp.path().join("hello-default");
+    let default_output = Command::new(duumbi_bin())
+        .args([
+            "build",
+            &fixture.to_string_lossy(),
+            "-o",
+            &default_binary.to_string_lossy(),
+        ])
+        .current_dir(tmp.path())
+        .output()
+        .expect("invariant: duumbi build must be runnable");
+
+    assert!(
+        default_output.status.success(),
+        "default build should ignore telemetry semantic errors: {}",
+        String::from_utf8_lossy(&default_output.stderr)
+    );
+    assert!(native_output_path(&default_binary).exists());
+
+    let traced_binary = tmp.path().join("hello-traced");
+    let traced_output = Command::new(duumbi_bin())
+        .args([
+            "build",
+            "--trace",
+            &fixture.to_string_lossy(),
+            "-o",
+            &traced_binary.to_string_lossy(),
+        ])
+        .current_dir(tmp.path())
+        .output()
+        .expect("invariant: duumbi build must be runnable");
+
+    assert!(
+        !traced_output.status.success(),
+        "traced build should reject invalid telemetry config"
+    );
+    let stderr = String::from_utf8_lossy(&traced_output.stderr);
+    assert!(stderr.contains("sample-rate"), "{stderr}");
+    assert!(stderr.contains("0.0 and 1.0"), "{stderr}");
+}
+
+#[test]
+fn phase1_trace_rejects_invalid_sample_rate_before_compilation() {
+    let tmp = tempfile::TempDir::new().expect("invariant: temp dir");
+    let duumbi_dir = tmp.path().join(".duumbi");
+    std::fs::create_dir_all(&duumbi_dir).expect("invariant: .duumbi must be creatable");
+    std::fs::write(
+        duumbi_dir.join("config.toml"),
+        r#"
+[telemetry]
+sample-rate = 2.0
+"#,
+    )
+    .expect("invariant: config must be writable");
+
+    let fixture =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/hello.jsonld");
+    let traced_binary = tmp.path().join("hello-traced");
+    let traced_output = Command::new(duumbi_bin())
+        .args([
+            "build",
+            "--trace",
+            &fixture.to_string_lossy(),
+            "-o",
+            &traced_binary.to_string_lossy(),
+        ])
+        .current_dir(tmp.path())
+        .output()
+        .expect("invariant: duumbi build must be runnable");
+
+    assert!(
+        !traced_output.status.success(),
+        "traced build should reject invalid telemetry config"
+    );
+    let stderr = String::from_utf8_lossy(&traced_output.stderr);
+    assert!(stderr.contains("sample-rate"), "{stderr}");
+    assert!(stderr.contains("0.0 and 1.0"), "{stderr}");
+    assert!(
+        !stderr.contains("Failed to link binary"),
+        "validation should fail before linking: {stderr}"
+    );
 }
 
 #[test]
@@ -226,4 +388,50 @@ fn phase1_workspace_init_build_run() {
     );
 
     let _ = std::fs::remove_dir_all(&tmp_dir);
+}
+
+#[test]
+fn phase1_workspace_trace_build_supports_offline() {
+    let duumbi_bin = duumbi_bin();
+    let tmp = tempfile::TempDir::new().expect("invariant: temp dir");
+    let workspace = tmp.path().join("ws");
+
+    let init_output = Command::new(&duumbi_bin)
+        .args(["init", &workspace.to_string_lossy()])
+        .output()
+        .expect("invariant: duumbi init must be runnable");
+    assert!(
+        init_output.status.success(),
+        "duumbi init failed: {}",
+        String::from_utf8_lossy(&init_output.stderr)
+    );
+    std::fs::write(
+        workspace.join(".duumbi/config.toml"),
+        r#"
+[workspace]
+name = "ws"
+namespace = "ws"
+"#,
+    )
+    .expect("invariant: dependency-free config must be writable");
+
+    let build_output = Command::new(&duumbi_bin)
+        .args(["build", "--trace", "--offline"])
+        .current_dir(&workspace)
+        .output()
+        .expect("invariant: duumbi build must be runnable");
+    assert!(
+        build_output.status.success(),
+        "workspace duumbi build --trace --offline failed: {}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+
+    let workspace_output = duumbi::workspace::workspace_output_path(&workspace);
+    assert!(workspace_output.exists());
+    assert!(!workspace.join(".duumbi/telemetry/traces.jsonl").exists());
+    assert!(
+        !workspace
+            .join(".duumbi/telemetry/crash_dump.jsonl")
+            .exists()
+    );
 }

--- a/tests/integration_phase1.rs
+++ b/tests/integration_phase1.rs
@@ -45,7 +45,7 @@ fn compile_fixture(fixture: &str, output_name: &str) -> std::path::PathBuf {
         String::from_utf8_lossy(&duumbi_output.stderr)
     );
 
-    output_binary
+    native_output_path(&output_binary)
 }
 
 #[test]
@@ -392,11 +392,11 @@ fn phase1_workspace_init_build_run() {
 
 #[test]
 fn phase1_workspace_trace_build_supports_offline() {
-    let duumbi_bin = duumbi_bin();
+    let duumbi_path = duumbi_bin();
     let tmp = tempfile::TempDir::new().expect("invariant: temp dir");
     let workspace = tmp.path().join("ws");
 
-    let init_output = Command::new(&duumbi_bin)
+    let init_output = Command::new(&duumbi_path)
         .args(["init", &workspace.to_string_lossy()])
         .output()
         .expect("invariant: duumbi init must be runnable");
@@ -415,7 +415,7 @@ namespace = "ws"
     )
     .expect("invariant: dependency-free config must be writable");
 
-    let build_output = Command::new(&duumbi_bin)
+    let build_output = Command::new(&duumbi_path)
         .args(["build", "--trace", "--offline"])
         .current_dir(&workspace)
         .output()


### PR DESCRIPTION
## Summary
- Related to #583
- Product spec: #609
- Technical spec: #611
- Branch: codex/duumbi-583-implementation

Workflow note: this PR must leave the execution issue open and intentionally uses non-closing issue references only.

## Changes
- Adds the local telemetry config domain and traced-build validation for sampling mode, sample rate, artifact-dir, env override, and capture-values.
- Keeps traced build selection explicit through `duumbi build --trace`; default build, REPL, Studio, and run behavior remain default-off.
- Rebases cleanly on current `main` telemetry work and preserves newer trace-map/runtime telemetry surfaces already present there.
- Adds CLI/config/integration tests for the trace surface, invalid telemetry validation, and Windows-safe binary path assertions.

## Ralph Cycle Evidence
- Cycle 1: telemetry domain/config contract and validation completed.
- Cycle 2: build options, CLI `--trace`, and compiler option plumbing completed.
- Cycle 3: integration coverage, formatting, and PR evidence completed.
- Cycle 4: resolved PR conflict against current `main`, repaired `windows-latest` CI assertions, reran CI.
- External LLM calls: 0. Estimated external LLM cost: USD 0. No resource gate triggered.

## Checks
- `cargo fmt --check`: passed locally.
- `cargo test telemetry`: passed locally.
- `cargo test --test integration_phase1 phase1_build_help_lists_trace_flag`: passed locally.
- `cargo test --test integration_phase1 phase1_trace_rejects_invalid_sample_rate_before_compilation`: passed locally.
- `cargo test --test integration_phase7_local offline`: passed locally.
- GitHub `check (ubuntu-latest)`: passed.
- GitHub `check (windows-latest)`: passed.
- GitHub `coverage`: passed.
- GitHub aggregate `check`: passed.

## Local Environment Note
- Full local link-based integration tests on this macOS workspace still hit `ld: unknown platform ... output.o`, which was already affecting pre-existing build/link tests. GitHub Ubuntu and Windows runners pass the PR checks.

## Scope Boundaries
- No remote export, Studio telemetry UI, `duumbi run --trace`, repair-agent behavior, product spec edits, technical spec edits, issue closure, or Stage 12 closure was performed.

## Readiness
Ready for human review. Do not mark the execution issue done from this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telemetry configuration now supports sampling mode and sample rate settings.

* **Documentation**
  * Clarified the --trace flag description.

* **Bug Fixes / Validation**
  * Traced builds now validate telemetry config earlier and fail fast on invalid trace settings.

* **Tests**
  * Added integration tests for traced builds, sampling validation, and artifact behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hgahub/duumbi/pull/614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->