### PR TITLE
[codex] Fix user-owned triage refill project lookup

### DIFF
--- a/.github/workflows/triage-queue-refill.yml
+++ b/.github/workflows/triage-queue-refill.yml
@@ -42,7 +42,7 @@ jobs:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           DEEPSEEK_MODEL: ${{ vars.DEEPSEEK_MODEL || 'deepseek-v4-pro' }}
           DUUMBI_PROJECT_OWNER: ${{ vars.DUUMBI_PROJECT_OWNER || github.repository_owner }}
-          DUUMBI_PROJECT_OWNER_TYPE: ${{ vars.DUUMBI_PROJECT_OWNER_TYPE || 'user' }}
+          DUUMBI_PROJECT_OWNER_TYPE: ${{ vars.DUUMBI_PROJECT_OWNER_TYPE }}
           DUUMBI_PROJECT_NUMBER: ${{ vars.DUUMBI_PROJECT_NUMBER }}
           DUUMBI_METRICS_PATH: duumbi-workflow-metrics.json
         with:

--- a/.github/workflows/triage-queue-refill.yml
+++ b/.github/workflows/triage-queue-refill.yml
@@ -42,6 +42,7 @@ jobs:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           DEEPSEEK_MODEL: ${{ vars.DEEPSEEK_MODEL || 'deepseek-v4-pro' }}
           DUUMBI_PROJECT_OWNER: ${{ vars.DUUMBI_PROJECT_OWNER || github.repository_owner }}
+          DUUMBI_PROJECT_OWNER_TYPE: ${{ vars.DUUMBI_PROJECT_OWNER_TYPE || 'user' }}
           DUUMBI_PROJECT_NUMBER: ${{ vars.DUUMBI_PROJECT_NUMBER }}
           DUUMBI_METRICS_PATH: duumbi-workflow-metrics.json
         with:

--- a/docs/automation/agentic-development-orchestration.md
+++ b/docs/automation/agentic-development-orchestration.md
@@ -73,6 +73,9 @@ closed.
   `triage-queue-refill.yml`.
 - `DUUMBI_PROJECT_OWNER`: optional repository variable; defaults to repository
   owner.
+- `DUUMBI_PROJECT_OWNER_TYPE`: optional repository variable; use `user` for a
+  personal-account project and `organization` for an org-owned project. Defaults
+  to `user`.
 
 ## Stage 4 Refill LLM Policy
 

--- a/docs/automation/agentic-development-orchestration.md
+++ b/docs/automation/agentic-development-orchestration.md
@@ -74,8 +74,8 @@ closed.
 - `DUUMBI_PROJECT_OWNER`: optional repository variable; defaults to repository
   owner.
 - `DUUMBI_PROJECT_OWNER_TYPE`: optional repository variable; use `user` for a
-  personal-account project and `organization` for an org-owned project. Defaults
-  to `user`.
+  personal-account project and `organization` for an org-owned project. When
+  omitted, the workflow infers the repository owner type from the GitHub event.
 
 ## Stage 4 Refill LLM Policy
 

