### PR TITLE
[codex] Quiet inbox enrichment dispatches

### DIFF
--- a/.agents/skills/duumbi-inbox-enrichment/SKILL.md
+++ b/.agents/skills/duumbi-inbox-enrichment/SKILL.md
@@ -50,6 +50,9 @@ Use this skill for:
 - a scheduled sweep of notes that lack the standard Inbox contract, classification, or enrichment marker
 
 For scheduled sweeps, process a bounded batch. Default maximum: 5 notes per run.
+Scheduled dispatchers should inspect the Inbox before sending an agent handoff.
+If no candidate notes are present, they should record `not_needed` in workflow
+summary/metrics and skip Slack notification.
 
 ## Context To Inspect
 

--- a/.github/workflows/inbox-enrichment-dispatch.yml
+++ b/.github/workflows/inbox-enrichment-dispatch.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout DUUMBI vault
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         continue-on-error: true
         with:
           repository: ${{ github.repository_owner }}/duumbi-vault

--- a/.github/workflows/inbox-enrichment-dispatch.yml
+++ b/.github/workflows/inbox-enrichment-dispatch.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout DUUMBI vault
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         continue-on-error: true
         with:
           repository: ${{ github.repository_owner }}/duumbi-vault
@@ -57,20 +57,9 @@ jobs:
             const inboxRoot = path.join(vaultRoot, "Duumbi", "00 Inbox (ToProcess)");
             const warnings = [];
             let workflowConclusion = "success";
+            let inspectedCount = 0;
 
             const toVaultRelative = (absolutePath) => path.relative(vaultRoot, absolutePath).split(path.sep).join("/");
-            const listMarkdownFiles = (dir) => {
-              const files = [];
-              for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-                const fullPath = path.join(dir, entry.name);
-                if (entry.isDirectory()) {
-                  files.push(...listMarkdownFiles(fullPath));
-                } else if (entry.isFile() && entry.name.endsWith(".md")) {
-                  files.push(fullPath);
-                }
-              }
-              return files;
-            };
             const isEnrichmentCandidate = (absolutePath) => {
               const text = fs.readFileSync(absolutePath, "utf8");
               const requiredSections = [
@@ -78,17 +67,43 @@ jobs:
                 "## Raw input",
                 "## Interpreted intent",
                 "## Classification",
+                "## Clarifications",
+                "### Answered",
+                "### Open",
+                "## Relevant DUUMBI context",
+                "## Related GitHub context",
                 "## Initial routing recommendation",
+                "## Requested follow-up",
                 "## Enrichment result",
               ];
               return requiredSections.some((section) => !text.includes(section));
             };
+            const collectCandidatePaths = (dir, limit) => {
+              const candidates = [];
+              const visit = (currentDir) => {
+                const entries = fs.readdirSync(currentDir, { withFileTypes: true })
+                  .sort((a, b) => a.name.localeCompare(b.name));
+                for (const entry of entries) {
+                  if (candidates.length >= limit) return;
+                  const fullPath = path.join(currentDir, entry.name);
+                  if (entry.isDirectory()) {
+                    visit(fullPath);
+                  } else if (entry.isFile() && entry.name.endsWith(".md")) {
+                    inspectedCount += 1;
+                    if (isEnrichmentCandidate(fullPath)) {
+                      candidates.push(toVaultRelative(fullPath));
+                    }
+                  }
+                }
+              };
+              visit(dir);
+              return candidates;
+            };
 
             let candidatePaths = [];
