### PR TITLE
feat(ci): collect workflow metrics for #610

### DIFF
--- a/.github/workflows/human-acceptance-request.yml
+++ b/.github/workflows/human-acceptance-request.yml
@@ -22,6 +22,7 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -38,6 +39,7 @@ jobs:
     outputs:
       issue_numbers: ${{ steps.request.outputs.issue_numbers }}
       should_notify: ${{ steps.request.outputs.should_notify }}
+      issues_queued_count: ${{ steps.request.outputs.issues_queued_count }}
     steps:
       - name: Validate request and build Slack payload
         id: request
@@ -255,6 +257,8 @@ jobs:
 
             if (issuesToNotify.length === 0) {
               core.info("No unnotified issues need human acceptance.");
+              core.setOutput("issue_numbers", "[]");
+              core.setOutput("issues_queued_count", "0");
               core.setOutput("should_notify", "false");
               return;
             }
@@ -262,6 +266,7 @@ jobs:
             const slackMessages = issuesToNotify.map((issue) => buildSlackMessage(issue, triggeredBy));
             core.setOutput("slack_messages", JSON.stringify(slackMessages));
             core.setOutput("issue_numbers", JSON.stringify(issuesToNotify.map((issue) => issue.number)));
+            core.setOutput("issues_queued_count", String(issuesToNotify.length));
             core.setOutput("should_notify", "true");
 
       - name: Post Slack notifications
@@ -340,3 +345,157 @@ jobs:
                 ].join("\n"),
               });
             }
+
+  metrics:
+    name: Write workflow metrics
+    needs: [notify, mark-notified]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Write DUUMBI workflow metrics
+        if: always()
+        continue-on-error: true
+        uses: actions/github-script@v9
+        env:
+          NOTIFY_RESULT: ${{ needs.notify.result }}
+          MARK_NOTIFIED_RESULT: ${{ needs.mark-notified.result }}
+          ISSUE_NUMBERS: ${{ needs.notify.outputs.issue_numbers || '[]' }}
+          SHOULD_NOTIFY: ${{ needs.notify.outputs.should_notify || 'false' }}
+          ISSUES_QUEUED_COUNT: ${{ needs.notify.outputs.issues_queued_count || '0' }}
+          DUUMBI_METRICS_PATH: duumbi-workflow-metrics.json
+        with:
+          script: |
+            const fs = require("fs");
+            const path = process.env.DUUMBI_METRICS_PATH || "duumbi-workflow-metrics.json";
+            const { owner, repo } = context.repo;
+            const now = new Date().toISOString();
+            const durationMs = (start, end) => {
+              if (!start || !end) return null;
+              const ms = new Date(end).getTime() - new Date(start).getTime();
+              return Number.isFinite(ms) && ms >= 0 ? ms : null;
+            };
+            const asNumber = (value) => {
+              const n = Number(value);
+              return Number.isFinite(n) ? n : null;
+            };
+            const safeJsonArray = (value) => {
+              try {
+                const parsed = JSON.parse(value || "[]");
+                return Array.isArray(parsed) ? parsed : [];
+              } catch {
+                return [];
+              }
+            };
+
+            let jobs = [];
+            let warning = null;
+            try {
+              jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+                owner, repo, run_id: context.runId, per_page: 100,
+              });
+            } catch (err) {
+              warning = `job metadata unavailable: ${String(err.message || err).slice(0, 160)}`;
+              core.warning(warning);
+            }
+
+            const phases = jobs.map((job) => ({
+              name: job.name,
+              conclusion: job.conclusion || job.status || "unknown",
+              started_at: job.started_at || null,
+              completed_at: job.completed_at || null,
+              duration_ms: durationMs(job.started_at, job.completed_at),
+              warning_count: null,
+              failure_count: job.conclusion === "failure" ? 1 : 0,
+            }));
+            const starts = phases.map((p) => p.started_at).filter(Boolean).sort();
+            const ends = phases.map((p) => p.completed_at).filter(Boolean).sort();
+            const startedAt = starts[0] || null;
+            const completedAt = ends[ends.length - 1] || now;
+            const failed = [process.env.NOTIFY_RESULT, process.env.MARK_NOTIFIED_RESULT].includes("failure");
+            const cancelled = [process.env.NOTIFY_RESULT, process.env.MARK_NOTIFIED_RESULT].includes("cancelled");
+            const workflowConclusion = failed ? "failure" : (cancelled ? "cancelled" : "success");
+            const issueNumbers = safeJsonArray(process.env.ISSUE_NUMBERS);
+            const issueNumber = issueNumbers.length === 1 ? Number(issueNumbers[0]) : null;
+
+            const metrics = {
+              schema_version: "duumbi.workflow_metrics.v1",
+              generated_at: now,
+              source: "github_actions",
+              repository: `${owner}/${repo}`,
+              workflow: {
+                name: context.workflow,
+                file: ".github/workflows/human-acceptance-request.yml",
+                run_id: context.runId,
+                run_attempt: Number(process.env.GITHUB_RUN_ATTEMPT || 1),
+                event_name: context.eventName,
+                actor: context.actor,
+                ref: context.ref,
+                sha: context.sha,
+                conclusion: workflowConclusion,
+                started_at: startedAt,
+                completed_at: completedAt,
+                duration_ms: durationMs(startedAt, completedAt),
+              },
+              correlation: {
+                issue_number: Number.isFinite(issueNumber) ? issueNumber : null,
+                pr_number: null,
+                stage: "5",
+                decision: null,
+                project_status: "Needs Human Acceptance",
+              },
+              phases,
+              counts: {
+                issues_considered: null,
+                issues_queued: asNumber(process.env.ISSUES_QUEUED_COUNT),
+                slack_notifications_attempted: process.env.SHOULD_NOTIFY === "true" ? issueNumbers.length : 0,
+                artifact_links_found: null,
+                artifact_links_missing: null,
+              },
+              provider_usage: {
+                available: false,
+                reason: "no_provider_step",
+                provider: null,
+                model: null,
+                request_count: null,
+                prompt_tokens: null,
+                completion_tokens: null,
+                total_tokens: null,
+                estimated_cost_usd: null,
+                latency_ms: null,
+                failure_count: null,
+              },
+              privacy: {
+                metadata_only: true,
+                raw_prompts_included: false,
+                raw_completions_included: false,
+                raw_slack_payloads_included: false,
+                secrets_included: false,
+              },
+              warnings: warning ? [warning] : [],
+            };
+
+            fs.writeFileSync(path, `${JSON.stringify(metrics, null, 2)}\n`);
+            await core.summary
+              .addHeading("DUUMBI Workflow Metrics", 2)
+              .addTable([
+                [{ data: "Field", header: true }, { data: "Value", header: true }],
+                ["Artifact", `duumbi-workflow-metrics-human-acceptance-${context.runId}-${process.env.GITHUB_RUN_ATTEMPT || 1}`],
+                ["Workflow conclusion", workflowConclusion],
+                ["Duration ms", String(metrics.workflow.duration_ms ?? "unavailable")],
+                ["Issues queued", String(metrics.counts.issues_queued ?? "unavailable")],
+                ["Slack notifications attempted", String(metrics.counts.slack_notifications_attempted ?? "unavailable")],
+                ["Provider usage", "unavailable: no_provider_step"],
+              ])
+              .write();
+
+      - name: Upload DUUMBI workflow metrics
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: duumbi-workflow-metrics-human-acceptance-${{ github.run_id }}-${{ github.run_attempt }}
+          path: duumbi-workflow-metrics.json
+          if-no-files-found: warn