--- a/scripts/github-actions/triage-queue-refill.mjs
+++ b/scripts/github-actions/triage-queue-refill.mjs
@@ -57,9 +57,35 @@ function parsePositiveInteger(value, fallback) {
   return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
-function normalizeProjectOwnerType(value) {
+function normalizeGitHubOwnerType(value) {
   const normalized = normalizeText(value).toLowerCase();
-  return normalized === "organization" || normalized === "org" ? "organization" : DEFAULT_PROJECT_OWNER_TYPE;
+  if (normalized === "organization" || normalized === "org") return "organization";
+  if (normalized === "user") return "user";
+  return null;
+}
+
+function normalizeProjectOwnerType(value, { allowBlank = false } = {}) {
+  const text = normalizeText(value);
+  if (!text) return allowBlank ? null : DEFAULT_PROJECT_OWNER_TYPE;
+  const ownerType = normalizeGitHubOwnerType(text);
+  if (!ownerType) {
+    throw new Error('DUUMBI_PROJECT_OWNER_TYPE must be "user" or "organization" when set.');
+  }
+  return ownerType;
+}
+
+function inferProjectOwnerType({ configuredType, context, projectOwner }) {
+  const explicitType = normalizeProjectOwnerType(configuredType, { allowBlank: true });
+  if (explicitType) return explicitType;
+
+  const repositoryOwner = context?.payload?.repository?.owner;
+  const repositoryOwnerType = normalizeGitHubOwnerType(repositoryOwner?.type);
+  const repositoryOwnerLogin = repositoryOwner?.login || context?.repo?.owner;
+  if (repositoryOwnerType && projectOwner === repositoryOwnerLogin) {
+    return repositoryOwnerType;
+  }
+
+  return DEFAULT_PROJECT_OWNER_TYPE;
 }
 
 function labelsForIssue(issue) {
@@ -866,7 +892,6 @@ export async function runTriageQueueRefill({
   const targetMinimum = parsePositiveInteger(inputs.target_human_acceptance_min, DEFAULT_TARGET_HUMAN_ACCEPTANCE_MIN);
   const projectPat = env.GH_PROJECT_PAT;
   const projectOwner = env.DUUMBI_PROJECT_OWNER || context.repo.owner;
-  const projectOwnerType = normalizeProjectOwnerType(env.DUUMBI_PROJECT_OWNER_TYPE);
   const projectNumber = Number(env.DUUMBI_PROJECT_NUMBER || 0);
   const deepSeekApiKey = env.DEEPSEEK_API_KEY;
   const deepSeekModel = env.DEEPSEEK_MODEL || DEFAULT_DEEPSEEK_MODEL;
@@ -891,6 +916,11 @@ export async function runTriageQueueRefill({
     if (!projectPat || !projectNumber) {
       throw new Error("Project V2 configuration is unavailable. Set GH_PROJECT_PAT and repository variable DUUMBI_PROJECT_NUMBER.");
     }
+    const projectOwnerType = inferProjectOwnerType({
+      configuredType: env.DUUMBI_PROJECT_OWNER_TYPE,
+      context,
+      projectOwner,
+    });
 
     const api = createGithubApi({
       fetchImpl,
@@ -900,7 +930,10 @@ export async function runTriageQueueRefill({
     });
     const project = await api.loadProject(projectOwner, projectNumber, projectOwnerType);
     if (!project) {
-      throw new Error(`Project V2 #${projectNumber} not found for ${projectOwnerType} ${projectOwner}.`);
+      throw new Error(
+        `Project V2 #${projectNumber} not found for ${projectOwnerType} ${projectOwner}. `
+        + 'Check DUUMBI_PROJECT_OWNER, DUUMBI_PROJECT_OWNER_TYPE ("user" or "organization"), and DUUMBI_PROJECT_NUMBER.',
+      );
     }
     validateProjectStatusConfig(project);
 

--- a/scripts/github-actions/triage-queue-refill.mjs
+++ b/scripts/github-actions/triage-queue-refill.mjs
@@ -9,6 +9,7 @@ export const HUMAN_ACCEPTANCE_LABEL = "needs-human-review";
 export const DEFAULT_TARGET_HUMAN_ACCEPTANCE_MIN = 3;
 export const DEFAULT_DEEPSEEK_MODEL = "deepseek-v4-pro";
 export const MAX_ISSUES_CREATED_PER_RUN = 1;
+export const DEFAULT_PROJECT_OWNER_TYPE = "user";
 
 const ACTIVE_VAULT_DOCS = [
   "Duumbi/How to use.md",
@@ -54,6 +55,11 @@ export function truncateText(value, maxLength = 4000) {
 function parsePositiveInteger(value, fallback) {
   const parsed = Number(value);
   return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function normalizeProjectOwnerType(value) {
+  const normalized = normalizeText(value).toLowerCase();
+  return normalized === "organization" || normalized === "org" ? "organization" : DEFAULT_PROJECT_OWNER_TYPE;
 }
 
 function labelsForIssue(issue) {
@@ -523,52 +529,18 @@ export function createGithubApi({ fetchImpl = fetch, token, owner, repo }) {
     repo,
     graphql,
     rest,
-    async loadProject(projectOwner, projectNumber) {
+    async loadProject(projectOwner, projectNumber, projectOwnerType = DEFAULT_PROJECT_OWNER_TYPE) {
       let cursor = null;
       let title = "";
       let id = "";
       let fields = { nodes: [] };
       const nodes = [];
+      const ownerType = normalizeProjectOwnerType(projectOwnerType);
+      const ownerField = ownerType === "organization" ? "organization" : "user";
       for (;;) {
         const data = await graphql(`
           query($login: String!, $number: Int!, $cursor: String) {
-            organization(login: $login) {
-              projectV2(number: $number) {
-                id
-                title
-                fields(first: 50) {
-                  nodes {
-                    ... on ProjectV2SingleSelectField { id name options { id name } }
-                  }
-                }
-                items(first: 100, after: $cursor) {
-                  pageInfo { hasNextPage endCursor }
-                  nodes {
-                    id
-                    content {
-                      ... on Issue {
-                        id
-                        number
-                        title
-                        url
-                        state
-                        body
-                        labels(first: 20) { nodes { name } }
-                      }
-                    }
-                    fieldValues(first: 50) {
-                      nodes {
-                        ... on ProjectV2ItemFieldSingleSelectValue {
-                          name
-                          field { ... on ProjectV2SingleSelectField { name } }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-            user(login: $login) {
+            ${ownerField}(login: $login) {
               projectV2(number: $number) {
                 id
                 title
@@ -605,7 +577,7 @@ export function createGithubApi({ fetchImpl = fetch, token, owner, repo }) {
               }
             }
           }`, { login: projectOwner, number: projectNumber, cursor });
-        const page = data.organization?.projectV2 || data.user?.projectV2;
+        const page = data[ownerField]?.projectV2;
         if (!page) return null;
         id = id || page.id;
         title = title || page.title;
@@ -894,6 +866,7 @@ export async function runTriageQueueRefill({
   const targetMinimum = parsePositiveInteger(inputs.target_human_acceptance_min, DEFAULT_TARGET_HUMAN_ACCEPTANCE_MIN);
   const projectPat = env.GH_PROJECT_PAT;
   const projectOwner = env.DUUMBI_PROJECT_OWNER || context.repo.owner;
+  const projectOwnerType = normalizeProjectOwnerType(env.DUUMBI_PROJECT_OWNER_TYPE);
   const projectNumber = Number(env.DUUMBI_PROJECT_NUMBER || 0);
   const deepSeekApiKey = env.DEEPSEEK_API_KEY;
   const deepSeekModel = env.DEEPSEEK_MODEL || DEFAULT_DEEPSEEK_MODEL;
@@ -925,9 +898,9 @@ export async function runTriageQueueRefill({
       owner: context.repo.owner,
       repo: context.repo.repo,
     });
-    const project = await api.loadProject(projectOwner, projectNumber);
+    const project = await api.loadProject(projectOwner, projectNumber, projectOwnerType);
     if (!project) {
-      throw new Error(`Project V2 #${projectNumber} not found for ${projectOwner}.`);
+      throw new Error(`Project V2 #${projectNumber} not found for ${projectOwnerType} ${projectOwner}.`);
     }
     validateProjectStatusConfig(project);
 

--- a/scripts/github-actions/triage-queue-refill.test.mjs
+++ b/scripts/github-actions/triage-queue-refill.test.mjs
@@ -147,7 +147,10 @@ function makeFetch({ project, decision, failAddToProject = false, failExistingLa
         });
       }
       if (body.query.includes("projectV2(number")) {
-        return response({ data: { organization: { projectV2: project }, user: null } });
+        if (body.query.includes("organization(login")) {
+          return response({ data: { organization: { projectV2: project } } });
+        }
+        return response({ data: { user: { projectV2: project } } });
       }
       if (body.query.includes("updateProjectV2ItemFieldValue")) {
         return response({ data: { updateProjectV2ItemFieldValue: { projectV2Item: { id: body.variables.itemId } } } });
@@ -279,6 +282,35 @@ test("runTriageQueueRefill exits without model call when the queue is full", asy
   const metrics = JSON.parse(fs.readFileSync(path.join(workspace, "metrics.json"), "utf8"));
   assert.equal(metrics.counts.issues_queued, 0);
   assert.equal(metrics.provider_usage.reason, "human_acceptance_queue_full");
+});
+
+test("runTriageQueueRefill queries user-owned Project V2 by default", async () => {
+  const project = projectWithItems([
+    issueItem({ number: 1, status: HUMAN_ACCEPTANCE_STATUS }),
+    issueItem({ number: 2, status: HUMAN_ACCEPTANCE_STATUS }),
+    issueItem({ number: 3, status: HUMAN_ACCEPTANCE_STATUS }),
+  ]);
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "duumbi-triage-user-project-"));
+  const { fetchImpl, calls } = makeFetch({ project, decision: { action: "no_action" } });
+  const core = makeCore();
+
+  const result = await runTriageQueueRefill({
+    env: {
+      GH_PROJECT_PAT: "pat",
+      DUUMBI_PROJECT_NUMBER: "4",
+      DUUMBI_METRICS_PATH: "metrics.json",
+    },
+    context: makeContext(),
+    core,
+    summary: makeSummary(),
+    fetchImpl,
+    workspace,
+  });
+
+  assert.equal(result.decision, "not_needed");
+  const projectQuery = calls.find((call) => call.body.query?.includes("projectV2(number"));
+  assert.ok(projectQuery.body.query.includes("user(login"));
+  assert.equal(projectQuery.body.query.includes("organization(login"), false);
 });
 
 test("runTriageQueueRefill routes one eligible Todo issue to human acceptance", async () => {

--- a/scripts/github-actions/triage-queue-refill.test.mjs
+++ b/scripts/github-actions/triage-queue-refill.test.mjs
@@ -66,7 +66,7 @@ function projectWithItems(items) {
   };
 }
 
-function makeContext(inputs = {}) {
+function makeContext(inputs = {}, ownerType = "User") {
   return {
     workflow: "Triage Queue Refill",
     runId: 12345,
@@ -75,7 +75,15 @@ function makeContext(inputs = {}) {
     ref: "refs/heads/main",
     sha: "abc123",
     repo: { owner: "hgahub", repo: "duumbi" },
-    payload: { inputs },
+    payload: {
+      inputs,
+      repository: {
+        owner: {
+          login: "hgahub",
+          type: ownerType,
+        },
+      },
+    },
   };
 }
 
@@ -311,6 +319,94 @@ test("runTriageQueueRefill queries user-owned Project V2 by default", async () =
   const projectQuery = calls.find((call) => call.body.query?.includes("projectV2(number"));
   assert.ok(projectQuery.body.query.includes("user(login"));
   assert.equal(projectQuery.body.query.includes("organization(login"), false);
+});
+
+test("runTriageQueueRefill queries organization-owned Project V2 when configured", async () => {
+  const project = projectWithItems([
+    issueItem({ number: 1, status: HUMAN_ACCEPTANCE_STATUS }),
+    issueItem({ number: 2, status: HUMAN_ACCEPTANCE_STATUS }),
+    issueItem({ number: 3, status: HUMAN_ACCEPTANCE_STATUS }),
+  ]);
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "duumbi-triage-org-project-"));
+  const { fetchImpl, calls } = makeFetch({ project, decision: { action: "no_action" } });
+  const core = makeCore();
+
+  const result = await runTriageQueueRefill({
+    env: {
+      GH_PROJECT_PAT: "pat",
+      DUUMBI_PROJECT_OWNER_TYPE: "organization",
+      DUUMBI_PROJECT_NUMBER: "4",
+      DUUMBI_METRICS_PATH: "metrics.json",
+    },
+    context: makeContext(),
+    core,
+    summary: makeSummary(),
+    fetchImpl,
+    workspace,
+  });
+
+  assert.equal(result.decision, "not_needed");
+  const projectQuery = calls.find((call) => call.body.query?.includes("projectV2(number"));
+  assert.ok(projectQuery.body.query.includes("organization(login"));
+  assert.equal(projectQuery.body.query.includes("user(login"), false);
+});
+
+test("runTriageQueueRefill infers organization-owned Project V2 from repository owner type", async () => {
+  const project = projectWithItems([
+    issueItem({ number: 1, status: HUMAN_ACCEPTANCE_STATUS }),
+    issueItem({ number: 2, status: HUMAN_ACCEPTANCE_STATUS }),
+    issueItem({ number: 3, status: HUMAN_ACCEPTANCE_STATUS }),
+  ]);
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "duumbi-triage-inferred-org-project-"));
+  const { fetchImpl, calls } = makeFetch({ project, decision: { action: "no_action" } });
+  const core = makeCore();
+
+  const result = await runTriageQueueRefill({
+    env: {
+      GH_PROJECT_PAT: "pat",
+      DUUMBI_PROJECT_NUMBER: "4",
+      DUUMBI_METRICS_PATH: "metrics.json",
+    },
+    context: makeContext({}, "Organization"),
+    core,
+    summary: makeSummary(),
+    fetchImpl,
+    workspace,
+  });
+
+  assert.equal(result.decision, "not_needed");
+  const projectQuery = calls.find((call) => call.body.query?.includes("projectV2(number"));
+  assert.ok(projectQuery.body.query.includes("organization(login"));
+  assert.equal(projectQuery.body.query.includes("user(login"), false);
+});
+
+test("runTriageQueueRefill rejects invalid DUUMBI_PROJECT_OWNER_TYPE", async () => {
+  const project = projectWithItems([
+    issueItem({ number: 1, status: HUMAN_ACCEPTANCE_STATUS }),
+    issueItem({ number: 2, status: HUMAN_ACCEPTANCE_STATUS }),
+    issueItem({ number: 3, status: HUMAN_ACCEPTANCE_STATUS }),
+  ]);
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "duumbi-triage-invalid-owner-type-"));
+  const { fetchImpl, calls } = makeFetch({ project, decision: { action: "no_action" } });
+  const core = makeCore();
+
+  const result = await runTriageQueueRefill({
+    env: {
+      GH_PROJECT_PAT: "pat",
+      DUUMBI_PROJECT_OWNER_TYPE: "organzation",
+      DUUMBI_PROJECT_NUMBER: "4",
+      DUUMBI_METRICS_PATH: "metrics.json",
+    },
+    context: makeContext(),
+    core,
+    summary: makeSummary(),
+    fetchImpl,
+    workspace,
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(core.failed, /DUUMBI_PROJECT_OWNER_TYPE must be "user" or "organization"/);
+  assert.equal(calls.some((call) => call.body.query?.includes("projectV2(number")), false);
 });
 
 test("runTriageQueueRefill routes one eligible Todo issue to human acceptance", async () => {


### PR DESCRIPTION
## Summary

- Fixes Triage Queue Refill Project V2 lookup for personal GitHub accounts by querying `user(login: ...)` by default instead of querying both organization and user roots in one GraphQL request.
- Adds optional `DUUMBI_PROJECT_OWNER_TYPE`; defaults to `user`, accepts `organization`/`org` only when the Project V2 really belongs to an organization.
- Documents the setting and adds coverage for the default user-owned project path.

## Why

The workflow run failed for `DUUMBI_PROJECT_OWNER=hgahub` with:

```text
Could not resolve to an Organization with the login of 'hgahub'.
```

`hgahub` is a personal account, not an organization. The workflow should not require an organization for a personal-account Project V2.

## Validation

- `node --test scripts/github-actions/triage-queue-refill.test.mjs`
- `node --check scripts/github-actions/triage-queue-refill.mjs`
- `node --check scripts/github-actions/triage-queue-refill.test.mjs`
- workflow sanity check for `DUUMBI_PROJECT_OWNER_TYPE`, NHA input, helper import, and pinned action refs
- `git diff --check`