-            let inspectedCount = 0;
             if (!fs.existsSync(inboxRoot)) {
               warnings.push("DUUMBI vault Inbox path is unavailable; enrichment dispatch failed closed.");
-              workflowConclusion = "blocked";
+              workflowConclusion = "failure";
               core.setFailed(`Missing Inbox path: ${inboxRoot}`);
             } else if (targetPath) {
               const normalizedTarget = targetPath.replace(/^duumbi-vault\//, "").replace(/^\/+/, "");
@@ -96,23 +111,26 @@ jobs:
               const relativeToInbox = path.relative(inboxRoot, targetAbsolute);
               if (relativeToInbox.startsWith("..") || path.isAbsolute(relativeToInbox)) {
                 warnings.push("Target path is outside Duumbi/00 Inbox (ToProcess); no dispatch sent.");
-                workflowConclusion = "blocked";
+                workflowConclusion = "failure";
                 core.setFailed(`Target path is outside Inbox: ${targetPath}`);
               } else if (!fs.existsSync(targetAbsolute) || !fs.statSync(targetAbsolute).isFile()) {
                 warnings.push("Target Inbox note does not exist; no dispatch sent.");
-                workflowConclusion = "blocked";
+                workflowConclusion = "failure";
                 core.setFailed(`Target Inbox note not found: ${targetPath}`);
               } else {
                 inspectedCount = 1;
-                candidatePaths = [toVaultRelative(targetAbsolute)];
+                candidatePaths = isEnrichmentCandidate(targetAbsolute) ? [toVaultRelative(targetAbsolute)] : [];
               }
             } else {
-              const inboxFiles = listMarkdownFiles(inboxRoot);
-              inspectedCount = inboxFiles.length;
-              candidatePaths = inboxFiles.filter(isEnrichmentCandidate).slice(0, effectiveBatchSize).map(toVaultRelative);
+              candidatePaths = collectCandidatePaths(inboxRoot, effectiveBatchSize);
             }
 
             const shouldDispatch = candidatePaths.length > 0;
+            const dispatchDecision = workflowConclusion === "failure"
+              ? "dispatch_blocked"
+              : shouldDispatch
+                ? "dispatch_requested"
+                : "dispatch_not_needed";
             const prompt = shouldDispatch ? [
               "Run DUUMBI scheduled Inbox enrichment with duumbi-inbox-enrichment.",
               "",
@@ -187,7 +205,7 @@ jobs:
                 issue_number: null,
                 pr_number: null,
                 stage: "inbox-enrichment",
-                decision: shouldDispatch ? "dispatch_requested" : "dispatch_not_needed",
+                decision: dispatchDecision,
                 project_status: null,
               },
               counts: {
@@ -219,6 +237,7 @@ jobs:
               },
               warnings: [
                 ...warnings,
+                ...(!shouldDispatch && workflowConclusion === "success" ? ["slack_notification_not_needed"] : []),
                 ...(shouldDispatch && slackNotification !== "posted" ? [`slack_notification_${slackNotification}`] : []),
               ],
             };

--- a/.github/workflows/inbox-enrichment-dispatch.yml
+++ b/.github/workflows/inbox-enrichment-dispatch.yml
@@ -2,7 +2,7 @@ name: Inbox Enrichment Dispatch
 
 on:
   schedule:
-    - cron: '0 */3 * * *'
+    - cron: '0 6,18 * * *'
   workflow_dispatch:
     inputs:
       target_path:
@@ -28,6 +28,15 @@ jobs:
     name: Dispatch enrichment prompt
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout DUUMBI vault
+        uses: actions/checkout@v5
+        continue-on-error: true
+        with:
+          repository: ${{ github.repository_owner }}/duumbi-vault
+          path: duumbi-vault
+          token: ${{ secrets.GH_PROJECT_PAT || github.token }}
+          persist-credentials: false
+
       - name: Build dispatch record
         id: dispatch
         uses: actions/github-script@v9
@@ -39,26 +48,91 @@ jobs:
         with:
           script: |
             const fs = require("fs");
+            const path = require("path");
             const inputs = context.payload.inputs || {};
             const targetPath = String(inputs.target_path || "").trim();
             const batchSize = Number(inputs.batch_size || 5);