--- a/.github/workflows/human-acceptance-request.yml
+++ b/.github/workflows/human-acceptance-request.yml
@@ -412,8 +412,9 @@ jobs:
             }));
             const starts = phases.map((p) => p.started_at).filter(Boolean).sort();
             const ends = phases.map((p) => p.completed_at).filter(Boolean).sort();
+            const hasInProgressJob = phases.some((p) => p.started_at && !p.completed_at);
             const startedAt = starts[0] || null;
-            const completedAt = ends[ends.length - 1] || now;
+            const completedAt = hasInProgressJob ? now : (ends[ends.length - 1] || now);
             const failed = [process.env.NOTIFY_RESULT, process.env.MARK_NOTIFIED_RESULT].includes("failure");
             const cancelled = [process.env.NOTIFY_RESULT, process.env.MARK_NOTIFIED_RESULT].includes("cancelled");
             const workflowConclusion = failed ? "failure" : (cancelled ? "cancelled" : "success");

--- a/.github/workflows/spec-review-request.yml
+++ b/.github/workflows/spec-review-request.yml
@@ -22,6 +22,7 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -38,6 +39,9 @@ jobs:
     outputs:
       issue_numbers: ${{ steps.request.outputs.issue_numbers }}
       should_notify: ${{ steps.request.outputs.should_notify }}
+      issues_queued_count: ${{ steps.request.outputs.issues_queued_count }}
+      artifact_links_found: ${{ steps.request.outputs.artifact_links_found }}
+      artifact_links_missing: ${{ steps.request.outputs.artifact_links_missing }}
     steps:
       - name: Validate request and build Slack payload
         id: request
@@ -271,18 +275,32 @@ jobs:
 
             if (issuesToNotify.length === 0) {
               core.info("No unnotified issues need product spec review.");
+              core.setOutput("issue_numbers", "[]");
+              core.setOutput("issues_queued_count", "0");
+              core.setOutput("artifact_links_found", "0");
+              core.setOutput("artifact_links_missing", "0");
               core.setOutput("should_notify", "false");
               return;
             }
 
             const slackMessages = [];
+            let artifactLinksFound = 0;
+            let artifactLinksMissing = 0;
             for (const issue of issuesToNotify) {
               const specArtifact = await findSpecArtifact(issue.number);
+              if (specArtifact.startsWith("<missing:")) {
+                artifactLinksMissing += 1;
+              } else {
+                artifactLinksFound += 1;
+              }
               slackMessages.push(buildSlackMessage(issue, triggeredBy, specArtifact));
             }
 
             core.setOutput("slack_messages", JSON.stringify(slackMessages));
             core.setOutput("issue_numbers", JSON.stringify(issuesToNotify.map((issue) => issue.number)));
+            core.setOutput("issues_queued_count", String(issuesToNotify.length));
+            core.setOutput("artifact_links_found", String(artifactLinksFound));
+            core.setOutput("artifact_links_missing", String(artifactLinksMissing));
             core.setOutput("should_notify", "true");
 
       - name: Post Slack notifications
@@ -361,3 +379,160 @@ jobs:
                 ].join("\n"),
               });
             }
