### PR TITLE
[codex] Add DeepSeek triage queue refill

### DIFF
--- a/.github/workflows/triage-queue-refill.yml
+++ b/.github/workflows/triage-queue-refill.yml
@@ -2,16 +2,11 @@ name: Triage Queue Refill
 
 on:
   schedule:
-    - cron: '0 */3 * * *'
+    - cron: '0 */4 * * *'
   workflow_dispatch:
     inputs:
-      target_todo_min:
-        description: Minimum Todo issues to keep available
-        required: false
-        type: number
-        default: 3
-      batch_limit:
-        description: Maximum triage items to request in one dispatch
+      target_human_acceptance_min:
+        description: Minimum Needs Human Acceptance issues to keep waiting
         required: false
         type: number
         default: 3
@@ -24,264 +19,47 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  inspect-and-dispatch:
-    name: Inspect Todo queue and dispatch triage
+  refill:
+    name: Refill Needs Human Acceptance queue
     runs-on: ubuntu-latest
     steps:
-      - name: Inspect Project V2 Todo count
-        uses: actions/github-script@v9
+      - name: Check out source repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Check out DUUMBI vault
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        continue-on-error: true
+        with:
+          repository: ${{ github.repository_owner }}/duumbi-vault
+          path: duumbi-vault
+          token: ${{ secrets.GH_PROJECT_PAT }}
+          persist-credentials: false
+
+      - name: Inspect Project V2 and refill queue
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553
         env:
           GH_PROJECT_PAT: ${{ secrets.GH_PROJECT_PAT }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          DEEPSEEK_MODEL: ${{ vars.DEEPSEEK_MODEL || 'deepseek-v4-pro' }}
           DUUMBI_PROJECT_OWNER: ${{ vars.DUUMBI_PROJECT_OWNER || github.repository_owner }}
           DUUMBI_PROJECT_NUMBER: ${{ vars.DUUMBI_PROJECT_NUMBER }}
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          SLACK_REVIEW_CHANNEL_ID: ${{ secrets.SLACK_REVIEW_CHANNEL_ID }}
-          DUUMBI_AGENT_DISPATCH_CHANNEL_ID: ${{ secrets.DUUMBI_AGENT_DISPATCH_CHANNEL_ID }}
           DUUMBI_METRICS_PATH: duumbi-workflow-metrics.json
         with:
           script: |
-            const fs = require("fs");
-            const inputs = context.payload.inputs || {};
-            const targetTodoMin = Number(inputs.target_todo_min || 3);
-            const batchLimit = Number(inputs.batch_limit || 3);
-            const projectPat = process.env.GH_PROJECT_PAT;
-            const projectOwner = process.env.DUUMBI_PROJECT_OWNER || context.repo.owner;
-            const projectNumber = Number(process.env.DUUMBI_PROJECT_NUMBER || 0);
-            const now = new Date().toISOString();
-            const warnings = [];
-
-            const metrics = (conclusion, counts, providerReason) => ({
-              schema_version: "duumbi.workflow_metrics.v1",
-              generated_at: now,
-              source: "github_actions",
-              repository: `${context.repo.owner}/${context.repo.repo}`,
-              workflow: {
-                name: context.workflow,
-                file: ".github/workflows/triage-queue-refill.yml",
-                run_id: context.runId,
-                run_attempt: Number(process.env.GITHUB_RUN_ATTEMPT || 1),
-                event_name: context.eventName,
-                actor: context.actor,
-                ref: context.ref,
-                sha: context.sha,
-                conclusion,
-                started_at: now,
-                completed_at: now,
-                duration_ms: null,
-              },
-              correlation: {
-                issue_number: null,
-                pr_number: null,
-                stage: "triage-queue-refill",
-                decision: null,
-                project_status: "Todo",
-              },
-              counts,
-              provider_usage: {
-                available: false,
-                reason: providerReason,
-                provider: null,
-                model: null,
-                request_count: null,
-                prompt_tokens: null,
-                completion_tokens: null,
-                total_tokens: null,
-                estimated_cost_usd: null,
-                latency_ms: null,
-                failure_count: null,
-              },
-              privacy: {
-                metadata_only: true,
-                raw_prompts_included: false,
-                raw_completions_included: false,
-                raw_slack_payloads_included: false,
-                secrets_included: false,
-              },
-              warnings,
+            const refill = await import(`${process.env.GITHUB_WORKSPACE}/scripts/github-actions/triage-queue-refill.mjs`);
+            await refill.runTriageQueueRefill({
+              env: process.env,
+              context,
+              core,
+              summary: core.summary,
+              fetchImpl: fetch,
+              workspace: process.env.GITHUB_WORKSPACE,
             });
-
-            if (!projectPat || !projectNumber) {
-              warnings.push("Project V2 configuration unavailable; triage refill failed closed.");
-              fs.writeFileSync(process.env.DUUMBI_METRICS_PATH, `${JSON.stringify(metrics("blocked", {
-                issues_considered: null,
-                issues_queued: null,
-                slack_notifications_attempted: 0,
-                artifact_links_found: null,
-                artifact_links_missing: null,
-              }, "project_graphql_unavailable"), null, 2)}\n`);
-              await core.summary
-                .addHeading("DUUMBI Triage Queue Refill", 2)
-                .addRaw("Project V2 configuration is unavailable. Set `GH_PROJECT_PAT` and repository variable `DUUMBI_PROJECT_NUMBER`.\n")
-                .write();
-              core.setFailed("Project V2 status is not readable; failing closed.");
-              return;
-            }
-
-            const gql = async (query, variables) => {
-              const res = await fetch("https://api.github.com/graphql", {
-                method: "POST",
-                headers: {
-                  Authorization: `bearer ${projectPat}`,
-                  "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ query, variables }),
-              });
-              const json = await res.json();
-              if (json.errors) throw new Error(json.errors.map((e) => e.message).join("; "));
-              return json.data;
-            };
-
-            const projectPageQuery = `
-              query($login: String!, $number: Int!, $cursor: String) {
-                organization(login: $login) {
-                  projectV2(number: $number) {
-                    title
-                    items(first: 100, after: $cursor) {
-                      pageInfo { hasNextPage endCursor }
-                      nodes {
-                        content {
-                          ... on Issue { number title url state }
-                        }
-                        fieldValues(first: 20) {
-                          nodes {
-                            ... on ProjectV2ItemFieldSingleSelectValue {
-                              name
-                              field { ... on ProjectV2SingleSelectField { name } }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-                user(login: $login) {
-                  projectV2(number: $number) {
-                    title
-                    items(first: 100, after: $cursor) {
-                      pageInfo { hasNextPage endCursor }
-                      nodes {
-                        content {
-                          ... on Issue { number title url state }
-                        }
-                        fieldValues(first: 20) {
-                          nodes {
-                            ... on ProjectV2ItemFieldSingleSelectValue {
-                              name
-                              field { ... on ProjectV2SingleSelectField { name } }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }`;
-
-            const loadProject = async () => {
-              let cursor = null;
-              let title = "";
-              const nodes = [];
-              for (;;) {
-                const data = await gql(projectPageQuery, { login: projectOwner, number: projectNumber, cursor });
-                const page = data.organization?.projectV2 || data.user?.projectV2;
-                if (!page) return null;
-                title = title || page.title;
-                nodes.push(...(page.items?.nodes || []));
-                const pageInfo = page.items?.pageInfo;
-                if (!pageInfo?.hasNextPage) break;
-                cursor = pageInfo.endCursor;
-              }
-              return { title, items: { nodes } };
-            };
-
-            const project = await loadProject();
-            if (!project) {
-              warnings.push(`Project V2 #${projectNumber} not found for ${projectOwner}.`);
-              core.setFailed(warnings[0]);
-              return;
-            }
-
-            const items = project.items.nodes || [];
-            const todoIssues = items.filter((item) => {
-              const issue = item.content;
-              if (!issue || issue.state !== "OPEN") return false;
-              const status = item.fieldValues.nodes.find((value) => value.field?.name === "Status");
-              return status?.name === "Todo";
-            });
-            const todoCount = todoIssues.length;
-            const shouldDispatch = todoCount < (Number.isFinite(targetTodoMin) ? targetTodoMin : 3);
-            const needed = shouldDispatch ? Math.min((Number.isFinite(targetTodoMin) ? targetTodoMin : 3) - todoCount, Number.isFinite(batchLimit) ? batchLimit : 3) : 0;
-
-            let slackNotification = "not_needed";
-            let prompt = "";
-            if (shouldDispatch) {
-              prompt = [
-                "Run DUUMBI Stage 4 triage with duumbi-triage.",
-                "",
-                "Target: bounded next-issue discovery sweep across Inbox notes, GitHub Issues, GitHub Ideas Discussions, and active DUUMBI Obsidian documentation.",
-                "",
-                `Goal: Refill the GitHub Project Todo queue. Current Todo count is ${todoCount}; create or route up to ${needed} issue(s), stopping when Todo reaches ${Number.isFinite(targetTodoMin) ? targetTodoMin : 3} or no actionable source remains.`,
-                "",
-                "For each selected item, inspect duplicates and route execution work to Needs Human Acceptance. Do not mark work accepted, create specs, create PRs, modify source code, or start implementation.",
-              ].join("\n");
-
-              const token = process.env.SLACK_BOT_TOKEN;
-              const channel = process.env.DUUMBI_AGENT_DISPATCH_CHANNEL_ID || process.env.SLACK_REVIEW_CHANNEL_ID;
-              if (token && channel) {
-                const res = await fetch("https://slack.com/api/chat.postMessage", {
-                  method: "POST",
-                  headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json; charset=utf-8",
-                  },
-                  body: JSON.stringify({
-                    channel,
-                    text: [
-                      "*DUUMBI Triage Queue Refill Dispatch*",
-                      `*Project:* ${project.title}`,
-                      `*Todo count:* ${todoCount}`,
-                      `*Requested items:* ${needed}`,
-                      "",
-                      "```",
-                      prompt,
-                      "```",
-                    ].join("\n"),
-                  }),
-                });
-                const body = await res.json();
-                slackNotification = res.ok && body.ok ? "posted" : "failed";
-                if (slackNotification === "failed") warnings.push(`Slack notification failed: ${body.error || res.status}`);
-              } else {
-                slackNotification = "not_configured";
-                warnings.push("Slack dispatch channel is not configured; prompt is available in the workflow summary.");
-              }
-            }
-
-            fs.writeFileSync(process.env.DUUMBI_METRICS_PATH, `${JSON.stringify(metrics("success", {
-              issues_considered: items.length,
-              issues_queued: needed,
-              slack_notifications_attempted: shouldDispatch && slackNotification !== "not_configured" ? 1 : 0,
-              artifact_links_found: null,
-              artifact_links_missing: null,
-            }, "agent_dispatch_only"), null, 2)}\n`);
-
-            const summary = core.summary
-              .addHeading("DUUMBI Triage Queue Refill", 2)
-              .addTable([
-                [{ data: "Field", header: true }, { data: "Value", header: true }],
-                ["Project", project.title],
-                ["Todo count", String(todoCount)],
-                ["Target Todo minimum", String(Number.isFinite(targetTodoMin) ? targetTodoMin : 3)],
-                ["Dispatch needed", String(shouldDispatch)],
-                ["Slack dispatch", slackNotification],
-              ]);
-            if (prompt) summary.addHeading("Agent Prompt", 3).addCodeBlock(prompt, "text");
-            await summary.write();
 
       - name: Upload DUUMBI workflow metrics
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: duumbi-workflow-metrics-triage-refill-${{ github.run_id }}-${{ github.run_attempt }}
           path: duumbi-workflow-metrics.json

--- a/docs/automation/agentic-development-orchestration.md
+++ b/docs/automation/agentic-development-orchestration.md
@@ -11,7 +11,10 @@ or source-repo contracts that support it.
   state.
 - Obsidian stores raw intake and durable knowledge.
 - Slack is a capture, notification, clarification, and approval surface.
-- GitHub Actions do not call model APIs directly. Scheduled workflows create
+- GitHub Actions generally avoid direct model calls. The Stage 4
+  `triage-queue-refill.yml` workflow is the explicit exception: it may call a
+  bounded DeepSeek API triage step when the Project V2 `Needs Human Acceptance`
+  queue drops below the configured minimum. Other scheduled workflows create
   deterministic dispatch records and Slack handoffs for Codex Cloud, Codex App,
   Codex CLI, or reviewed local agent runs.
 
@@ -34,7 +37,7 @@ or source-repo contracts that support it.
 |---|---|---|
 | `slack-intake-dispatch.yml` | Slack shortcut repository dispatch, manual | Dispatches Stage 1 Slack intake without requiring the developer to name the skill. |
 | `inbox-enrichment-dispatch.yml` | 06:00 UTC and 18:00 UTC, manual | Checks `duumbi-vault` for unnormalized Inbox notes and dispatches `duumbi-inbox-enrichment` only when candidate notes exist. |
-| `triage-queue-refill.yml` | every 3 hours, manual | Reads Project V2 Todo count and dispatches bounded Stage 4 triage when Todo is below the configured minimum. |
+| `triage-queue-refill.yml` | every 4 hours, manual | Reads Project V2 `Needs Human Acceptance` count and uses a bounded DeepSeek Stage 4 triage refill when fewer than three issues are waiting. |
 | `clarification-routing.yml` | issue comment mention, manual | Routes `@Codex` or `@Copilot` clarification replies to the right stage-specific agent. |
 | `spec-ai-gate.yml` | manual, repository dispatch | Records Stage 7/9 AI gate decisions and dispatches `stage-approval.yml` for clean approvals. |
 | `stage10-authorization-request.yml` | label, hourly, manual, repository dispatch | Sends Stage 10 resource authorization Slack notifications and records resource decisions. |
@@ -62,10 +65,48 @@ closed.
 - `DUUMBI_AGENT_DISPATCH_CHANNEL_ID`: optional agent dispatch channel; falls
   back to `SLACK_REVIEW_CHANNEL_ID`.
 - `GH_PROJECT_PAT`: PAT that can read and update GitHub Project V2.
+- `DEEPSEEK_API_KEY`: DeepSeek API key used only by `triage-queue-refill.yml`
+  when the `Needs Human Acceptance` queue is below target.
+- `DEEPSEEK_MODEL`: optional repository variable for the refill model; defaults
+  to `deepseek-v4-pro`.
 - `DUUMBI_PROJECT_NUMBER`: repository variable for the Project V2 number used by
   `triage-queue-refill.yml`.
 - `DUUMBI_PROJECT_OWNER`: optional repository variable; defaults to repository
   owner.
+
+## Stage 4 Refill LLM Policy
+
+`triage-queue-refill.yml` runs at most six times per day. It first reads Project
+V2 with `GH_PROJECT_PAT`; if at least three open issues are already in
+`Needs Human Acceptance`, it exits without calling a model or posting Slack.
+
+When refill is needed, the workflow checks out `duumbi-vault`, builds bounded
+context from active Inbox notes, Ideas Discussions, Project V2 issue state, and
+active Atlas/runbook docs, and asks DeepSeek for one strict JSON decision:
+`route_existing_issue`, `create_issue`, `needs_clarification`, or `no_action`.
+Only `route_existing_issue` and `create_issue` perform GitHub writes, and at
+most one issue is queued per run.
+
+All GitHub writes use `GH_PROJECT_PAT` rather than `GITHUB_TOKEN`, so adding the
+existing `needs-human-review` label can trigger the separate Human Acceptance
+Slack gate. The refill workflow itself does not post Slack notifications; this
+avoids duplicate messages.
+
+Default model: `deepseek-v4-pro`. DeepSeek's public docs list V4 Pro and Flash
+with 1M context, JSON output, tool calls, and low per-token prices. As of
+2026-05-25, approximate monthly costs for six runs per day are:
+
+| Scenario | DeepSeek Flash | DeepSeek Pro |
+|---|---:|---:|
+| 20k input + 2k output per run | USD 0.61/month | USD 1.88/month |
+| 80k input + 6k output per run | USD 2.32/month | USD 7.20/month |
+
+Reference pricing pages:
+
+- DeepSeek models and pricing: https://api-docs.deepseek.com/quick_start/pricing
+- DeepSeek JSON output: https://api-docs.deepseek.com/guides/json_mode
+- OpenAI pricing: https://developers.openai.com/api/docs/pricing
+- Anthropic pricing: https://platform.claude.com/docs/en/about-claude/pricing
 
 ## Gate Policy
 
@@ -87,7 +128,10 @@ emits the Stage 12 closure prompt after merge.
 
 All new workflows write metadata-only metrics artifacts. They must not store raw
 Slack payloads, issue bodies, comments, prompts from users, model completions,
-provider payloads, credentials, or broad logs.
+provider payloads, credentials, or broad logs. The Stage 4 refill workflow may
+send bounded triage context to DeepSeek, but its metrics artifact records only
+metadata, counts, provider name/model, token usage, estimated cost, and
+warnings.
 
 Slack capability URLs, including `response_url`, stay inside the Slack bridge
 function and are not forwarded through GitHub `repository_dispatch` payloads.

--- a/scripts/github-actions/triage-queue-refill.mjs
+++ b/scripts/github-actions/triage-queue-refill.mjs
@@ -1,0 +1,1041 @@
+import fsModule from "node:fs";
+import pathModule from "node:path";
+
+export const WORKFLOW_FILE = ".github/workflows/triage-queue-refill.yml";
+export const HUMAN_ACCEPTANCE_STATUS = "Needs Human Acceptance";
+export const TODO_STATUS = "Todo";
+export const STATUS_FIELD_NAME = "Status";
+export const HUMAN_ACCEPTANCE_LABEL = "needs-human-review";
+export const DEFAULT_TARGET_HUMAN_ACCEPTANCE_MIN = 3;
+export const DEFAULT_DEEPSEEK_MODEL = "deepseek-v4-pro";
+export const MAX_ISSUES_CREATED_PER_RUN = 1;
+
+const ACTIVE_VAULT_DOCS = [
+  "Duumbi/How to use.md",
+  "Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - PRD.md",
+  "Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - Glossary.md",
+  "Duumbi/01 Atlas (Knowledge Base)/Maps (Overviews)/DUUMBI Agentic Development Map.md",
+  "Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - Agentic Development Runbook.md",
+];
+
+const DEEPSEEK_PRICING_USD_PER_1M = {
+  "deepseek-v4-flash": {
+    inputCacheHit: 0.0028,
+    inputCacheMiss: 0.14,
+    output: 0.28,
+  },
+  "deepseek-v4-pro": {
+    inputCacheHit: 0.003625,
+    inputCacheMiss: 0.435,
+    output: 0.87,
+  },
+};
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+export function normalizeText(value) {
+  return String(value ?? "")
+    .replace(/\r\n?/g, "\n")
+    .replace(/\u0000/g, "")
+    .replace(/[\u0001-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, "")
+    .trim();
+}
+
+export function truncateText(value, maxLength = 4000) {
+  const text = normalizeText(value);
+  if (maxLength <= 0) return "";
+  if (text.length <= maxLength) return text;
+  const ellipsis = "...";
+  return `${text.slice(0, Math.max(0, maxLength - ellipsis.length)).trimEnd()}${ellipsis}`;
+}
+
+function parsePositiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function labelsForIssue(issue) {
+  return (issue?.labels?.nodes || issue?.labels || [])
+    .map((label) => (typeof label === "string" ? label : label?.name))
+    .filter(Boolean);
+}
+
+export function statusNameForProjectItem(item) {
+  const values = item?.fieldValues?.nodes || [];
+  const status = values.find((value) => value?.field?.name === STATUS_FIELD_NAME);
+  return status?.name || null;
+}
+
+export function openIssueItemsWithStatus(project, statusName) {
+  return (project?.items?.nodes || []).filter((item) => {
+    const issue = item?.content;
+    return issue?.state === "OPEN" && statusNameForProjectItem(item) === statusName;
+  });
+}
+
+export function countOpenIssueItemsWithStatus(project, statusName = HUMAN_ACCEPTANCE_STATUS) {
+  return openIssueItemsWithStatus(project, statusName).length;
+}
+
+export function summarizeIssueItem(item) {
+  const issue = item.content || {};
+  return {
+    item_id: item.id,
+    node_id: issue.id || null,
+    number: Number(issue.number),
+    title: truncateText(issue.title, 240),
+    url: issue.url || null,
+    state: issue.state || null,
+    status: statusNameForProjectItem(item),
+    labels: labelsForIssue(issue),
+    body: truncateText(issue.body || "", 2500),
+  };
+}
+
+export function findStatusField(project) {
+  const fields = project?.fields?.nodes || [];
+  return fields.find((field) => field?.name === STATUS_FIELD_NAME && Array.isArray(field.options)) || null;
+}
+
+export function findStatusOption(project, statusName) {
+  const field = findStatusField(project);
+  return field?.options?.find((option) => option?.name === statusName) || null;
+}
+
+export function validateProjectStatusConfig(project) {
+  const statusField = findStatusField(project);
+  if (!statusField) {
+    throw new Error("Project V2 Status field is not readable; failing closed.");
+  }
+  const humanAcceptanceOption = findStatusOption(project, HUMAN_ACCEPTANCE_STATUS);
+  if (!humanAcceptanceOption) {
+    throw new Error(`Project V2 Status option "${HUMAN_ACCEPTANCE_STATUS}" is not readable; failing closed.`);
+  }
+  return { statusField, humanAcceptanceOption };
+}
+
+export function buildProjectSnapshot(project, targetMinimum = DEFAULT_TARGET_HUMAN_ACCEPTANCE_MIN) {
+  const items = project?.items?.nodes || [];
+  const humanAcceptanceIssues = openIssueItemsWithStatus(project, HUMAN_ACCEPTANCE_STATUS).map(summarizeIssueItem);
+  const eligibleTodoIssues = openIssueItemsWithStatus(project, TODO_STATUS).map(summarizeIssueItem);
+  const openProjectIssues = items
+    .filter((item) => item?.content?.state === "OPEN")
+    .map(summarizeIssueItem);
+
+  return {
+    project_title: project?.title || "",
+    target_status: HUMAN_ACCEPTANCE_STATUS,
+    target_minimum: targetMinimum,
+    current_human_acceptance_count: humanAcceptanceIssues.length,
+    eligible_todo_issues: eligibleTodoIssues,
+    human_acceptance_issues: humanAcceptanceIssues,
+    open_project_issues: openProjectIssues,
+  };
+}
+
+function walkMarkdownFiles(fs, path, root, limit) {
+  const results = [];
+  const visit = (dir) => {
+    if (results.length >= limit) return;
+    const entries = fs
+      .readdirSync(dir, { withFileTypes: true })
+      .sort((a, b) => a.name.localeCompare(b.name));
+    for (const entry of entries) {
+      if (results.length >= limit) return;
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        visit(fullPath);
+      } else if (entry.isFile() && entry.name.endsWith(".md")) {
+        results.push(fullPath);
+      }
+    }
+  };
+  visit(root);
+  return results;
+}
+
+function readMarkdownNotes(fs, path, root, baseRoot, limit, maxChars) {
+  if (!fs.existsSync(root)) return [];
+  return walkMarkdownFiles(fs, path, root, limit).map((absolutePath) => ({
+    path: path.relative(baseRoot, absolutePath).split(path.sep).join("/"),
+    text: truncateText(fs.readFileSync(absolutePath, "utf8"), maxChars),
+  }));
+}
+
+function readVaultDocs(fs, path, vaultRoot, warnings) {
+  return ACTIVE_VAULT_DOCS.flatMap((relativePath) => {
+    const absolutePath = path.join(vaultRoot, relativePath);
+    if (!fs.existsSync(absolutePath)) {
+      warnings.push(`Vault context document is missing: ${relativePath}`);
+      return [];
+    }
+    return [{
+      path: relativePath,
+      text: truncateText(fs.readFileSync(absolutePath, "utf8"), 5000),
+    }];
+  });
+}
+
+export async function collectTriageContext({
+  fs = fsModule,
+  path = pathModule,
+  workspace = process.cwd(),
+  vaultPath = "duumbi-vault",
+  project,
+  targetMinimum,
+  api,
+  warnings = [],
+}) {
+  const vaultRoot = path.resolve(workspace, vaultPath);
+  const duumbiRoot = path.join(vaultRoot, "Duumbi");
+  if (!fs.existsSync(vaultRoot) || !fs.statSync(vaultRoot).isDirectory()) {
+    throw new Error(`DUUMBI vault checkout is unavailable at ${vaultRoot}; failing closed.`);
+  }
+  if (!fs.existsSync(duumbiRoot) || !fs.statSync(duumbiRoot).isDirectory()) {
+    throw new Error(`DUUMBI vault root is unavailable at ${duumbiRoot}; failing closed.`);
+  }
+
+  let ideaDiscussions = [];
+  try {
+    ideaDiscussions = await api.listIdeaDiscussions();
+  } catch (error) {
+    warnings.push(`GitHub Ideas Discussions context unavailable: ${truncateText(error.message, 180)}`);
+  }
+
+  const inboxRoot = path.join(duumbiRoot, "00 Inbox (ToProcess)");
+  const inboxNotes = readMarkdownNotes(fs, path, inboxRoot, vaultRoot, 8, 3500);
+  const activeDocs = readVaultDocs(fs, path, vaultRoot, warnings);
+
+  return {
+    generated_at: nowIso(),
+    repository: `${api.owner}/${api.repo}`,
+    stage: "triage-queue-refill",
+    policy: {
+      max_new_human_acceptance_issues: MAX_ISSUES_CREATED_PER_RUN,
+      target_status: HUMAN_ACCEPTANCE_STATUS,
+      target_label: HUMAN_ACCEPTANCE_LABEL,
+      route_existing_issue_requires_status: TODO_STATUS,
+      forbidden: [
+        "Do not create product specs.",
+        "Do not create technical specs.",
+        "Do not create PRs.",
+        "Do not modify source code.",
+        "Do not start implementation.",
+        "Do not mark work accepted.",
+      ],
+    },
+    project: buildProjectSnapshot(project, targetMinimum),
+    inbox_notes: inboxNotes,
+    idea_discussions: ideaDiscussions.slice(0, 10).map((discussion) => ({
+      title: truncateText(discussion.title, 240),
+      url: discussion.url,
+      category: discussion.category?.name || null,
+      updated_at: discussion.updatedAt || null,
+      body: truncateText(discussion.body || "", 3000),
+    })),
+    active_vault_docs: activeDocs,
+  };
+}
+
+export function buildDeepSeekMessages(contextPayload) {
+  const schema = {
+    action: "route_existing_issue | create_issue | needs_clarification | no_action",
+    existing_issue_number: "integer, required only for route_existing_issue",
+    issue: {
+      title: "string, required only for create_issue",
+      body: "string, required only for create_issue",
+      user_outcome: "string",
+      proposed_direction: "string",
+      scope_in: ["string"],
+      scope_out: ["string"],
+      risks: ["string"],
+      open_questions: ["string"],
+    },
+    source_links: ["non-empty source URLs or vault paths for route_existing_issue/create_issue"],
+    rationale: "short factual rationale",
+  };
+
+  return [
+    {
+      role: "system",
+      content: [
+        "You are the DUUMBI Stage 4 triage refiller.",
+        "Return exactly one valid json object and no markdown.",
+        "Choose at most one next item.",
+        "Prefer routing an eligible existing Todo issue when it already represents the work.",
+        `Only route existing issues listed under project.eligible_todo_issues, and route them to ${HUMAN_ACCEPTANCE_STATUS}.`,
+        "Create a new issue only when no existing eligible Todo issue represents the next actionable work.",
+        "Use no_action when no actionable item remains. Use needs_clarification when the next candidate cannot be routed safely.",
+        "Do not approve work, create specs, create PRs, change source code, or start implementation.",
+        `Expected json schema example: ${JSON.stringify(schema)}`,
+      ].join("\n"),
+    },
+    {
+      role: "user",
+      content: JSON.stringify(contextPayload, null, 2),
+    },
+  ];
+}
+
+function stripJsonFence(value) {
+  const text = normalizeText(value);
+  const fenceMatch = text.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  return fenceMatch ? fenceMatch[1].trim() : text;
+}
+
+export function parseTriageDecision(content) {
+  const text = stripJsonFence(content);
+  try {
+    const parsed = JSON.parse(text);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("Decision must be a JSON object.");
+    }
+    return parsed;
+  } catch (firstError) {
+    const start = text.indexOf("{");
+    const end = text.lastIndexOf("}");
+    if (start >= 0 && end > start) {
+      try {
+        const parsed = JSON.parse(text.slice(start, end + 1));
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed;
+      } catch {
+        // Fall through to the original parse error.
+      }
+    }
+    throw new Error(`DeepSeek decision was not valid JSON: ${firstError.message}`);
+  }
+}
+
+function normalizeStringArray(value) {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => truncateText(item, 1000)).filter(Boolean);
+}
+
+function requireSourceLinks(decision) {
+  const sourceLinks = normalizeStringArray(decision.source_links);
+  if (sourceLinks.length === 0) {
+    throw new Error("DeepSeek decision is missing required source_links.");
+  }
+  return sourceLinks;
+}
+
+export function validateTriageDecision(decision, contextPayload) {
+  const action = normalizeText(decision?.action);
+  const validActions = new Set(["route_existing_issue", "create_issue", "needs_clarification", "no_action"]);
+  if (!validActions.has(action)) {
+    throw new Error(`DeepSeek decision action is not supported: ${action || "<missing>"}`);
+  }
+
+  const normalized = {
+    action,
+    rationale: truncateText(decision.rationale || "", 2000),
+    source_links: normalizeStringArray(decision.source_links),
+  };
+
+  if (action === "no_action" || action === "needs_clarification") {
+    return normalized;
+  }
+
+  normalized.source_links = requireSourceLinks(decision);
+
+  if (action === "route_existing_issue") {
+    const issueNumber = Number(decision.existing_issue_number);
+    if (!Number.isInteger(issueNumber) || issueNumber < 1) {
+      throw new Error("route_existing_issue requires a positive existing_issue_number.");
+    }
+    const eligible = new Map((contextPayload?.project?.eligible_todo_issues || []).map((issue) => [Number(issue.number), issue]));
+    if (!eligible.has(issueNumber)) {
+      throw new Error(`Issue #${issueNumber} is not an eligible Todo issue for triage refill.`);
+    }
+    return {
+      ...normalized,
+      existing_issue_number: issueNumber,
+      existing_issue: eligible.get(issueNumber),
+    };
+  }
+
+  const issue = decision.issue || {};
+  const title = truncateText(issue.title, 240);
+  const body = truncateText(issue.body, 8000);
+  if (!title) {
+    throw new Error("create_issue decision is missing issue.title.");
+  }
+  if (!body) {
+    throw new Error("create_issue decision is missing issue.body.");
+  }
+
+  return {
+    ...normalized,
+    issue: {
+      title,
+      body,
+      user_outcome: truncateText(issue.user_outcome || "", 3000),
+      proposed_direction: truncateText(issue.proposed_direction || "", 3000),
+      scope_in: normalizeStringArray(issue.scope_in),
+      scope_out: normalizeStringArray(issue.scope_out),
+      risks: normalizeStringArray(issue.risks),
+      open_questions: normalizeStringArray(issue.open_questions),
+    },
+  };
+}
+
+function markdownList(items, fallback = "- none") {
+  const values = normalizeStringArray(items);
+  return values.length ? values.map((item) => `- ${item}`).join("\n") : fallback;
+}
+
+export function buildCreatedIssueBody(decision) {
+  const issue = decision.issue;
+  return [
+    "## Summary",
+    "",
+    issue.body,
+    "",
+    "## Source",
+    "- Origin: Automated Stage 4 triage refill",
+    "- Links:",
+    markdownList(decision.source_links),
+    "",
+    "## User Outcome",
+    "",
+    issue.user_outcome || "Triage should determine whether this is worth accepting for specification.",
+    "",
+    "## Problem",
+    "",
+    issue.body,
+    "",
+    "## Proposed Direction",
+    "",
+    issue.proposed_direction || "Route this candidate to human acceptance before specification.",
+    "",
+    "## Knowledge Context",
+    "- Relevant Obsidian notes:",
+    markdownList(decision.source_links.filter((link) => !/^https?:\/\//i.test(link))),
+    "- Related issues or discussions:",
+    markdownList(decision.source_links.filter((link) => /^https?:\/\//i.test(link))),
+    "- Existing code or docs:",
+    "- not inspected by automated refill",
+    "",
+    "## Scope Candidate",
+    "- In:",
+    markdownList(issue.scope_in),
+    "- Out:",
+    markdownList(issue.scope_out),
+    "",
+    "## Risks And Trade-Offs",
+    "",
+    markdownList(issue.risks),
+    "",
+    "## Open Questions",
+    "",
+    markdownList(issue.open_questions),
+    "",
+    "## Triage Recommendation",
+    "- accept for spec",
+    "",
+    "## Acceptance Gate",
+    "- [ ] Human reviewed",
+    "- [ ] Accepted for spec",
+    "",
+    "<!-- duumbi-triage-queue-refill:v1 -->",
+  ].join("\n");
+}
+
+export function buildExistingIssueComment(decision) {
+  return [
+    "<!-- duumbi-triage-queue-refill:v1 -->",
+    "## Stage 4 Automated Triage Refill",
+    "",
+    `**Decision:** Route existing issue to \`${HUMAN_ACCEPTANCE_STATUS}\`.`,
+    `**Rationale:** ${decision.rationale || "Selected as the next bounded triage candidate."}`,
+    "",
+    "**Source links:**",
+    markdownList(decision.source_links),
+    "",
+    "**Next stage:** Needs Human Acceptance",
+  ].join("\n");
+}
+
+export function estimateDeepSeekCostUsd(model, usage = {}) {
+  const pricing = DEEPSEEK_PRICING_USD_PER_1M[model] || DEEPSEEK_PRICING_USD_PER_1M[DEFAULT_DEEPSEEK_MODEL];
+  const completionTokens = Number(usage.completion_tokens || 0);
+  const cacheHitTokens = Number(usage.prompt_cache_hit_tokens || 0);
+  const cacheMissTokens = Number(usage.prompt_cache_miss_tokens || 0);
+  const promptTokens = Number(usage.prompt_tokens || 0);
+
+  const inputCost = cacheHitTokens || cacheMissTokens
+    ? (cacheHitTokens * pricing.inputCacheHit + cacheMissTokens * pricing.inputCacheMiss) / 1_000_000
+    : (promptTokens * pricing.inputCacheMiss) / 1_000_000;
+  const outputCost = (completionTokens * pricing.output) / 1_000_000;
+  const cost = inputCost + outputCost;
+  return Number.isFinite(cost) ? Number(cost.toFixed(8)) : null;
+}
+
+async function readJsonResponse(response) {
+  const text = await response.text();
+  try {
+    return { text, json: text ? JSON.parse(text) : {} };
+  } catch (error) {
+    throw new Error(`Response was not JSON: ${truncateText(error.message, 160)}; body=${truncateText(text, 240)}`);
+  }
+}
+
+export function createGithubApi({ fetchImpl = fetch, token, owner, repo }) {
+  const authHeaders = {
+    Authorization: `bearer ${token}`,
+    "Content-Type": "application/json",
+    "User-Agent": "duumbi-triage-queue-refill",
+  };
+
+  const graphql = async (query, variables = {}) => {
+    const response = await fetchImpl("https://api.github.com/graphql", {
+      method: "POST",
+      headers: authHeaders,
+      body: JSON.stringify({ query, variables }),
+    });
+    const { text, json } = await readJsonResponse(response);
+    if (!response.ok) {
+      throw new Error(`GitHub GraphQL failed: ${response.status} ${truncateText(text, 240)}`);
+    }
+    if (json.errors) {
+      throw new Error(json.errors.map((error) => error.message).join("; "));
+    }
+    return json.data;
+  };
+
+  const rest = async (method, urlPath, body = null) => {
+    const response = await fetchImpl(`https://api.github.com${urlPath}`, {
+      method,
+      headers: authHeaders,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    const { text, json } = await readJsonResponse(response);
+    if (!response.ok) {
+      throw new Error(`GitHub REST ${method} ${urlPath} failed: ${response.status} ${truncateText(text, 240)}`);
+    }
+    return json;
+  };
+
+  return {
+    owner,
+    repo,
+    graphql,
+    rest,
+    async loadProject(projectOwner, projectNumber) {
+      let cursor = null;
+      let title = "";
+      let id = "";
+      let fields = { nodes: [] };
+      const nodes = [];
+      for (;;) {
+        const data = await graphql(`
+          query($login: String!, $number: Int!, $cursor: String) {
+            organization(login: $login) {
+              projectV2(number: $number) {
+                id
+                title
+                fields(first: 50) {
+                  nodes {
+                    ... on ProjectV2SingleSelectField { id name options { id name } }
+                  }
+                }
+                items(first: 100, after: $cursor) {
+                  pageInfo { hasNextPage endCursor }
+                  nodes {
+                    id
+                    content {
+                      ... on Issue {
+                        id
+                        number
+                        title
+                        url
+                        state
+                        body
+                        labels(first: 20) { nodes { name } }
+                      }
+                    }
+                    fieldValues(first: 50) {
+                      nodes {
+                        ... on ProjectV2ItemFieldSingleSelectValue {
+                          name
+                          field { ... on ProjectV2SingleSelectField { name } }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            user(login: $login) {
+              projectV2(number: $number) {
+                id
+                title
+                fields(first: 50) {
+                  nodes {
+                    ... on ProjectV2SingleSelectField { id name options { id name } }
+                  }
+                }
+                items(first: 100, after: $cursor) {
+                  pageInfo { hasNextPage endCursor }
+                  nodes {
+                    id
+                    content {
+                      ... on Issue {
+                        id
+                        number
+                        title
+                        url
+                        state
+                        body
+                        labels(first: 20) { nodes { name } }
+                      }
+                    }
+                    fieldValues(first: 50) {
+                      nodes {
+                        ... on ProjectV2ItemFieldSingleSelectValue {
+                          name
+                          field { ... on ProjectV2SingleSelectField { name } }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }`, { login: projectOwner, number: projectNumber, cursor });
+        const page = data.organization?.projectV2 || data.user?.projectV2;
+        if (!page) return null;
+        id = id || page.id;
+        title = title || page.title;
+        fields = page.fields || fields;
+        nodes.push(...(page.items?.nodes || []));
+        const pageInfo = page.items?.pageInfo;
+        if (!pageInfo?.hasNextPage) break;
+        cursor = pageInfo.endCursor;
+      }
+      return { id, title, fields, items: { nodes } };
+    },
+    async listIdeaDiscussions() {
+      const data = await graphql(`
+        query($owner: String!, $repo: String!) {
+          repository(owner: $owner, name: $repo) {
+            discussions(first: 20, orderBy: { field: UPDATED_AT, direction: DESC }) {
+              nodes {
+                title
+                url
+                body
+                updatedAt
+                category { name }
+              }
+            }
+          }
+        }`, { owner, repo });
+      return (data.repository?.discussions?.nodes || []).filter((discussion) =>
+        String(discussion.category?.name || "").toLowerCase() === "ideas",
+      );
+    },
+    async updateProjectStatus(project, itemId, statusName) {
+      const statusField = findStatusField(project);
+      const option = findStatusOption(project, statusName);
+      if (!statusField || !option) {
+        throw new Error(`Project V2 Status option "${statusName}" is not readable; failing closed.`);
+      }
+      await graphql(`
+        mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+          updateProjectV2ItemFieldValue(input: {
+            projectId: $projectId,
+            itemId: $itemId,
+            fieldId: $fieldId,
+            value: { singleSelectOptionId: $optionId }
+          }) { projectV2Item { id } }
+        }`, {
+        projectId: project.id,
+        itemId,
+        fieldId: statusField.id,
+        optionId: option.id,
+      });
+    },
+    async addIssueToProject(projectId, issueNodeId) {
+      const data = await graphql(`
+        mutation($projectId: ID!, $contentId: ID!) {
+          addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+            item { id }
+          }
+        }`, { projectId, contentId: issueNodeId });
+      return data.addProjectV2ItemById?.item?.id || null;
+    },
+    async createIssue(title, body) {
+      return rest("POST", `/repos/${owner}/${repo}/issues`, { title, body });
+    },
+    async createIssueComment(issueNumber, body) {
+      return rest("POST", `/repos/${owner}/${repo}/issues/${issueNumber}/comments`, { body });
+    },
+    async addIssueLabel(issueNumber, label) {
+      return rest("POST", `/repos/${owner}/${repo}/issues/${issueNumber}/labels`, { labels: [label] });
+    },
+    async updateIssue(issueNumber, fields) {
+      return rest("PATCH", `/repos/${owner}/${repo}/issues/${issueNumber}`, fields);
+    },
+  };
+}
+
+export async function callDeepSeek({
+  fetchImpl = fetch,
+  apiKey,
+  model = DEFAULT_DEEPSEEK_MODEL,
+  messages,
+  timeoutMs = 120_000,
+}) {
+  const started = Date.now();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl("https://api.deepseek.com/chat/completions", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        response_format: { type: "json_object" },
+        temperature: 0.2,
+        max_tokens: 2500,
+      }),
+      signal: controller.signal,
+    });
+    const { text, json } = await readJsonResponse(response);
+    if (!response.ok) {
+      throw new Error(`DeepSeek API failed: ${response.status} ${truncateText(text, 240)}`);
+    }
+    const content = json.choices?.[0]?.message?.content;
+    if (!normalizeText(content)) {
+      throw new Error("DeepSeek returned empty decision content.");
+    }
+    return {
+      model: json.model || model,
+      content,
+      usage: json.usage || {},
+      latencyMs: Date.now() - started,
+    };
+  } catch (error) {
+    if (error?.name === "AbortError") {
+      throw new Error(`DeepSeek API timed out after ${timeoutMs}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function buildWorkflowMetrics({
+  context,
+  conclusion,
+  decision = null,
+  counts,
+  providerUsage,
+  warnings = [],
+  issueNumber = null,
+  generatedAt = nowIso(),
+}) {
+  return {
+    schema_version: "duumbi.workflow_metrics.v1",
+    generated_at: generatedAt,
+    source: "github_actions",
+    repository: `${context.repo.owner}/${context.repo.repo}`,
+    workflow: {
+      name: context.workflow,
+      file: WORKFLOW_FILE,
+      run_id: context.runId,
+      run_attempt: Number(process.env.GITHUB_RUN_ATTEMPT || 1),
+      event_name: context.eventName,
+      actor: context.actor,
+      ref: context.ref,
+      sha: context.sha,
+      conclusion,
+      started_at: generatedAt,
+      completed_at: generatedAt,
+      duration_ms: null,
+    },
+    correlation: {
+      issue_number: issueNumber,
+      pr_number: null,
+      stage: "triage-queue-refill",
+      decision,
+      project_status: HUMAN_ACCEPTANCE_STATUS,
+    },
+    counts,
+    provider_usage: providerUsage,
+    privacy: {
+      metadata_only: true,
+      raw_prompts_included: false,
+      raw_completions_included: false,
+      raw_slack_payloads_included: false,
+      secrets_included: false,
+    },
+    warnings,
+  };
+}
+
+function providerUsageNotCalled(reason) {
+  return {
+    available: false,
+    reason,
+    provider: null,
+    model: null,
+    request_count: null,
+    prompt_tokens: null,
+    completion_tokens: null,
+    total_tokens: null,
+    estimated_cost_usd: null,
+    latency_ms: null,
+    failure_count: null,
+  };
+}
+
+function providerUsageFromDeepSeek(model, usage, latencyMs) {
+  return {
+    available: true,
+    reason: "deepseek_api_call",
+    provider: "deepseek",
+    model,
+    request_count: 1,
+    prompt_tokens: Number.isFinite(Number(usage.prompt_tokens)) ? Number(usage.prompt_tokens) : null,
+    completion_tokens: Number.isFinite(Number(usage.completion_tokens)) ? Number(usage.completion_tokens) : null,
+    total_tokens: Number.isFinite(Number(usage.total_tokens)) ? Number(usage.total_tokens) : null,
+    estimated_cost_usd: estimateDeepSeekCostUsd(model, usage),
+    latency_ms: Number.isFinite(latencyMs) ? latencyMs : null,
+    failure_count: 0,
+  };
+}
+
+async function applyTriageDecision({ api, project, decision }) {
+  if (decision.action === "route_existing_issue") {
+    await api.createIssueComment(decision.existing_issue_number, buildExistingIssueComment(decision));
+    await api.addIssueLabel(decision.existing_issue_number, HUMAN_ACCEPTANCE_LABEL);
+    await api.updateProjectStatus(project, decision.existing_issue.item_id, HUMAN_ACCEPTANCE_STATUS);
+    return {
+      issueNumber: decision.existing_issue_number,
+      issueUrl: decision.existing_issue.url,
+      action: decision.action,
+    };
+  }
+
+  if (decision.action === "create_issue") {
+    const createdIssue = await api.createIssue(decision.issue.title, buildCreatedIssueBody(decision));
+    let itemId = null;
+    try {
+      itemId = await api.addIssueToProject(project.id, createdIssue.node_id);
+      if (!itemId) {
+        throw new Error("Created issue could not be added to Project V2.");
+      }
+      await api.addIssueLabel(createdIssue.number, HUMAN_ACCEPTANCE_LABEL);
+      await api.updateProjectStatus(project, itemId, HUMAN_ACCEPTANCE_STATUS);
+    } catch (error) {
+      const rollbackBody = [
+        "<!-- duumbi-triage-queue-refill-rollback:v1 -->",
+        "Automated triage refill rolled this issue back because the Project V2 queue update did not complete.",
+        "",
+        `Failure: ${truncateText(error.message || error, 500)}`,
+      ].join("\n");
+      try {
+        await api.createIssueComment(createdIssue.number, rollbackBody);
+        await api.updateIssue(createdIssue.number, { state: "closed" });
+      } catch (rollbackError) {
+        throw new Error(`Created issue #${createdIssue.number} could not be fully queued, and rollback failed: ${truncateText(rollbackError.message || rollbackError, 300)}`);
+      }
+      throw new Error(`Created issue #${createdIssue.number} was closed after incomplete queue update: ${truncateText(error.message || error, 300)}`);
+    }
+    return {
+      issueNumber: createdIssue.number,
+      issueUrl: createdIssue.html_url,
+      action: decision.action,
+    };
+  }
+
+  return { issueNumber: null, issueUrl: null, action: decision.action };
+}
+
+async function writeSummary(summary, result) {
+  if (!summary) return;
+  const table = [
+    [{ data: "Field", header: true }, { data: "Value", header: true }],
+    ["Project", result.projectTitle || "unavailable"],
+    ["Needs Human Acceptance count", String(result.humanAcceptanceCount ?? "unavailable")],
+    ["Target minimum", String(result.targetMinimum ?? DEFAULT_TARGET_HUMAN_ACCEPTANCE_MIN)],
+    ["Refill needed", String(result.refillNeeded)],
+    ["Decision", result.decision || "none"],
+    ["Issue", result.issueNumber ? `#${result.issueNumber}` : "none"],
+    ["Direct Slack notification", "not_sent"],
+    ["Model", result.model || "not_called"],
+  ];
+  await summary
+    .addHeading("DUUMBI Triage Queue Refill", 2)
+    .addTable(table)
+    .write();
+}
+
+export async function runTriageQueueRefill({
+  env = process.env,
+  context,
+  core,
+  summary,
+  fetchImpl = fetch,
+  fs = fsModule,
+  path = pathModule,
+  workspace = process.cwd(),
+} = {}) {
+  const warnings = [];
+  const metricsPath = env.DUUMBI_METRICS_PATH || "duumbi-workflow-metrics.json";
+  const inputs = context?.payload?.inputs || {};
+  const targetMinimum = parsePositiveInteger(inputs.target_human_acceptance_min, DEFAULT_TARGET_HUMAN_ACCEPTANCE_MIN);
+  const projectPat = env.GH_PROJECT_PAT;
+  const projectOwner = env.DUUMBI_PROJECT_OWNER || context.repo.owner;
+  const projectNumber = Number(env.DUUMBI_PROJECT_NUMBER || 0);
+  const deepSeekApiKey = env.DEEPSEEK_API_KEY;
+  const deepSeekModel = env.DEEPSEEK_MODEL || DEFAULT_DEEPSEEK_MODEL;
+
+  let result = {
+    ok: false,
+    projectTitle: null,
+    humanAcceptanceCount: null,
+    targetMinimum,
+    refillNeeded: false,
+    decision: null,
+    issueNumber: null,
+    model: null,
+    inspectedIssueCount: null,
+  };
+
+  const writeMetrics = (metrics) => {
+    fs.writeFileSync(path.resolve(workspace, metricsPath), `${JSON.stringify(metrics, null, 2)}\n`);
+  };
+
+  try {
+    if (!projectPat || !projectNumber) {
+      throw new Error("Project V2 configuration is unavailable. Set GH_PROJECT_PAT and repository variable DUUMBI_PROJECT_NUMBER.");
+    }
+
+    const api = createGithubApi({
+      fetchImpl,
+      token: projectPat,
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+    });
+    const project = await api.loadProject(projectOwner, projectNumber);
+    if (!project) {
+      throw new Error(`Project V2 #${projectNumber} not found for ${projectOwner}.`);
+    }
+    validateProjectStatusConfig(project);
+
+    const humanAcceptanceCount = countOpenIssueItemsWithStatus(project, HUMAN_ACCEPTANCE_STATUS);
+    result = {
+      ...result,
+      ok: true,
+      projectTitle: project.title,
+      humanAcceptanceCount,
+      inspectedIssueCount: project.items.nodes.length,
+      refillNeeded: humanAcceptanceCount < targetMinimum,
+    };
+
+    if (!result.refillNeeded) {
+      const metrics = buildWorkflowMetrics({
+        context,
+        conclusion: "success",
+        decision: "not_needed",
+        counts: {
+          issues_considered: project.items.nodes.length,
+          issues_queued: 0,
+          slack_notifications_attempted: 0,
+          artifact_links_found: null,
+          artifact_links_missing: null,
+        },
+        providerUsage: providerUsageNotCalled("human_acceptance_queue_full"),
+        warnings: ["slack_notification_not_needed", "model_call_not_needed"],
+      });
+      writeMetrics(metrics);
+      await writeSummary(summary, { ...result, decision: "not_needed" });
+      core?.info?.(`Needs Human Acceptance queue is full: ${humanAcceptanceCount}/${targetMinimum}.`);
+      return { ...result, decision: "not_needed" };
+    }
+
+    if (!deepSeekApiKey) {
+      throw new Error("DEEPSEEK_API_KEY is not configured; failing closed before triage refill.");
+    }
+
+    const triageContext = await collectTriageContext({
+      fs,
+      path,
+      workspace,
+      project,
+      targetMinimum,
+      api,
+      warnings,
+    });
+    const messages = buildDeepSeekMessages(triageContext);
+    const deepSeekResponse = await callDeepSeek({
+      fetchImpl,
+      apiKey: deepSeekApiKey,
+      model: deepSeekModel,
+      messages,
+    });
+    const parsedDecision = parseTriageDecision(deepSeekResponse.content);
+    const decision = validateTriageDecision(parsedDecision, triageContext);
+    const applied = await applyTriageDecision({ api, project, decision });
+    const queued = applied.issueNumber ? 1 : 0;
+
+    result = {
+      ...result,
+      ok: true,
+      decision: decision.action,
+      issueNumber: applied.issueNumber,
+      issueUrl: applied.issueUrl,
+      model: deepSeekResponse.model,
+    };
+
+    const metrics = buildWorkflowMetrics({
+      context,
+      conclusion: "success",
+      decision: decision.action,
+      issueNumber: applied.issueNumber,
+      counts: {
+        issues_considered: project.items.nodes.length,
+        issues_queued: queued,
+        slack_notifications_attempted: 0,
+        artifact_links_found: decision.source_links?.length || null,
+        artifact_links_missing: decision.source_links?.length ? 0 : null,
+      },
+      providerUsage: providerUsageFromDeepSeek(deepSeekResponse.model, deepSeekResponse.usage, deepSeekResponse.latencyMs),
+      warnings,
+    });
+    writeMetrics(metrics);
+    await writeSummary(summary, result);
+    core?.info?.(`Triage refill decision: ${decision.action}${applied.issueNumber ? ` issue #${applied.issueNumber}` : ""}.`);
+    return result;
+  } catch (error) {
+    const message = truncateText(error.message || error, 500);
+    warnings.push(message);
+    const metrics = buildWorkflowMetrics({
+      context,
+      conclusion: "blocked",
+      decision: "blocked",
+      issueNumber: result.issueNumber,
+      counts: {
+        issues_considered: result.inspectedIssueCount,
+        issues_queued: 0,
+        slack_notifications_attempted: 0,
+        artifact_links_found: null,
+        artifact_links_missing: null,
+      },
+      providerUsage: providerUsageNotCalled("triage_refill_blocked"),
+      warnings,
+    });
+    writeMetrics(metrics);
+    await writeSummary(summary, { ...result, decision: "blocked" });
+    core?.setFailed?.(message);
+    return { ...result, ok: false, error: message };
+  }
+}

--- a/scripts/github-actions/triage-queue-refill.test.mjs
+++ b/scripts/github-actions/triage-queue-refill.test.mjs
@@ -1,0 +1,453 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  HUMAN_ACCEPTANCE_STATUS,
+  TODO_STATUS,
+  callDeepSeek,
+  countOpenIssueItemsWithStatus,
+  parseTriageDecision,
+  runTriageQueueRefill,
+  truncateText,
+  validateTriageDecision,
+} from "./triage-queue-refill.mjs";
+
+function response(body, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+function issueItem({ number, status, state = "OPEN", labels = [] }) {
+  return {
+    id: `item-${number}`,
+    content: {
+      id: `issue-node-${number}`,
+      number,
+      title: `Issue ${number}`,
+      url: `https://github.com/hgahub/duumbi/issues/${number}`,
+      state,
+      body: `Body for issue ${number}`,
+      labels: { nodes: labels.map((name) => ({ name })) },
+    },
+    fieldValues: {
+      nodes: [
+        {
+          name: status,
+          field: { name: "Status" },
+        },
+      ],
+    },
+  };
+}
+
+function projectWithItems(items) {
+  return {
+    id: "project-node",
+    title: "Duumbi project",
+    fields: {
+      nodes: [
+        {
+          id: "status-field",
+          name: "Status",
+          options: [
+            { id: "todo-option", name: TODO_STATUS },
+            { id: "human-acceptance-option", name: HUMAN_ACCEPTANCE_STATUS },
+          ],
+        },
+      ],
+    },
+    items: { nodes: items },
+  };
+}
+
+function makeContext(inputs = {}) {
+  return {
+    workflow: "Triage Queue Refill",
+    runId: 12345,
+    eventName: "workflow_dispatch",
+    actor: "tester",
+    ref: "refs/heads/main",
+    sha: "abc123",
+    repo: { owner: "hgahub", repo: "duumbi" },
+    payload: { inputs },
+  };
+}
+
+function makeCore() {
+  return {
+    failed: null,
+    infos: [],
+    warnings: [],
+    info(message) {
+      this.infos.push(message);
+    },
+    warning(message) {
+      this.warnings.push(message);
+    },
+    setFailed(message) {
+      this.failed = message;
+    },
+  };
+}
+
+function makeSummary() {
+  return {
+    rows: [],
+    addHeading() {
+      return this;
+    },
+    addTable(rows) {
+      this.rows = rows;
+      return this;
+    },
+    async write() {
+      return undefined;
+    },
+  };
+}
+
+function makeWorkspace() {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "duumbi-triage-refill-"));
+  const inbox = path.join(workspace, "duumbi-vault", "Duumbi", "00 Inbox (ToProcess)");
+  fs.mkdirSync(inbox, { recursive: true });
+  fs.writeFileSync(path.join(inbox, "candidate.md"), "# Candidate\n\nShip a useful next thing.\n");
+  return workspace;
+}
+
+function makeFetch({ project, decision, failAddToProject = false, failExistingLabel = false }) {
+  const calls = [];
+  const fetchImpl = async (url, options = {}) => {
+    const body = options.body ? JSON.parse(options.body) : {};
+    calls.push({ url, method: options.method || "GET", body });
+
+    if (url === "https://api.github.com/graphql") {
+      if (body.query.includes("discussions(first: 20")) {
+        return response({
+          data: {
+            repository: {
+              discussions: {
+                nodes: [
+                  {
+                    title: "Idea discussion",
+                    url: "https://github.com/hgahub/duumbi/discussions/1",
+                    body: "A candidate idea.",
+                    updatedAt: "2026-05-25T00:00:00Z",
+                    category: { name: "Ideas" },
+                  },
+                ],
+              },
+            },
+          },
+        });
+      }
+      if (body.query.includes("projectV2(number")) {
+        return response({ data: { organization: { projectV2: project }, user: null } });
+      }
+      if (body.query.includes("updateProjectV2ItemFieldValue")) {
+        return response({ data: { updateProjectV2ItemFieldValue: { projectV2Item: { id: body.variables.itemId } } } });
+      }
+      if (body.query.includes("addProjectV2ItemById")) {
+        return response({ data: { addProjectV2ItemById: { item: { id: "new-project-item" } } } });
+      }
+    }
+
+    if (url === "https://api.deepseek.com/chat/completions") {
+      return response({
+        model: "deepseek-v4-pro",
+        choices: [{ message: { content: JSON.stringify(decision) } }],
+        usage: { prompt_tokens: 1000, completion_tokens: 200, total_tokens: 1200 },
+      });
+    }
+
+    if (url.endsWith("/issues/10/comments")) {
+      return response({ id: 1000, body: body.body });
+    }
+    if (url.endsWith("/issues/10/labels")) {
+      if (failExistingLabel) {
+        return response({ message: "Label does not exist" }, 404);
+      }
+      return response([{ name: "needs-human-review" }]);
+    }
+    if (url.endsWith("/repos/hgahub/duumbi/issues")) {
+      return response({
+        number: 99,
+        node_id: "issue-node-99",
+        html_url: "https://github.com/hgahub/duumbi/issues/99",
+      });
+    }
+    if (url.endsWith("/issues/99/labels")) {
+      return response([{ name: "needs-human-review" }]);
+    }
+    if (url.endsWith("/issues/99/comments")) {
+      return response({ id: 1001, body: body.body });
+    }
+    if (url.endsWith("/issues/99")) {
+      return response({ number: 99, state: body.state || "open" });
+    }
+
+    throw new Error(`Unexpected fetch: ${url} ${body.query || ""}`);
+  };
+  const originalFetch = fetchImpl;
+  if (failAddToProject) {
+    return {
+      calls,
+      fetchImpl: async (url, options = {}) => {
+        const body = options.body ? JSON.parse(options.body) : {};
+        if (url === "https://api.github.com/graphql" && body.query?.includes("addProjectV2ItemById")) {
+          calls.push({ url, method: options.method || "GET", body });
+          return response({ errors: [{ message: "Project permission denied" }] }, 200);
+        }
+        return originalFetch(url, options);
+      },
+    };
+  }
+  return { fetchImpl, calls };
+}
+
+test("counts only open Project V2 issues in Needs Human Acceptance", () => {
+  const project = projectWithItems([
+    issueItem({ number: 1, status: HUMAN_ACCEPTANCE_STATUS }),
+    issueItem({ number: 2, status: HUMAN_ACCEPTANCE_STATUS, state: "CLOSED" }),
+    issueItem({ number: 3, status: TODO_STATUS }),
+    { id: "empty", content: null, fieldValues: { nodes: [] } },
+  ]);
+
+  assert.equal(countOpenIssueItemsWithStatus(project, HUMAN_ACCEPTANCE_STATUS), 1);
+});
+
+test("truncateText respects the requested maximum length", () => {
+  assert.equal(truncateText("abcdef", 4), "a...");
+  assert.equal(truncateText("abcdef", 3), "...");
+  assert.equal(truncateText("abcdef", 2), "...");
+  assert.equal(truncateText("abcdef", 0), "");
+  assert.ok(truncateText("x".repeat(4001), 4000).length <= 4000);
+});
+
+test("callDeepSeek fails with a bounded timeout", async () => {
+  const fetchImpl = (_url, options) => new Promise((_resolve, reject) => {
+    options.signal.addEventListener("abort", () => {
+      const error = new Error("The operation was aborted");
+      error.name = "AbortError";
+      reject(error);
+    });
+  });
+
+  await assert.rejects(
+    () => callDeepSeek({
+      fetchImpl,
+      apiKey: "deepseek-key",
+      messages: [{ role: "user", content: "{}" }],
+      timeoutMs: 1,
+    }),
+    /timed out after 1ms/,
+  );
+});
+
+test("runTriageQueueRefill exits without model call when the queue is full", async () => {
+  const project = projectWithItems([
+    issueItem({ number: 1, status: HUMAN_ACCEPTANCE_STATUS }),
+    issueItem({ number: 2, status: HUMAN_ACCEPTANCE_STATUS }),
+    issueItem({ number: 3, status: HUMAN_ACCEPTANCE_STATUS }),
+    issueItem({ number: 4, status: TODO_STATUS }),
+  ]);
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "duumbi-triage-full-"));
+  const { fetchImpl, calls } = makeFetch({ project, decision: { action: "no_action" } });
+  const core = makeCore();
+
+  const result = await runTriageQueueRefill({
+    env: {
+      GH_PROJECT_PAT: "pat",
+      DUUMBI_PROJECT_NUMBER: "1",
+      DUUMBI_METRICS_PATH: "metrics.json",
+    },
+    context: makeContext(),
+    core,
+    summary: makeSummary(),
+    fetchImpl,
+    workspace,
+  });
+
+  assert.equal(result.decision, "not_needed");
+  assert.equal(core.failed, null);
+  assert.equal(calls.some((call) => call.url.includes("deepseek.com")), false);
+  const metrics = JSON.parse(fs.readFileSync(path.join(workspace, "metrics.json"), "utf8"));
+  assert.equal(metrics.counts.issues_queued, 0);
+  assert.equal(metrics.provider_usage.reason, "human_acceptance_queue_full");
+});
+
+test("runTriageQueueRefill routes one eligible Todo issue to human acceptance", async () => {
+  const project = projectWithItems([
+    issueItem({ number: 1, status: HUMAN_ACCEPTANCE_STATUS }),
+    issueItem({ number: 2, status: HUMAN_ACCEPTANCE_STATUS }),
+    issueItem({ number: 10, status: TODO_STATUS }),
+  ]);
+  const decision = {
+    action: "route_existing_issue",
+    existing_issue_number: 10,
+    source_links: ["duumbi-vault/Duumbi/00 Inbox (ToProcess)/candidate.md"],
+    rationale: "Best next actionable candidate.",
+  };
+  const workspace = makeWorkspace();
+  const { fetchImpl, calls } = makeFetch({ project, decision });
+  const core = makeCore();
+
+  const result = await runTriageQueueRefill({
+    env: {
+      GH_PROJECT_PAT: "pat",
+      DEEPSEEK_API_KEY: "deepseek-key",
+      DUUMBI_PROJECT_NUMBER: "1",
+      DUUMBI_METRICS_PATH: "metrics.json",
+    },
+    context: makeContext(),
+    core,
+    summary: makeSummary(),
+    fetchImpl,
+    workspace,
+  });
+
+  assert.equal(core.failed, null);
+  assert.equal(result.decision, "route_existing_issue");
+  assert.equal(result.issueNumber, 10);
+  assert.equal(calls.filter((call) => call.url === "https://api.deepseek.com/chat/completions").length, 1);
+
+  const statusUpdates = calls.filter((call) => call.body.query?.includes("updateProjectV2ItemFieldValue"));
+  assert.equal(statusUpdates.length, 1);
+  assert.equal(statusUpdates[0].body.variables.itemId, "item-10");
+  assert.equal(statusUpdates[0].body.variables.optionId, "human-acceptance-option");
+
+  const labelCalls = calls.filter((call) => call.url.endsWith("/issues/10/labels"));
+  assert.equal(labelCalls.length, 1);
+  assert.deepEqual(labelCalls[0].body.labels, ["needs-human-review"]);
+  assert.ok(calls.indexOf(labelCalls[0]) < calls.indexOf(statusUpdates[0]));
+
+  const metrics = JSON.parse(fs.readFileSync(path.join(workspace, "metrics.json"), "utf8"));
+  assert.equal(metrics.counts.issues_queued, 1);
+  assert.equal(metrics.counts.slack_notifications_attempted, 0);
+  assert.equal(metrics.provider_usage.provider, "deepseek");
+});
+
+test("runTriageQueueRefill blocks before status update when existing issue label fails", async () => {
+  const project = projectWithItems([
+    issueItem({ number: 1, status: HUMAN_ACCEPTANCE_STATUS }),
+    issueItem({ number: 10, status: TODO_STATUS }),
+  ]);
+  const decision = {
+    action: "route_existing_issue",
+    existing_issue_number: 10,
+    source_links: ["duumbi-vault/Duumbi/00 Inbox (ToProcess)/candidate.md"],
+    rationale: "Best next actionable candidate.",
+  };
+  const workspace = makeWorkspace();
+  const { fetchImpl, calls } = makeFetch({ project, decision, failExistingLabel: true });
+  const core = makeCore();
+
+  const result = await runTriageQueueRefill({
+    env: {
+      GH_PROJECT_PAT: "pat",
+      DEEPSEEK_API_KEY: "deepseek-key",
+      DUUMBI_PROJECT_NUMBER: "1",
+      DUUMBI_METRICS_PATH: "metrics.json",
+    },
+    context: makeContext(),
+    core,
+    summary: makeSummary(),
+    fetchImpl,
+    workspace,
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(core.failed, /GitHub REST POST/);
+  assert.equal(calls.some((call) => call.body.query?.includes("updateProjectV2ItemFieldValue")), false);
+  const metrics = JSON.parse(fs.readFileSync(path.join(workspace, "metrics.json"), "utf8"));
+  assert.equal(metrics.counts.issues_considered, 2);
+  assert.equal(metrics.provider_usage.request_count, null);
+});
+
+test("runTriageQueueRefill closes a created issue when Project insertion fails", async () => {
+  const project = projectWithItems([
+    issueItem({ number: 1, status: HUMAN_ACCEPTANCE_STATUS }),
+    issueItem({ number: 2, status: HUMAN_ACCEPTANCE_STATUS }),
+  ]);
+  const decision = {
+    action: "create_issue",
+    source_links: ["duumbi-vault/Duumbi/00 Inbox (ToProcess)/candidate.md"],
+    rationale: "No existing Todo issue represents the candidate.",
+    issue: {
+      title: "New triage candidate",
+      body: "Create a new triage candidate.",
+    },
+  };
+  const workspace = makeWorkspace();
+  const { fetchImpl, calls } = makeFetch({ project, decision, failAddToProject: true });
+  const core = makeCore();
+
+  const result = await runTriageQueueRefill({
+    env: {
+      GH_PROJECT_PAT: "pat",
+      DEEPSEEK_API_KEY: "deepseek-key",
+      DUUMBI_PROJECT_NUMBER: "1",
+      DUUMBI_METRICS_PATH: "metrics.json",
+    },
+    context: makeContext(),
+    core,
+    summary: makeSummary(),
+    fetchImpl,
+    workspace,
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(core.failed, /was closed after incomplete queue update/);
+  assert.equal(calls.some((call) => call.url.endsWith("/issues/99/comments")), true);
+  const closeCalls = calls.filter((call) => call.url.endsWith("/issues/99") && call.method === "PATCH");
+  assert.equal(closeCalls.length, 1);
+  assert.equal(closeCalls[0].body.state, "closed");
+  assert.equal(calls.some((call) => call.url.endsWith("/issues/99/labels")), false);
+});
+
+test("triage decision validation rejects malformed or unsafe model output", () => {
+  const contextPayload = {
+    project: {
+      eligible_todo_issues: [{ number: 7, item_id: "item-7" }],
+    },
+  };
+
+  assert.throws(() => parseTriageDecision("not-json"), /not valid JSON/);
+  assert.throws(
+    () => validateTriageDecision({ action: "delete_issue" }, contextPayload),
+    /not supported/,
+  );
+  assert.throws(
+    () => validateTriageDecision({ action: "route_existing_issue", existing_issue_number: 7 }, contextPayload),
+    /source_links/,
+  );
+  assert.throws(
+    () => validateTriageDecision({
+      action: "route_existing_issue",
+      existing_issue_number: 99,
+      source_links: ["https://github.com/hgahub/duumbi/issues/99"],
+    }, contextPayload),
+    /not an eligible Todo issue/,
+  );
+  assert.throws(
+    () => validateTriageDecision({
+      action: "create_issue",
+      source_links: ["duumbi-vault/Duumbi/00 Inbox (ToProcess)/candidate.md"],
+      issue: { body: "Missing title." },
+    }, contextPayload),
+    /issue.title/,
+  );
+  assert.throws(
+    () => validateTriageDecision({
+      action: "create_issue",
+      source_links: ["duumbi-vault/Duumbi/00 Inbox (ToProcess)/candidate.md"],
+      issue: { title: "Missing body" },
+    }, contextPayload),
+    /issue.body/,
+  );
+});


### PR DESCRIPTION
## Summary

- Reworks `triage-queue-refill.yml` to run every four hours and refill the `Needs Human Acceptance` queue instead of counting `Todo` items.
- Adds a testable DeepSeek-backed helper that reads bounded Project/Vault/GitHub context, validates strict JSON triage decisions, and queues at most one issue per run.
- Documents the Stage 4 exception to the no-model-in-Actions policy, required configuration, and DeepSeek cost guardrails.

## Behavior

When at least three open Project V2 issues are already in `Needs Human Acceptance`, the workflow exits without a model call or Slack notification. When fewer than three are waiting, it calls DeepSeek, either routes one eligible `Todo` issue or creates one issue, sets Project status to `Needs Human Acceptance`, and adds `needs-human-review` with `GH_PROJECT_PAT` so the existing Human Acceptance Slack gate can notify the user.

## Validation

- `node --test scripts/github-actions/triage-queue-refill.test.mjs`
- `node --check scripts/github-actions/triage-queue-refill.mjs`
- `node --check scripts/github-actions/triage-queue-refill.test.mjs`
- workflow sanity check for four-hour cron, `target_human_acceptance_min`, helper import, and `DEEPSEEK_API_KEY`
- `git diff --check`

## Configuration Required Before Live Run

- Secret `GH_PROJECT_PAT` with Project V2 read/write, issue write, discussion read, and `duumbi-vault` checkout access.
- Secret `DEEPSEEK_API_KEY`.
- Repository variable `DUUMBI_PROJECT_NUMBER`.
- Optional repository variable `DUUMBI_PROJECT_OWNER`; defaults to repository owner.
- Optional repository variable `DEEPSEEK_MODEL`; defaults to `deepseek-v4-pro`.
- Existing label `needs-human-review`.
- Existing Human Acceptance Slack gate configuration: `SLACK_BOT_TOKEN` and `SLACK_REVIEW_CHANNEL_ID` for `.github/workflows/human-acceptance-request.yml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated triage queue refill workflow schedule from every 3 hours to every 4 hours.
  * Refactored triage queue refill workflow implementation and updated queue management configuration.

* **Documentation**
  * Updated automation orchestration documentation to reflect workflow redesign and new queue management approach.

* **Tests**
  * Added test suite for triage queue refill workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hgahub/duumbi/pull/624?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->