-            const prompt = [
+            const effectiveBatchSize = Number.isFinite(batchSize) && batchSize > 0 ? batchSize : 5;
+            const vaultRoot = path.resolve("duumbi-vault");
+            const inboxRoot = path.join(vaultRoot, "Duumbi", "00 Inbox (ToProcess)");
+            const warnings = [];
+            let workflowConclusion = "success";
+
+            const toVaultRelative = (absolutePath) => path.relative(vaultRoot, absolutePath).split(path.sep).join("/");
+            const listMarkdownFiles = (dir) => {
+              const files = [];
+              for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+                const fullPath = path.join(dir, entry.name);
+                if (entry.isDirectory()) {
+                  files.push(...listMarkdownFiles(fullPath));
+                } else if (entry.isFile() && entry.name.endsWith(".md")) {
+                  files.push(fullPath);
+                }
+              }
+              return files;
+            };
+            const isEnrichmentCandidate = (absolutePath) => {
+              const text = fs.readFileSync(absolutePath, "utf8");
+              const requiredSections = [
+                "## Source",
+                "## Raw input",
+                "## Interpreted intent",
+                "## Classification",
+                "## Initial routing recommendation",
+                "## Enrichment result",
+              ];
+              return requiredSections.some((section) => !text.includes(section));
+            };
+
+            let candidatePaths = [];
+            let inspectedCount = 0;
+            if (!fs.existsSync(inboxRoot)) {
+              warnings.push("DUUMBI vault Inbox path is unavailable; enrichment dispatch failed closed.");
+              workflowConclusion = "blocked";
+              core.setFailed(`Missing Inbox path: ${inboxRoot}`);
+            } else if (targetPath) {
+              const normalizedTarget = targetPath.replace(/^duumbi-vault\//, "").replace(/^\/+/, "");
+              const targetAbsolute = path.resolve(vaultRoot, normalizedTarget);
+              const relativeToInbox = path.relative(inboxRoot, targetAbsolute);
+              if (relativeToInbox.startsWith("..") || path.isAbsolute(relativeToInbox)) {
+                warnings.push("Target path is outside Duumbi/00 Inbox (ToProcess); no dispatch sent.");
+                workflowConclusion = "blocked";
+                core.setFailed(`Target path is outside Inbox: ${targetPath}`);
+              } else if (!fs.existsSync(targetAbsolute) || !fs.statSync(targetAbsolute).isFile()) {
+                warnings.push("Target Inbox note does not exist; no dispatch sent.");
+                workflowConclusion = "blocked";
+                core.setFailed(`Target Inbox note not found: ${targetPath}`);
+              } else {
+                inspectedCount = 1;
+                candidatePaths = [toVaultRelative(targetAbsolute)];
+              }
+            } else {
+              const inboxFiles = listMarkdownFiles(inboxRoot);
+              inspectedCount = inboxFiles.length;
+              candidatePaths = inboxFiles.filter(isEnrichmentCandidate).slice(0, effectiveBatchSize).map(toVaultRelative);
+            }
+
+            const shouldDispatch = candidatePaths.length > 0;
+            const prompt = shouldDispatch ? [
               "Run DUUMBI scheduled Inbox enrichment with duumbi-inbox-enrichment.",
               "",
               targetPath
-                ? `Target Inbox note: ${targetPath}`
-                : `Target: bounded scheduled sweep of untagged or unnormalized notes under Duumbi/00 Inbox (ToProcess)/`,
-              `Batch size: ${Number.isFinite(batchSize) && batchSize > 0 ? batchSize : 5}`,
+                ? `Target Inbox note: ${candidatePaths[0]}`
+                : "Target: bounded scheduled sweep of untagged or unnormalized notes under Duumbi/00 Inbox (ToProcess)/",
+              `Batch size: ${effectiveBatchSize}`,
+              "",
+              "Candidate notes:",
+              ...candidatePaths.map((candidatePath) => `- ${candidatePath}`),
               "",
               "Goal: Normalize manually edited Inbox notes into the DUUMBI Inbox contract, classify them, detect duplicates against active Inbox, Processed Inbox, Atlas, GitHub Issues, and GitHub Discussions, and leave them ready for Stage 4 triage.",
               "",
               "Do not create GitHub issues, specs, PRs, source changes, Atlas notes, or implementation work.",
-            ].join("\n");
+            ].join("\n") : "";
 
             const token = process.env.SLACK_BOT_TOKEN;
             const channel = process.env.DUUMBI_AGENT_DISPATCH_CHANNEL_ID || process.env.SLACK_REVIEW_CHANNEL_ID;