+
+  metrics:
+    name: Write workflow metrics
+    needs: [notify, mark-notified]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Write DUUMBI workflow metrics
+        if: always()
+        continue-on-error: true
+        uses: actions/github-script@v9
+        env:
+          NOTIFY_RESULT: ${{ needs.notify.result }}
+          MARK_NOTIFIED_RESULT: ${{ needs.mark-notified.result }}
+          ISSUE_NUMBERS: ${{ needs.notify.outputs.issue_numbers || '[]' }}
+          SHOULD_NOTIFY: ${{ needs.notify.outputs.should_notify || 'false' }}
+          ISSUES_QUEUED_COUNT: ${{ needs.notify.outputs.issues_queued_count || '0' }}
+          ARTIFACT_LINKS_FOUND: ${{ needs.notify.outputs.artifact_links_found || '0' }}
+          ARTIFACT_LINKS_MISSING: ${{ needs.notify.outputs.artifact_links_missing || '0' }}
+          DUUMBI_METRICS_PATH: duumbi-workflow-metrics.json
+        with:
+          script: |
+            const fs = require("fs");
+            const path = process.env.DUUMBI_METRICS_PATH || "duumbi-workflow-metrics.json";
+            const { owner, repo } = context.repo;
+            const now = new Date().toISOString();
+            const durationMs = (start, end) => {
+              if (!start || !end) return null;
+              const ms = new Date(end).getTime() - new Date(start).getTime();
+              return Number.isFinite(ms) && ms >= 0 ? ms : null;
+            };
+            const asNumber = (value) => {
+              const n = Number(value);
+              return Number.isFinite(n) ? n : null;
+            };
+            const safeJsonArray = (value) => {
+              try {
+                const parsed = JSON.parse(value || "[]");
+                return Array.isArray(parsed) ? parsed : [];
+              } catch {
+                return [];
+              }
+            };
+
+            let jobs = [];
+            let warning = null;
+            try {
+              jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+                owner, repo, run_id: context.runId, per_page: 100,
+              });
+            } catch (err) {
+              warning = `job metadata unavailable: ${String(err.message || err).slice(0, 160)}`;
+              core.warning(warning);
+            }
+
+            const phases = jobs.map((job) => ({
+              name: job.name,
+              conclusion: job.conclusion || job.status || "unknown",
+              started_at: job.started_at || null,
+              completed_at: job.completed_at || null,
+              duration_ms: durationMs(job.started_at, job.completed_at),
+              warning_count: null,
+              failure_count: job.conclusion === "failure" ? 1 : 0,
+            }));
+            const starts = phases.map((p) => p.started_at).filter(Boolean).sort();
+            const ends = phases.map((p) => p.completed_at).filter(Boolean).sort();
+            const startedAt = starts[0] || null;
+            const completedAt = ends[ends.length - 1] || now;
+            const failed = [process.env.NOTIFY_RESULT, process.env.MARK_NOTIFIED_RESULT].includes("failure");
+            const cancelled = [process.env.NOTIFY_RESULT, process.env.MARK_NOTIFIED_RESULT].includes("cancelled");
+            const workflowConclusion = failed ? "failure" : (cancelled ? "cancelled" : "success");
+            const issueNumbers = safeJsonArray(process.env.ISSUE_NUMBERS);
+            const issueNumber = issueNumbers.length === 1 ? Number(issueNumbers[0]) : null;
+
+            const metrics = {
+              schema_version: "duumbi.workflow_metrics.v1",
+              generated_at: now,
+              source: "github_actions",
+              repository: `${owner}/${repo}`,
+              workflow: {
+                name: context.workflow,
+                file: ".github/workflows/spec-review-request.yml",
+                run_id: context.runId,
+                run_attempt: Number(process.env.GITHUB_RUN_ATTEMPT || 1),
+                event_name: context.eventName,
+                actor: context.actor,
+                ref: context.ref,
+                sha: context.sha,
+                conclusion: workflowConclusion,
+                started_at: startedAt,
+                completed_at: completedAt,
+                duration_ms: durationMs(startedAt, completedAt),
+              },
+              correlation: {
+                issue_number: Number.isFinite(issueNumber) ? issueNumber : null,
+                pr_number: null,
+                stage: "7",
+                decision: null,
+                project_status: "Spec Review",
+              },
+              phases,
+              counts: {
+                issues_considered: null,
+                issues_queued: asNumber(process.env.ISSUES_QUEUED_COUNT),
+                slack_notifications_attempted: process.env.SHOULD_NOTIFY === "true" ? issueNumbers.length : 0,
+                artifact_links_found: asNumber(process.env.ARTIFACT_LINKS_FOUND),
+                artifact_links_missing: asNumber(process.env.ARTIFACT_LINKS_MISSING),
+              },
+              provider_usage: {
+                available: false,
+                reason: "no_provider_step",
+                provider: null,
+                model: null,
+                request_count: null,
+                prompt_tokens: null,
+                completion_tokens: null,
+                total_tokens: null,
+                estimated_cost_usd: null,
+                latency_ms: null,
+                failure_count: null,
+              },
+              privacy: {
+                metadata_only: true,
+                raw_prompts_included: false,
+                raw_completions_included: false,
+                raw_slack_payloads_included: false,
+                secrets_included: false,
+              },
+              warnings: warning ? [warning] : [],
+            };
+
+            fs.writeFileSync(path, `${JSON.stringify(metrics, null, 2)}\n`);
+            await core.summary
+              .addHeading("DUUMBI Workflow Metrics", 2)
+              .addTable([
+                [{ data: "Field", header: true }, { data: "Value", header: true }],
+                ["Artifact", `duumbi-workflow-metrics-spec-review-${context.runId}-${process.env.GITHUB_RUN_ATTEMPT || 1}`],
+                ["Workflow conclusion", workflowConclusion],
+                ["Duration ms", String(metrics.workflow.duration_ms ?? "unavailable")],
+                ["Issues queued", String(metrics.counts.issues_queued ?? "unavailable")],
+                ["Artifact links found", String(metrics.counts.artifact_links_found ?? "unavailable")],
+                ["Artifact links missing", String(metrics.counts.artifact_links_missing ?? "unavailable")],
+                ["Provider usage", "unavailable: no_provider_step"],
+              ])
+              .write();
+
+      - name: Upload DUUMBI workflow metrics
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: duumbi-workflow-metrics-spec-review-${{ github.run_id }}-${{ github.run_attempt }}
+          path: duumbi-workflow-metrics.json
+          if-no-files-found: warn

