### PR TITLE
[codex] Remove Oz workflow references

### DIFF
--- a/.agents/skills/duumbi-human-acceptance/SKILL.md
+++ b/.agents/skills/duumbi-human-acceptance/SKILL.md
@@ -35,7 +35,7 @@ This skill does not:
 - The durable Stage 5 decision record is a structured GitHub issue comment.
 - GitHub Issues and Project fields hold acceptance and execution state.
 - Obsidian stores durable knowledge, not live acceptance state.
-- Slack, Codex, and Oz may carry the human decision to the agent, but the decision must be recorded back on the GitHub Issue.
+- Slack, Codex App, Codex Cloud, and reviewed local agents may carry the human decision to the agent, but the decision must be recorded back on the GitHub Issue.
 
 ## Language Rules
 
@@ -164,7 +164,7 @@ For every explicit decision, write this structured GitHub issue comment:
 ## Stage 5 Human Acceptance Decision
 
 **Decision:** <Accept | Needs Clarification | Duplicate | Defer | Reject>
-**Reviewer source:** <Codex | Oz | Slack | GitHub | other>
+**Reviewer source:** <Codex App | Codex Cloud | Codex CLI | Slack | GitHub | other>
 **Rationale:** <short rationale>
 **Stage 4 recommendation considered:** <yes/no and short note>
 **Remaining open questions:** <none or list>

--- a/.agents/skills/duumbi-obsidian-capture/SKILL.md
+++ b/.agents/skills/duumbi-obsidian-capture/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: duumbi-obsidian-capture
-description: "Run DUUMBI Stage 1 Slack Oz intake: read a Slack idea or request, inspect active vault context, clarify intent, and create one raw intake note under Duumbi/00 Inbox (ToProcess) for later triage."
+description: "Run DUUMBI Stage 1 Slack intake: read a Slack idea or request, inspect active vault context, clarify intent, and create one raw intake note under Duumbi/00 Inbox (ToProcess) for later triage."
 ---
 
 You are the DUUMBI Slack-to-Inbox Capture Agent.
 
-Your job is to handle Stage 1 intake from Slack. A planner may post in the dedicated DUUMBI idea channel, use a Slack shortcut, or invoke `@Oz use duumbi-obsidian-capture` to discuss an idea. You help clarify the idea, answer questions from available DUUMBI context, and when the user confirms, create one raw intake note under `Duumbi/00 Inbox (ToProcess)/`.
+Your job is to handle Stage 1 intake from Slack. A planner may post in the dedicated DUUMBI idea channel, use a Slack shortcut, or invoke the configured Slack-to-Codex handoff to discuss an idea. You help clarify the idea, answer questions from available DUUMBI context, and when the user confirms, create one raw intake note under `Duumbi/00 Inbox (ToProcess)/`.
 
 ## Stage Boundary
 

--- a/.agents/skills/duumbi-spec-review/SKILL.md
+++ b/.agents/skills/duumbi-spec-review/SKILL.md
@@ -110,7 +110,7 @@ Review the product spec for:
 - decisions cite evidence or issue comments
 - behavior covers success, empty, error, retry, cancellation, and relevant accessibility/focus states
 - BDD scenarios are present, clear, written in English Gherkin-style language, and describe observable outcomes
-- tasks are small enough for Codex or Oz runs
+- tasks are small enough for Codex App, Codex Cloud, or reviewed local agent runs
 - checks map to acceptance criteria
 - checks map to BDD scenarios, including E2E expectations where relevant
 - open questions are resolved or explicitly accepted as risk
@@ -182,7 +182,7 @@ For every explicit decision, write this structured GitHub issue comment:
 ## Stage 7 Product Spec Review Decision
 
 **Decision:** <Approve | Request Changes | Needs Clarification | Reject / No Longer Needed>
-**Reviewer source:** <Codex | Oz | Slack | GitHub | other>
+**Reviewer source:** <Codex App | Codex Cloud | Codex CLI | Slack | GitHub | other>
 **Spec artifact:** <comment link or PRODUCT.md path / PR link>
 **Rationale:** <short rationale>
 **Blocking findings:** <none or list>

--- a/.agents/skills/duumbi-tech-spec-draft/SKILL.md
+++ b/.agents/skills/duumbi-tech-spec-draft/SKILL.md
@@ -138,7 +138,7 @@ Use this structure:
 Which approved product-spec outcomes this technical spec implements.
 
 ## Agent Audience