-            let slackNotification = "not_configured";
-            if (token && channel) {
+            let slackNotification = shouldDispatch ? "not_configured" : "not_needed";
+            if (shouldDispatch && token && channel) {
               const res = await fetch("https://slack.com/api/chat.postMessage", {
                 method: "POST",
                 headers: {
@@ -85,7 +159,7 @@ jobs:
               } else {
                 slackNotification = "posted";
               }
-            } else {
+            } else if (shouldDispatch) {
               core.warning("Slack dispatch channel is not configured; prompt is available in the workflow summary.");
             }
 
@@ -104,7 +178,7 @@ jobs:
                 actor: context.actor,
                 ref: context.ref,
                 sha: context.sha,
-                conclusion: "success",
+                conclusion: workflowConclusion,
                 started_at: now,
                 completed_at: now,
                 duration_ms: null,
@@ -113,14 +187,14 @@ jobs:
                 issue_number: null,
                 pr_number: null,
                 stage: "inbox-enrichment",
-                decision: null,
+                decision: shouldDispatch ? "dispatch_requested" : "dispatch_not_needed",
                 project_status: null,
               },
               counts: {
-                issues_considered: null,
-                issues_queued: null,
-                slack_notifications_attempted: token && channel ? 1 : 0,
-                artifact_links_found: null,
+                issues_considered: inspectedCount,
+                issues_queued: candidatePaths.length,
+                slack_notifications_attempted: shouldDispatch && token && channel ? 1 : 0,
+                artifact_links_found: candidatePaths.length,
                 artifact_links_missing: null,
               },
               provider_usage: {
@@ -143,21 +217,26 @@ jobs:
                 raw_slack_payloads_included: false,
                 secrets_included: false,
               },
-              warnings: slackNotification === "posted" ? [] : [`slack_notification_${slackNotification}`],
+              warnings: [
+                ...warnings,
+                ...(shouldDispatch && slackNotification !== "posted" ? [`slack_notification_${slackNotification}`] : []),
+              ],
             };
             fs.writeFileSync(process.env.DUUMBI_METRICS_PATH, `${JSON.stringify(metrics, null, 2)}\n`);
 
-            await core.summary
+            const summary = core.summary
               .addHeading("DUUMBI Inbox Enrichment Dispatch", 2)
               .addTable([
                 [{ data: "Field", header: true }, { data: "Value", header: true }],
                 ["Target", targetPath || "scheduled sweep"],
-                ["Batch size", String(Number.isFinite(batchSize) && batchSize > 0 ? batchSize : 5)],
+                ["Batch size", String(effectiveBatchSize)],
+                ["Inbox notes inspected", String(inspectedCount)],
+                ["Candidate notes", candidatePaths.length ? candidatePaths.join("<br>") : "none"],
+                ["Dispatch needed", String(shouldDispatch)],
                 ["Slack dispatch", slackNotification],
-              ])
-              .addHeading("Agent Prompt", 3)
-              .addCodeBlock(prompt, "text")
-              .write();
+              ]);
+            if (prompt) summary.addHeading("Agent Prompt", 3).addCodeBlock(prompt, "text");
+            await summary.write();
 
       - name: Upload DUUMBI workflow metrics
         if: always()