--- a/.github/workflows/spec-review-request.yml
+++ b/.github/workflows/spec-review-request.yml
@@ -448,8 +448,9 @@ jobs:
             }));
             const starts = phases.map((p) => p.started_at).filter(Boolean).sort();
             const ends = phases.map((p) => p.completed_at).filter(Boolean).sort();
+            const hasInProgressJob = phases.some((p) => p.started_at && !p.completed_at);
             const startedAt = starts[0] || null;
-            const completedAt = ends[ends.length - 1] || now;
+            const completedAt = hasInProgressJob ? now : (ends[ends.length - 1] || now);
             const failed = [process.env.NOTIFY_RESULT, process.env.MARK_NOTIFIED_RESULT].includes("failure");
             const cancelled = [process.env.NOTIFY_RESULT, process.env.MARK_NOTIFIED_RESULT].includes("cancelled");
             const workflowConclusion = failed ? "failure" : (cancelled ? "cancelled" : "success");

--- a/.github/workflows/stage-approval.yml
+++ b/.github/workflows/stage-approval.yml
@@ -31,6 +31,7 @@ on:
     types: [stage-approval]
 
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: write
@@ -517,3 +518,158 @@ jobs:
                 .addCodeBlock(nextCodexPrompt, 'text');
             }
             await summaryBuilder.write();
+
+      - name: Write DUUMBI workflow metrics
+        if: always()
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        env:
+          DUUMBI_JOB_STATUS: ${{ job.status }}
+          DUUMBI_METRICS_PATH: duumbi-workflow-metrics.json
+        with:
+          script: |
+            const fs = require('fs');
+            const path = process.env.DUUMBI_METRICS_PATH || 'duumbi-workflow-metrics.json';
+            const { owner, repo } = context.repo;
+            const payload = context.payload || {};
+            const raw = context.eventName === 'repository_dispatch'
+              ? (payload.client_payload || {})
+              : (payload.inputs || {});
+
+            const asNumber = (value) => {
+              const n = Number(value);
+              return Number.isFinite(n) && n > 0 ? n : null;
+            };
+            const durationMs = (start, end) => {
+              if (!start || !end) return null;
+              const ms = new Date(end).getTime() - new Date(start).getTime();
+              return Number.isFinite(ms) && ms >= 0 ? ms : null;
+            };
+            const now = new Date().toISOString();
+
+            let jobs = [];
+            let warning = null;
+            try {
+              jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+                owner, repo, run_id: context.runId, per_page: 100,
+              });
+            } catch (err) {
+              warning = `job metadata unavailable: ${String(err.message || err).slice(0, 160)}`;
+              core.warning(warning);
+            }
+
+            const phases = jobs.map((job) => {
+              const completedAt = job.completed_at || (job.name === 'Execute approval' ? now : null);
+              const conclusion = job.name === 'Execute approval'
+                ? String(process.env.DUUMBI_JOB_STATUS || job.conclusion || job.status || 'unknown')
+                : (job.conclusion || job.status || 'unknown');
+              return {
+                name: job.name,
+                conclusion,
+                started_at: job.started_at || null,
+                completed_at: completedAt,
+                duration_ms: durationMs(job.started_at, completedAt),
+                warning_count: null,
+                failure_count: conclusion === 'failure' ? 1 : 0,
+              };
+            });
+
+            if (phases.length === 0) {
+              phases.push({
+                name: 'Execute approval',
+                conclusion: String(process.env.DUUMBI_JOB_STATUS || 'unknown'),
+                started_at: null,
+                completed_at: now,
+                duration_ms: null,
+                warning_count: warning ? 1 : null,
+                failure_count: process.env.DUUMBI_JOB_STATUS === 'failure' ? 1 : 0,
+              });
+            }
+
+            const starts = phases.map((p) => p.started_at).filter(Boolean).sort();
+            const ends = phases.map((p) => p.completed_at).filter(Boolean).sort();
+            const startedAt = starts[0] || null;
+            const completedAt = ends[ends.length - 1] || now;
+            const workflowStatus = String(process.env.DUUMBI_JOB_STATUS || 'unknown');
+
+            const metrics = {
+              schema_version: 'duumbi.workflow_metrics.v1',
+              generated_at: now,
+              source: 'github_actions',
+              repository: `${owner}/${repo}`,
+              workflow: {
+                name: context.workflow,
+                file: '.github/workflows/stage-approval.yml',
+                run_id: context.runId,
+                run_attempt: Number(process.env.GITHUB_RUN_ATTEMPT || 1),
+                event_name: context.eventName,
+                actor: context.actor,
+                ref: context.ref,
+                sha: context.sha,
+                conclusion: workflowStatus,
+                started_at: startedAt,
+                completed_at: completedAt,
+                duration_ms: durationMs(startedAt, completedAt),
+              },
+              correlation: {
+                issue_number: asNumber(raw.issue_number),
+                pr_number: asNumber(raw.pr_number),
+                stage: raw.stage ? String(raw.stage) : null,
+                decision: raw.decision ? String(raw.decision) : null,
+                project_status: null,
+              },
+              phases,
+              counts: {
+                issues_considered: null,
+                issues_queued: null,
+                slack_notifications_attempted: null,
+                artifact_links_found: null,
+                artifact_links_missing: null,
+              },
+              provider_usage: {
+                available: false,
+                reason: 'no_provider_step',
+                provider: null,
+                model: null,
+                request_count: null,
+                prompt_tokens: null,
+                completion_tokens: null,
+                total_tokens: null,
+                estimated_cost_usd: null,
+                latency_ms: null,
+                failure_count: null,
+              },
+              privacy: {
+                metadata_only: true,
+                raw_prompts_included: false,
+                raw_completions_included: false,
+                raw_slack_payloads_included: false,
+                secrets_included: false,
+              },
+              warnings: warning ? [warning] : [],
+            };
+
+            fs.writeFileSync(path, `${JSON.stringify(metrics, null, 2)}\n`);
+
+            await core.summary
+              .addHeading('DUUMBI Workflow Metrics', 2)
+              .addTable([
+                [{ data: 'Field', header: true }, { data: 'Value', header: true }],
+                ['Artifact', `duumbi-workflow-metrics-stage-approval-${context.runId}-${process.env.GITHUB_RUN_ATTEMPT || 1}`],
+                ['Workflow conclusion', workflowStatus],
+                ['Duration ms', String(metrics.workflow.duration_ms ?? 'unavailable')],
+                ['Issue', String(metrics.correlation.issue_number ?? 'unavailable')],
+                ['Stage', String(metrics.correlation.stage ?? 'unavailable')],
+                ['Decision', String(metrics.correlation.decision ?? 'unavailable')],
+                ['Provider usage', 'unavailable: no_provider_step'],
+              ])
+              .write();
+
+      - name: Upload DUUMBI workflow metrics
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: duumbi-workflow-metrics-stage-approval-${{ github.run_id }}-${{ github.run_attempt }}
+          path: duumbi-workflow-metrics.json
+          if-no-files-found: warn