-Which agents should use this spec: Codex, Oz, specialized reviewer, tester, or other.
+Which agents should use this spec: Codex App, Codex Cloud, Codex CLI, specialized reviewer, tester, or other.
 
 ## Source Context
 - Product spec:

--- a/.agents/skills/duumbi-tech-spec-review/SKILL.md
+++ b/.agents/skills/duumbi-tech-spec-review/SKILL.md
@@ -213,7 +213,7 @@ For every explicit decision, write this structured GitHub issue comment:
 ## Stage 9 Technical Spec Review Decision
 
 **Decision:** <Approve | Request Changes | Needs Clarification | Reject / No Longer Needed>
-**Reviewer source:** <Codex | Oz | Slack | GitHub | other>
+**Reviewer source:** <Codex App | Codex Cloud | Codex CLI | Slack | GitHub | other>
 **Technical spec:** <TECHNICAL.md path / PR link>
 **Product spec:** <PRODUCT.md path / comment link>
 **Rationale:** <short rationale>

--- a/.github/workflows/human-acceptance-request.yml
+++ b/.github/workflows/human-acceptance-request.yml
@@ -338,7 +338,7 @@ jobs:
                 issue_number: issueNumber,
                 body: [
                   marker,
-                  "Human acceptance Slack notification requested through Oz.",
+                  "Human acceptance Slack notification requested through GitHub Actions.",
                   "",
                   `Workflow run: ${runUrl}`,
                   `Source event: ${context.eventName}`,

--- a/.github/workflows/implementation-review-request.yml
+++ b/.github/workflows/implementation-review-request.yml
@@ -389,7 +389,7 @@ jobs:
                 issue_number: issueNumber,
                 body: [
                   marker,
-                  "Implementation review handoff Slack notification requested through Oz.",
+                  "Implementation review handoff Slack notification requested through GitHub Actions.",
                   "",
                   `Workflow run: ${runUrl}`,
                   `Source event: ${context.eventName}`,

--- a/.github/workflows/implementation-review-request.yml
+++ b/.github/workflows/implementation-review-request.yml
@@ -286,6 +286,7 @@ jobs:
                           pr_number: Number(context.payload.pull_request?.number || 0),
                           label: context.payload.label?.name,
                           action: context.payload.action,
+                          labels: labelsFor(context.payload.pull_request || {}),
                         };
                 if (context.eventName === "issues" && raw.label !== labelName) {
                   core.info(`Ignoring label "${raw.label}".`);
@@ -294,6 +295,11 @@ jobs:
                 }
                 if (context.eventName === "pull_request" && raw.action === "labeled" && raw.label !== labelName) {
                   core.info(`Ignoring PR label "${raw.label}".`);
+                  core.setOutput("should_notify", "false");
+                  return;
+                }
+                if (context.eventName === "pull_request" && raw.action === "ready_for_review" && !raw.labels.includes(labelName)) {
+                  core.info(`Ignoring ready_for_review for PR without "${labelName}".`);
                   core.setOutput("should_notify", "false");
                   return;
                 }

--- a/.github/workflows/ralph-cycle-approval-request.yml
+++ b/.github/workflows/ralph-cycle-approval-request.yml
@@ -323,7 +323,7 @@ jobs:
                 issue_number: issueNumber,
                 body: [
                   marker,
-                  "Ralph Cycle resource authorization Slack notification requested through Oz.",
+                  "Ralph Cycle resource authorization Slack notification requested through GitHub Actions.",
                   "",
                   `Workflow run: ${runUrl}`,
                   `Source event: ${context.eventName}`,

--- a/.github/workflows/spec-review-request.yml
+++ b/.github/workflows/spec-review-request.yml
@@ -372,7 +372,7 @@ jobs:
                 issue_number: issueNumber,
                 body: [
                   marker,
-                  "Product spec review Slack notification requested through Oz.",
+                  "Product spec review Slack notification requested through GitHub Actions.",
                   "",
                   `Workflow run: ${runUrl}`,
                   `Source event: ${context.eventName}`,

--- a/.github/workflows/technical-spec-review-request.yml
+++ b/.github/workflows/technical-spec-review-request.yml
@@ -407,7 +407,7 @@ jobs:
                 issue_number: issueNumber,
                 body: [
                   marker,
-                  "Technical spec review Slack notification requested through Oz.",
+                  "Technical spec review Slack notification requested through GitHub Actions.",
                   "",
                   `Workflow run: ${runUrl}`,
                   `Source event: ${context.eventName}`,

--- a/docs/automation/agentic-development-orchestration.md
+++ b/docs/automation/agentic-development-orchestration.md
@@ -12,8 +12,8 @@ or source-repo contracts that support it.
 - Obsidian stores raw intake and durable knowledge.
 - Slack is a capture, notification, clarification, and approval surface.
 - GitHub Actions do not call model APIs directly. Scheduled workflows create
-  deterministic dispatch records and Slack handoffs for Oz/Codex Cloud or Codex
-  App runs.
+  deterministic dispatch records and Slack handoffs for Codex Cloud, Codex App,
+  Codex CLI, or reviewed local agent runs.
 
 ## Skills Added Or Updated
 

--- a/docs/automation/human-acceptance-slack-gate.md
+++ b/docs/automation/human-acceptance-slack-gate.md
@@ -2,7 +2,7 @@
 
 The Human Acceptance Slack Gate connects the DUUMBI Stage 4 triage label
 `needs-human-review` to a Slack review notification from GitHub Actions. The
-current version uses GitHub Actions, Slack, Warp/Oz fallback prompts, and the
+current version uses GitHub Actions, Slack, Codex handoff prompts, and the
 Slack approval bridge for deterministic button decisions.
 
 The durable Stage 5 decision remains the GitHub issue comment and Project/label
@@ -19,19 +19,14 @@ updates performed by `duumbi-human-acceptance`.
 5. The read-only notification job posts one Slack message per issue with the
    Slack Web API `chat.postMessage`.
 6. The Slack message includes interactive buttons when the bridge is configured.
-   If the bridge is unavailable, the reviewer can reply in-thread with
-   `@Oz accepted: <short rationale>`.
+   If the bridge is unavailable, the reviewer should record the decision from
+   Codex App, Codex Cloud, Codex CLI, or a reviewed local agent run using the
+   `duumbi-human-acceptance` skill.
 7. After Slack posting succeeds, a separate marker job writes an operational
    marker comment to the issue so future scheduled sweeps do not send duplicate
    notifications.
-8. Fallback only: the reviewer replies in Slack with:
-
-```text
-@Oz accepted: <short rationale>
-```
-
-9. Fallback only: the inbound Warp/Oz Slack integration handles the reviewer reply and runs in
-   the `duumbi-vault-knowledge-env` environment:
+8. Fallback only: the reviewer records the decision with the configured Codex
+   handoff:
 
 ```text
 Run DUUMBI Stage 5 Human Acceptance with duumbi-human-acceptance.
@@ -55,8 +50,8 @@ without an external webhook receiver. The no-server contract is therefore:
 - The GitHub Action trigger is the issue label `needs-human-review`.
 - A scheduled sweep runs hourly and catches open `needs-human-review`
   issues that have not yet received the notification marker.
-- A scheduled sweep processes at most 10 issues per run to keep the Oz prompt
-  and Slack notifications bounded.
+- A scheduled sweep processes at most 10 issues per run to keep generated
+  handoff prompts and Slack notifications bounded.
 - Stage 4 must keep adding `needs-human-review` whenever it routes an issue to
   `Needs Human Acceptance`.
 
@@ -82,25 +77,14 @@ The marker is operational state only. It is not the Stage 5 decision record.
 No `SLACK_WEBHOOK_URL` is required. The workflow uses the Slack Web API directly
 from GitHub Actions. The Slack bot must be invited to the target review channel.
 
-The Warp/Oz Slack integration, visible in Slack under Apps -> Warp, remains
-available for the fallback reviewer reply path: a human replies with
-`@Oz accepted: <short rationale>`, and that inbound Slack mention starts Oz.
+There is no secondary Slack-agent fallback path. If interactive buttons are
+unavailable, the reviewer uses Codex App, Codex Cloud, Codex CLI, or a reviewed
+local agent run with the `duumbi-human-acceptance` skill.
 
 For interactive buttons, `scripts/slack-approval-bridge` routes Stage 5, Stage 7,
 and Stage 9 to `stage-approval.yml`, Stage 10 to
 `stage10-authorization-request.yml`, and Stage 11 to
 `stage11-merge-decision.yml`.
-
-`duumbi-vault-knowledge-env` is an Oz environment, not an agent profile. Its
-environment ID is:
-
-```text
-eKLEWjD4PNqFC6j0EcDEYA
-```
-
-Do not pass the environment name through the Oz action's `profile` input. That
-input expects an agent profile and fails with `Agent profile "... " not found`
-when given the environment name.
 
 The Slack notification job uses `issues: read`. A separate marker job uses
 `issues: write` only after Slack posting succeeds.
@@ -122,14 +106,22 @@ Expected result: the workflow posts a Slack notification to
 1. Add the `needs-human-review` label to a test issue.
 2. Confirm that GitHub Actions runs `Human Acceptance Request`.
 3. Confirm that the workflow posts a Slack notification.
-4. Reply in the Slack notification thread with:
+4. If interactive buttons are unavailable, run the fallback Codex handoff:
 
 ```text
-@Oz accepted: <short rationale>
+Run DUUMBI Stage 5 Human Acceptance with duumbi-human-acceptance.
+
+Target issue: <GitHub issue URL>
+Human decision: Accept
+Reviewer source: Slack
+Rationale: <short human rationale>
+
+Goal: Record the structured Stage 5 decision, set the issue to Spec Needed, add accepted and needs-spec labels, and remove needs-human-review when available.
+
+Do not create product specs, technical specs, PRs, source-code changes, or implementation branches.
 ```
 
-6. Confirm that inbound Oz routes the acceptance run to
-   `duumbi-vault-knowledge-env`.
+6. Confirm that the Codex handoff records the acceptance decision.
 7. Confirm that the issue receives the notification marker comment.
 8. Confirm that the issue receives a Stage 5 decision comment, is moved to
    `Spec Needed`, gets `accepted` and `needs-spec`, and loses

--- a/scripts/slack-approval-bridge/README.md
+++ b/scripts/slack-approval-bridge/README.md
@@ -5,7 +5,7 @@ Actions workflows via `repository_dispatch`.
 
 Clicking **Approve**, **Request Changes**, or **Needs Clarification** in a
 DUUMBI Slack notification triggers a deterministic GitHub Action instead of
-an LLM-based Oz agent. Slack shortcuts can also dispatch Stage 1 intake.
+launching an agent directly. Slack shortcuts can also dispatch Stage 1 intake.
 Existing Stage 5, Stage 7, and Stage 9 buttons continue to route to
 `stage-approval.yml`. Stage 10 resource authorization buttons that include
 `action_type: "stage_10_authorization"` route to `stage-10-authorization.yml`.

--- a/scripts/slack-approval-bridge/src/functions/slackApproval.js
+++ b/scripts/slack-approval-bridge/src/functions/slackApproval.js
@@ -14,7 +14,7 @@ const crypto = require("node:crypto");
  *
  * Bridges Slack interactive button clicks → GitHub repository_dispatch so that
  * approval decisions execute deterministically via GitHub Actions instead of
- * spawning an LLM-based Oz agent.
+ * launching an agent directly.
  *
  * App Settings (configure in Azure Function App):
  *   SLACK_SIGNING_SECRET  — Slack app signing secret


### PR DESCRIPTION
## Summary

Remove Oz from the active DUUMBI source-repo workflow contracts.

## Changes

- Replace Slack/Oz intake wording with Slack-to-Codex handoff language.
- Remove Oz from reviewer source examples and skill contracts.
- Update GitHub Actions notification marker text so new audit comments reference GitHub Actions, not Oz.
- Rewrite the human acceptance Slack gate fallback to use Codex App, Codex Cloud, Codex CLI, or a reviewed local agent run.
- Update Slack bridge docs and comments so the bridge is described as deterministic GitHub Actions routing, not agent launch.

## Validation

- `rg -n "\bOz\b|\bOZ_\w+\b|stage_launch|stage-launch|Warp Oz" .github .agents docs scripts AGENTS.md README.md` returns no matches.
- `npm test` in `scripts/slack-approval-bridge` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated automation workflow documentation to clarify supported agent and reviewer source options (Codex App, Codex Cloud, Codex CLI, and reviewed local agents)
  * Refined human acceptance approval process with updated handoff mechanisms

* **Chores**
  * Updated system notification references and workflow configuration to reflect current automation infrastructure

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hgahub/duumbi/pull/622?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->