--- a/docs/automation/agentic-development-orchestration.md
+++ b/docs/automation/agentic-development-orchestration.md
@@ -33,7 +33,7 @@ or source-repo contracts that support it.
 | Workflow | Trigger | Purpose |
 |---|---|---|
 | `slack-intake-dispatch.yml` | Slack shortcut repository dispatch, manual | Dispatches Stage 1 Slack intake without requiring the developer to name the skill. |
-| `inbox-enrichment-dispatch.yml` | twice daily, manual | Checks `duumbi-vault` for unnormalized Inbox notes and dispatches `duumbi-inbox-enrichment` only when candidate notes exist. |
+| `inbox-enrichment-dispatch.yml` | 06:00 UTC and 18:00 UTC, manual | Checks `duumbi-vault` for unnormalized Inbox notes and dispatches `duumbi-inbox-enrichment` only when candidate notes exist. |
 | `triage-queue-refill.yml` | every 3 hours, manual | Reads Project V2 Todo count and dispatches bounded Stage 4 triage when Todo is below the configured minimum. |
 | `clarification-routing.yml` | issue comment mention, manual | Routes `@Codex` or `@Copilot` clarification replies to the right stage-specific agent. |
 | `spec-ai-gate.yml` | manual, repository dispatch | Records Stage 7/9 AI gate decisions and dispatches `stage-approval.yml` for clean approvals. |

--- a/docs/automation/agentic-development-orchestration.md
+++ b/docs/automation/agentic-development-orchestration.md
@@ -33,7 +33,7 @@ or source-repo contracts that support it.
 | Workflow | Trigger | Purpose |
 |---|---|---|
 | `slack-intake-dispatch.yml` | Slack shortcut repository dispatch, manual | Dispatches Stage 1 Slack intake without requiring the developer to name the skill. |
-| `inbox-enrichment-dispatch.yml` | every 3 hours, manual | Dispatches `duumbi-inbox-enrichment` prompt for unnormalized Inbox notes. |
+| `inbox-enrichment-dispatch.yml` | twice daily, manual | Checks `duumbi-vault` for unnormalized Inbox notes and dispatches `duumbi-inbox-enrichment` only when candidate notes exist. |
 | `triage-queue-refill.yml` | every 3 hours, manual | Reads Project V2 Todo count and dispatches bounded Stage 4 triage when Todo is below the configured minimum. |
 | `clarification-routing.yml` | issue comment mention, manual | Routes `@Codex` or `@Copilot` clarification replies to the right stage-specific agent. |
 | `spec-ai-gate.yml` | manual, repository dispatch | Records Stage 7/9 AI gate decisions and dispatches `stage-approval.yml` for clean approvals. |


### PR DESCRIPTION
## Summary

- Run inbox enrichment dispatch twice daily instead of every 3 hours.
- Check `duumbi-vault/Duumbi/00 Inbox (ToProcess)/` before posting Slack handoffs.
- Record `not_needed` in workflow summary/metrics and skip Slack when no candidate notes exist.
- Update the source repo skill/docs to match the new behavior.

## Validation

- Parsed `.github/workflows/inbox-enrichment-dispatch.yml` as YAML.
- Checked the embedded GitHub Script with `node --check`.
- Ran `git diff --check` for the source repo changes.
- Ran `git diff --check` for the related `duumbi-vault` runbook change before its direct main push.

## Related Vault Update

The matching `duumbi-vault` runbook update was committed and pushed directly to `main` as requested: `4167f23` (`docs: update inbox enrichment cadence`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Inbox enrichment dispatch now runs on a fixed twice-daily schedule (06:00 and 18:00) instead of every 3 hours.
  * Improved validation with clearer error reporting when dispatch prerequisites fail.

* **Documentation**
  * Updated dispatcher guidance on pre-dispatch Inbox inspection procedures.
  * Updated automation documentation to reflect new dispatch schedule.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hgahub/duumbi/pull/623?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->