--- a/.github/workflows/technical-spec-review-request.yml
+++ b/.github/workflows/technical-spec-review-request.yml
@@ -22,6 +22,7 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -38,6 +39,9 @@ jobs:
     outputs:
       issue_numbers: ${{ steps.request.outputs.issue_numbers }}
       should_notify: ${{ steps.request.outputs.should_notify }}
+      issues_queued_count: ${{ steps.request.outputs.issues_queued_count }}
+      artifact_links_found: ${{ steps.request.outputs.artifact_links_found }}
+      artifact_links_missing: ${{ steps.request.outputs.artifact_links_missing }}
     steps:
       - name: Validate request and build Slack payload
         id: request
@@ -306,18 +310,32 @@ jobs:
 
             if (issuesToNotify.length === 0) {
               core.info("No unnotified issues need technical spec review.");
+              core.setOutput("issue_numbers", "[]");
+              core.setOutput("issues_queued_count", "0");
+              core.setOutput("artifact_links_found", "0");
+              core.setOutput("artifact_links_missing", "0");
               core.setOutput("should_notify", "false");
               return;
             }
 
             const slackMessages = [];
+            let artifactLinksFound = 0;
+            let artifactLinksMissing = 0;
             for (const issue of issuesToNotify) {
               const artifacts = await findStage8Artifacts(issue.number);
+              if (artifacts.technicalSpecArtifact.startsWith("<missing:")) {
+                artifactLinksMissing += 1;
+              } else {
+                artifactLinksFound += 1;
+              }
               slackMessages.push(buildSlackMessage(issue, triggeredBy, artifacts));
             }
 
             core.setOutput("slack_messages", JSON.stringify(slackMessages));
             core.setOutput("issue_numbers", JSON.stringify(issuesToNotify.map((issue) => issue.number)));
+            core.setOutput("issues_queued_count", String(issuesToNotify.length));
+            core.setOutput("artifact_links_found", String(artifactLinksFound));
+            core.setOutput("artifact_links_missing", String(artifactLinksMissing));
             core.setOutput("should_notify", "true");
 
       - name: Post Slack notifications
@@ -396,3 +414,160 @@ jobs:
                 ].join("\n"),
               });
             }
+
+  metrics:
+    name: Write workflow metrics
+    needs: [notify, mark-notified]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Write DUUMBI workflow metrics
+        if: always()
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        env:
+          NOTIFY_RESULT: ${{ needs.notify.result }}
+          MARK_NOTIFIED_RESULT: ${{ needs.mark-notified.result }}
+          ISSUE_NUMBERS: ${{ needs.notify.outputs.issue_numbers || '[]' }}
+          SHOULD_NOTIFY: ${{ needs.notify.outputs.should_notify || 'false' }}
+          ISSUES_QUEUED_COUNT: ${{ needs.notify.outputs.issues_queued_count || '0' }}
+          ARTIFACT_LINKS_FOUND: ${{ needs.notify.outputs.artifact_links_found || '0' }}
+          ARTIFACT_LINKS_MISSING: ${{ needs.notify.outputs.artifact_links_missing || '0' }}
+          DUUMBI_METRICS_PATH: duumbi-workflow-metrics.json
+        with:
+          script: |
+            const fs = require("fs");
+            const path = process.env.DUUMBI_METRICS_PATH || "duumbi-workflow-metrics.json";
+            const { owner, repo } = context.repo;
+            const now = new Date().toISOString();
+            const durationMs = (start, end) => {
+              if (!start || !end) return null;
+              const ms = new Date(end).getTime() - new Date(start).getTime();
+              return Number.isFinite(ms) && ms >= 0 ? ms : null;
+            };
+            const asNumber = (value) => {
+              const n = Number(value);
+              return Number.isFinite(n) ? n : null;
+            };
+            const safeJsonArray = (value) => {
+              try {
+                const parsed = JSON.parse(value || "[]");
+                return Array.isArray(parsed) ? parsed : [];
+              } catch {
+                return [];
+              }
+            };
+
+            let jobs = [];
+            let warning = null;
+            try {
+              jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+                owner, repo, run_id: context.runId, per_page: 100,
+              });
+            } catch (err) {
+              warning = `job metadata unavailable: ${String(err.message || err).slice(0, 160)}`;
+              core.warning(warning);
+            }
+
+            const phases = jobs.map((job) => ({
+              name: job.name,
+              conclusion: job.conclusion || job.status || "unknown",
+              started_at: job.started_at || null,
+              completed_at: job.completed_at || null,
+              duration_ms: durationMs(job.started_at, job.completed_at),
+              warning_count: null,
+              failure_count: job.conclusion === "failure" ? 1 : 0,
+            }));
+            const starts = phases.map((p) => p.started_at).filter(Boolean).sort();
+            const ends = phases.map((p) => p.completed_at).filter(Boolean).sort();
+            const startedAt = starts[0] || null;
+            const completedAt = ends[ends.length - 1] || now;
+            const failed = [process.env.NOTIFY_RESULT, process.env.MARK_NOTIFIED_RESULT].includes("failure");
+            const cancelled = [process.env.NOTIFY_RESULT, process.env.MARK_NOTIFIED_RESULT].includes("cancelled");
+            const workflowConclusion = failed ? "failure" : (cancelled ? "cancelled" : "success");
+            const issueNumbers = safeJsonArray(process.env.ISSUE_NUMBERS);
+            const issueNumber = issueNumbers.length === 1 ? Number(issueNumbers[0]) : null;
+
+            const metrics = {
+              schema_version: "duumbi.workflow_metrics.v1",
+              generated_at: now,
+              source: "github_actions",
+              repository: `${owner}/${repo}`,
+              workflow: {
+                name: context.workflow,
+                file: ".github/workflows/technical-spec-review-request.yml",
+                run_id: context.runId,
+                run_attempt: Number(process.env.GITHUB_RUN_ATTEMPT || 1),
+                event_name: context.eventName,
+                actor: context.actor,
+                ref: context.ref,
+                sha: context.sha,
+                conclusion: workflowConclusion,
+                started_at: startedAt,
+                completed_at: completedAt,
+                duration_ms: durationMs(startedAt, completedAt),
+              },
+              correlation: {
+                issue_number: Number.isFinite(issueNumber) ? issueNumber : null,
+                pr_number: null,
+                stage: "9",
+                decision: null,
+                project_status: "Technical Spec Review",
+              },
+              phases,
+              counts: {
+                issues_considered: null,
+                issues_queued: asNumber(process.env.ISSUES_QUEUED_COUNT),
+                slack_notifications_attempted: process.env.SHOULD_NOTIFY === "true" ? issueNumbers.length : 0,
+                artifact_links_found: asNumber(process.env.ARTIFACT_LINKS_FOUND),
+                artifact_links_missing: asNumber(process.env.ARTIFACT_LINKS_MISSING),
+              },
+              provider_usage: {
+                available: false,
+                reason: "no_provider_step",
+                provider: null,
+                model: null,
+                request_count: null,
+                prompt_tokens: null,
+                completion_tokens: null,
+                total_tokens: null,
+                estimated_cost_usd: null,
+                latency_ms: null,
+                failure_count: null,
+              },
+              privacy: {
+                metadata_only: true,
+                raw_prompts_included: false,
+                raw_completions_included: false,
+                raw_slack_payloads_included: false,
+                secrets_included: false,
+              },
+              warnings: warning ? [warning] : [],
+            };
+
+            fs.writeFileSync(path, `${JSON.stringify(metrics, null, 2)}\n`);
+            await core.summary
+              .addHeading("DUUMBI Workflow Metrics", 2)
+              .addTable([
+                [{ data: "Field", header: true }, { data: "Value", header: true }],
+                ["Artifact", `duumbi-workflow-metrics-technical-spec-review-${context.runId}-${process.env.GITHUB_RUN_ATTEMPT || 1}`],
+                ["Workflow conclusion", workflowConclusion],
+                ["Duration ms", String(metrics.workflow.duration_ms ?? "unavailable")],
+                ["Issues queued", String(metrics.counts.issues_queued ?? "unavailable")],
+                ["Artifact links found", String(metrics.counts.artifact_links_found ?? "unavailable")],
+                ["Artifact links missing", String(metrics.counts.artifact_links_missing ?? "unavailable")],
+                ["Provider usage", "unavailable: no_provider_step"],
+              ])
+              .write();
+
+      - name: Upload DUUMBI workflow metrics
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: duumbi-workflow-metrics-technical-spec-review-${{ github.run_id }}-${{ github.run_attempt }}
+          path: duumbi-workflow-metrics.json
+          if-no-files-found: warn

--- a/.github/workflows/technical-spec-review-request.yml
+++ b/.github/workflows/technical-spec-review-request.yml
@@ -483,8 +483,9 @@ jobs:
             }));
             const starts = phases.map((p) => p.started_at).filter(Boolean).sort();
             const ends = phases.map((p) => p.completed_at).filter(Boolean).sort();
+            const hasInProgressJob = phases.some((p) => p.started_at && !p.completed_at);
             const startedAt = starts[0] || null;
-            const completedAt = ends[ends.length - 1] || now;
+            const completedAt = hasInProgressJob ? now : (ends[ends.length - 1] || now);
             const failed = [process.env.NOTIFY_RESULT, process.env.MARK_NOTIFIED_RESULT].includes("failure");
             const cancelled = [process.env.NOTIFY_RESULT, process.env.MARK_NOTIFIED_RESULT].includes("cancelled");
             const workflowConclusion = failed ? "failure" : (cancelled ? "cancelled" : "success");

--- a/scripts/eval_intent.sh
+++ b/scripts/eval_intent.sh
@@ -20,6 +20,10 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 CORPUS_DIR="$PROJECT_DIR/docs/e2e/corpus"
 RESULTS_DIR="$PROJECT_DIR/docs/e2e/results"
 
+now_ms() {
+    echo "$(($(date +%s) * 1000))"
+}
+
 # Parse args
 PROVIDER="default"
 FILTER=""
@@ -36,6 +40,8 @@ mkdir -p "$RESULTS_DIR"
 
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 REPORT="$RESULTS_DIR/${PROVIDER}_${TIMESTAMP}.json"
+RUN_START_MS=$(now_ms)
+USAGE_UNAVAILABLE_REASON="duumbi_intent_create_usage_not_exposed"
 
 echo "=== Intent Create Eval ==="
 echo "Provider: $PROVIDER"
@@ -83,12 +89,15 @@ for txt_file in "$CORPUS_DIR"/*.txt; do
     TOTAL=$((TOTAL + 1))
 
     echo -n "[$TOTAL] $task_id ... "
+    TASK_START_MS=$(now_ms)
 
     # Snapshot existing intents before this run
     BEFORE_FILES=$(ls "$PROJECT_DIR/.duumbi/intents/"*.yaml 2>/dev/null | sort || true)
 
     # Run intent create
     GENERATED=""
+    DUUMBI_COMMAND_ATTEMPTED=false
+    DUUMBI_COMMAND_ATTEMPTED=true
     if output=$(cd "$PROJECT_DIR" && "$DUUMBI" intent create "$description" --yes 2>&1); then
         # Find the newly created file (diff against snapshot)
         AFTER_FILES=$(ls "$PROJECT_DIR/.duumbi/intents/"*.yaml 2>/dev/null | sort || true)
@@ -99,12 +108,29 @@ for txt_file in "$CORPUS_DIR"/*.txt; do
             GENERATED=$(ls -t "$PROJECT_DIR/.duumbi/intents/"*.yaml 2>/dev/null | head -1)
         fi
     fi
+    TASK_END_MS=$(now_ms)
+    TASK_DURATION_MS=$((TASK_END_MS - TASK_START_MS))
 
     if [[ -z "$GENERATED" ]] || [[ ! -f "$GENERATED" ]]; then
         echo "ERROR (no output)"
         ERRORS=$((ERRORS + 1))
-        RESULTS=$(echo "$RESULTS" | jq --arg id "$task_id" --arg status "error" \
-            '. + [{"task": $id, "status": $status, "score": 0}]')
+        RESULTS=$(echo "$RESULTS" | jq \
+            --arg id "$task_id" \
+            --arg status "error" \
+            --arg reason "$USAGE_UNAVAILABLE_REASON" \
+            --argjson duration "$TASK_DURATION_MS" \
+            --argjson attempted "$DUUMBI_COMMAND_ATTEMPTED" \
+            '. + [{
+                "task": $id,
+                "status": $status,
+                "score": 0,
+                "duration_ms": $duration,
+                "duumbi_command_attempted": $attempted,
+                "provider_usage": {
+                    "available": false,
+                    "reason": $reason
+                }
+            }]')
         continue
     fi
 
@@ -220,13 +246,31 @@ for txt_file in "$CORPUS_DIR"/*.txt; do
     RESULTS=$(echo "$RESULTS" | jq \
         --arg id "$task_id" \
         --arg status "$status" \
+        --arg reason "$USAGE_UNAVAILABLE_REASON" \
         --argjson score "$total_score" \
         --argjson json "$score_json" \
         --argjson mod "$score_modules" \
         --argjson test "$score_tests" \
         --argjson edge "$score_edge" \
         --argjson crit "$score_criteria" \
-        '. + [{"task": $id, "status": $status, "score": $score, "json": $json, "modules": $mod, "tests": $test, "edge_cases": $edge, "criteria": $crit}]')
+        --argjson duration "$TASK_DURATION_MS" \
+        --argjson attempted "$DUUMBI_COMMAND_ATTEMPTED" \
+        '. + [{
+            "task": $id,
+            "status": $status,
+            "score": $score,
+            "json": $json,
+            "modules": $mod,
+            "tests": $test,
+            "edge_cases": $edge,
+            "criteria": $crit,
+            "duration_ms": $duration,
+            "duumbi_command_attempted": $attempted,
+            "provider_usage": {
+                "available": false,
+                "reason": $reason
+            }
+        }]')
 done
 
 # Summary
@@ -245,9 +289,25 @@ if [[ $TOTAL -gt 0 ]]; then
 fi
 
 # Write report
+RUN_END_MS=$(now_ms)
+RUN_DURATION_MS=$((RUN_END_MS - RUN_START_MS))
 echo "$RESULTS" | jq '{
     provider: "'"$PROVIDER"'",
     timestamp: "'"$TIMESTAMP"'",
+    duration_ms: '"$RUN_DURATION_MS"',
+    usage_summary: {
+        available: false,
+        reason: "'"$USAGE_UNAVAILABLE_REASON"'",
+        provider: "'"$PROVIDER"'",
+        model: null,
+        request_count: null,
+        prompt_tokens: null,
+        completion_tokens: null,
+        total_tokens: null,
+        estimated_cost_usd: null,
+        provider_failure_count: null
+    },
+    duumbi_command_attempts: '"$TOTAL"',
     total: '"$TOTAL"',
     passed: '"$PASSED"',
     failed: '"$FAILED"',

--- a/scripts/eval_intent.sh
+++ b/scripts/eval_intent.sh
@@ -96,7 +96,6 @@ for txt_file in "$CORPUS_DIR"/*.txt; do
 
     # Run intent create
     GENERATED=""
-    DUUMBI_COMMAND_ATTEMPTED=false
     DUUMBI_COMMAND_ATTEMPTED=true
     if output=$(cd "$PROJECT_DIR" && "$DUUMBI" intent create "$description" --yes 2>&1); then
         # Find the newly created file (diff against snapshot)


### PR DESCRIPTION
## Summary

Related to #610.

- Adds metadata-only workflow metrics JSON artifacts and step summaries to Stage Approval, Human Acceptance Request, Product Spec Review Request, and Technical Spec Review Request workflows.
- Adds safe count/correlation outputs for review request workflows without writing Slack message bodies, issue bodies, comment bodies, provider output, or secrets to metrics artifacts.
- Extends `scripts/eval_intent.sh` reports with total/per-task duration, command-attempt count, and explicit provider usage unavailable metadata.

## Specs

- Product spec: https://github.com/hgahub/duumbi/pull/612
- Technical spec: https://github.com/hgahub/duumbi/pull/613

## Ralph Cycle Evidence

### Cycle 1

Goal: Add Stage Approval workflow metrics scaffolding and local verification.

Changes:
- `.github/workflows/stage-approval.yml`: adds `actions: read`, metadata-only metrics JSON generation, GitHub summary output, and warning-only artifact upload.

Checks:
- `git diff --check`: passed
- Ruby YAML parse for `stage-approval.yml`: passed
- Stage Approval metrics simulation with `workflow_dispatch` and `repository_dispatch`: passed
- `jq` validation of simulated metrics JSON: passed
- `actionlint`: unavailable

Resource use:
- External LLM calls: 0
- Estimated external LLM cost: USD 0

### Cycle 2

Goal: Add review request workflow metrics paths and safe outputs.

Changes:
- `.github/workflows/human-acceptance-request.yml`: adds safe queued issue count and metrics job.
- `.github/workflows/spec-review-request.yml`: adds safe queued issue count, artifact availability counts, and metrics job.
- `.github/workflows/technical-spec-review-request.yml`: adds safe queued issue count, artifact availability counts, and metrics job.

Checks:
- `git diff --check`: passed
- Ruby YAML parse for all four touched workflows: passed
- Static secret/payload scan: reviewed; matches are existing secret/env references, existing Slack posting code, context reads, and new privacy flag names. Metrics artifacts do not write those values.
- `actionlint`: unavailable

Resource use:
- External LLM calls: 0
- Estimated external LLM cost: USD 0

### Cycle 3

Goal: Add eval report timing and explicit provider usage availability.

Changes:
- `scripts/eval_intent.sh`: adds coarse millisecond timing, per-task duration, total duration, command-attempt count, and provider usage unavailable metadata.

Checks:
- `bash -n scripts/eval_intent.sh`: passed
- `jq` report-field construction simulation: passed
- `git diff --cached --check`: passed

Resource use:
- External LLM calls: 0
- Estimated external LLM cost: USD 0
- Live provider E2E: not run; this implementation avoided live provider calls and generated report artifacts.
- Live GitHub Actions smoke: not run; the approved technical spec treats live workflow mutation as requiring a safe test issue or explicit approval.

## Review Notes

- Metrics upload steps use `continue-on-error: true` so artifact upload warnings do not mask primary workflow results.
- Provider usage remains explicit unavailable metadata until DUUMBI exposes a verified provider usage contract.
- Generated evaluation reports under `docs/e2e/results/` were not committed.
