### PR TITLE
[codex] Route clarification comments through DeepSeek

### DIFF
--- a/.github/workflows/clarification-routing.yml
+++ b/.github/workflows/clarification-routing.yml
@@ -34,7 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Evaluate clarification
         env:

--- a/.github/workflows/clarification-routing.yml
+++ b/.github/workflows/clarification-routing.yml
@@ -14,6 +14,11 @@ on:
         required: false
         type: string
         default: ''
+      comment_body:
+        description: Source clarification comment body; must start with @Clarification
+        required: false
+        type: string
+        default: '@Clarification'
 
 permissions:
   contents: read
@@ -28,176 +33,19 @@ jobs:
     name: Route clarification response
     runs-on: ubuntu-latest
     steps:
-      - name: Create clarification handoff
-        uses: actions/github-script@v9
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Evaluate clarification
         env:
+          GITHUB_TOKEN: ${{ github.token }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          DEEPSEEK_MODEL: ${{ vars.DEEPSEEK_MODEL || 'deepseek-v4-pro' }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_REVIEW_CHANNEL_ID: ${{ secrets.SLACK_REVIEW_CHANNEL_ID }}
           DUUMBI_AGENT_DISPATCH_CHANNEL_ID: ${{ secrets.DUUMBI_AGENT_DISPATCH_CHANNEL_ID }}
           DUUMBI_METRICS_PATH: duumbi-workflow-metrics.json
-        with:
-          script: |
-            const fs = require("fs");
-            const isCommentEvent = context.eventName === "issue_comment";
-            const issue = isCommentEvent ? context.payload.issue : null;
-            if (issue?.pull_request) {
-              core.info("Ignoring pull request comment.");
-              return;
-            }
-
-            const issueNumber = isCommentEvent ? issue.number : Number(context.payload.inputs.issue_number);
-            const commentUrl = isCommentEvent ? context.payload.comment.html_url : String(context.payload.inputs.comment_url || "");
-            const commentBody = isCommentEvent ? String(context.payload.comment.body || "") : "";
-            const mentioned = /@(?:Codex|Copilot)\b/i.test(commentBody) || !isCommentEvent;
-            if (!mentioned) {
-              core.info("No @Codex or @Copilot mention; ignoring.");
-              return;
-            }
-
-            const { data: freshIssue } = await github.rest.issues.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-            });
-            const labels = (freshIssue.labels || []).map((label) => typeof label === "string" ? label : label.name).filter(Boolean);
-            const marker = `<!-- duumbi-clarification-routing:v1 issue=${issueNumber} comment=${commentUrl || "manual"} -->`;
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-              per_page: 100,
-            });
-            if (comments.some((comment) => (comment.body || "").includes(marker))) {
-              core.info("Clarification handoff marker already exists.");
-              return;
-            }
-
-            const issueUrl = freshIssue.html_url;
-            const prompt = [
-              "Run DUUMBI clarification evaluation.",
-              "",
-              `Target issue: ${issueUrl}`,
-              commentUrl ? `Source clarification comment: ${commentUrl}` : "Source clarification comment: manual workflow dispatch",
-              `Current labels: ${labels.join(", ") || "none"}`,
-              "",
-              "Goal: Evaluate the developer clarification response, inspect the current issue and DUUMBI context, decide whether the item is ready to return to its prior workflow stage or still needs clarification, and write the appropriate GitHub comment/status recommendation.",
-              "",
-              "Use the stage-specific DUUMBI skill that matches the issue state. Do not create specs, PRs, source changes, or implementation work unless the issue is already in the matching later stage and that skill explicitly permits it.",
-            ].join("\n");
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-              body: [
-                marker,
-                "Clarification response routed for agent evaluation.",
-                "",
-                `Source comment: ${commentUrl || "manual workflow dispatch"}`,
-                "",
-                "```text",
-                prompt,
-                "```",
-              ].join("\n"),
-            });
-
-            const token = process.env.SLACK_BOT_TOKEN;
-            const channel = process.env.DUUMBI_AGENT_DISPATCH_CHANNEL_ID || process.env.SLACK_REVIEW_CHANNEL_ID;
-            let slackNotification = "not_configured";
-            if (token && channel) {
-              const res = await fetch("https://slack.com/api/chat.postMessage", {
-                method: "POST",
-                headers: {
-                  Authorization: `Bearer ${token}`,
-                  "Content-Type": "application/json; charset=utf-8",
-                },
-                body: JSON.stringify({
-                  channel,
-                  text: [
-                    "*DUUMBI Clarification Routing*",
-                    `*Issue:* <${issueUrl}|#${issueNumber} ${freshIssue.title}>`,
-                    commentUrl ? `*Comment:* ${commentUrl}` : "*Comment:* manual dispatch",
-                    "",
-                    "```",
-                    prompt,
-                    "```",
-                  ].join("\n"),
-                }),
-              });
-              const body = await res.json();
-              slackNotification = res.ok && body.ok ? "posted" : "failed";
-              if (slackNotification === "failed") core.warning(`Slack notification failed: ${body.error || res.status}`);
-            }
-
-            const now = new Date().toISOString();
-            const metrics = {
-              schema_version: "duumbi.workflow_metrics.v1",
-              generated_at: now,
-              source: "github_actions",
-              repository: `${context.repo.owner}/${context.repo.repo}`,
-              workflow: {
-                name: context.workflow,
-                file: ".github/workflows/clarification-routing.yml",
-                run_id: context.runId,
-                run_attempt: Number(process.env.GITHUB_RUN_ATTEMPT || 1),
-                event_name: context.eventName,
-                actor: context.actor,
-                ref: context.ref,
-                sha: context.sha,
-                conclusion: "success",
-                started_at: now,
-                completed_at: now,
-                duration_ms: null,
-              },
-              correlation: {
-                issue_number: issueNumber,
-                pr_number: null,
-                stage: "clarification-routing",
-                decision: null,
-                project_status: labels.includes("needs-clarification") ? "Needs Clarification" : null,
-              },
-              counts: {
-                issues_considered: 1,
-                issues_queued: 1,
-                slack_notifications_attempted: slackNotification === "posted" ? 1 : 0,
-                artifact_links_found: commentUrl ? 1 : 0,
-                artifact_links_missing: commentUrl ? 0 : 1,
-              },
-              provider_usage: {
-                available: false,
-                reason: "agent_dispatch_only",
-                provider: null,
-                model: null,
-                request_count: null,
-                prompt_tokens: null,
-                completion_tokens: null,
-                total_tokens: null,
-                estimated_cost_usd: null,
-                latency_ms: null,
-                failure_count: null,
-              },
-              privacy: {
-                metadata_only: true,
-                raw_prompts_included: false,
-                raw_completions_included: false,
-                raw_slack_payloads_included: false,
-                secrets_included: false,
-              },
-              warnings: slackNotification === "posted" ? [] : [`slack_notification_${slackNotification}`],
-            };
-            fs.writeFileSync(process.env.DUUMBI_METRICS_PATH, `${JSON.stringify(metrics, null, 2)}\n`);
-
-            await core.summary
-              .addHeading("DUUMBI Clarification Routing", 2)
-              .addTable([
-                [{ data: "Field", header: true }, { data: "Value", header: true }],
-                ["Issue", `#${issueNumber}`],
-                ["Source comment", commentUrl || "manual dispatch"],
-                ["Slack dispatch", slackNotification],
-              ])
-              .addHeading("Agent Prompt", 3)
-              .addCodeBlock(prompt, "text")
-              .write();
+        run: node scripts/github-actions/clarification-routing.mjs
 
       - name: Upload DUUMBI workflow metrics
         if: always()

--- a/docs/automation/agentic-development-orchestration.md
+++ b/docs/automation/agentic-development-orchestration.md
@@ -38,7 +38,7 @@ or source-repo contracts that support it.
 | `slack-intake-dispatch.yml` | Slack shortcut repository dispatch, manual | Dispatches Stage 1 Slack intake without requiring the developer to name the skill. |
 | `inbox-enrichment-dispatch.yml` | 06:00 UTC and 18:00 UTC, manual | Checks `duumbi-vault` for unnormalized Inbox notes and dispatches `duumbi-inbox-enrichment` only when candidate notes exist. |
 | `triage-queue-refill.yml` | every 4 hours, manual | Reads Project V2 `Needs Human Acceptance` count and uses a bounded DeepSeek Stage 4 triage refill when fewer than three issues are waiting. |
-| `clarification-routing.yml` | issue comment mention, manual | Routes `@Codex` or `@Copilot` clarification replies to the right stage-specific agent. |
+| `clarification-routing.yml` | `@Clarification` issue comment, manual | Uses DeepSeek to synthesize an explicit clarification comment on `needs-human-review` issues, posts a GitHub synthesis comment, and sends Slack. |
 | `spec-ai-gate.yml` | manual, repository dispatch | Records Stage 7/9 AI gate decisions and dispatches `stage-approval.yml` for clean approvals. |
 | `stage10-authorization-request.yml` | label, hourly, manual, repository dispatch | Sends Stage 10 resource authorization Slack notifications and records resource decisions. |
 | `stage11-review-request.yml` | label, hourly, manual | Sends implementation review handoff notifications and records the Stage 11 notification marker. |
@@ -79,6 +79,14 @@ closed.
 
 ## Stage 4 Refill LLM Policy
 
+`clarification-routing.yml` ignores general `@Codex` and `@Copilot` issue
+comments. It only processes comments whose visible text starts with
+`@Clarification`, and only when the target issue still carries the
+`needs-human-review` Stage 5 label. The workflow calls DeepSeek for a bounded
+JSON clarification synthesis, writes the synthesis as an issue comment, and
+sends a Slack notification when Slack secrets are configured. It does not update
+labels, Project V2 status, specs, PRs, or source code.
+
 `triage-queue-refill.yml` runs at most six times per day. It first reads Project
 V2 with `GH_PROJECT_PAT`; if at least three open issues are already in
 `Needs Human Acceptance`, it exits without calling a model or posting Slack.
@@ -93,7 +101,8 @@ most one issue is queued per run.
 All GitHub writes use `GH_PROJECT_PAT` rather than `GITHUB_TOKEN`, so adding the
 existing `needs-human-review` label can trigger the separate Human Acceptance
 Slack gate. The refill workflow itself does not post Slack notifications; this
-avoids duplicate messages.
+avoids duplicate messages. Clarification routing uses `GITHUB_TOKEN` because it
+only comments on the already-routed issue.
 
 Default model: `deepseek-v4-pro`. DeepSeek's public docs list V4 Pro and Flash
 with 1M context, JSON output, tool calls, and low per-token prices. As of

--- a/docs/automation/agentic-development-orchestration.md
+++ b/docs/automation/agentic-development-orchestration.md
@@ -38,7 +38,7 @@ or source-repo contracts that support it.
 | `slack-intake-dispatch.yml` | Slack shortcut repository dispatch, manual | Dispatches Stage 1 Slack intake without requiring the developer to name the skill. |
 | `inbox-enrichment-dispatch.yml` | 06:00 UTC and 18:00 UTC, manual | Checks `duumbi-vault` for unnormalized Inbox notes and dispatches `duumbi-inbox-enrichment` only when candidate notes exist. |
 | `triage-queue-refill.yml` | every 4 hours, manual | Reads Project V2 `Needs Human Acceptance` count and uses a bounded DeepSeek Stage 4 triage refill when fewer than three issues are waiting. |
-| `clarification-routing.yml` | `@Clarification` issue comment, manual | Uses DeepSeek to synthesize an explicit clarification comment on `needs-human-review` issues, posts a GitHub synthesis comment, and sends Slack. |
+| `clarification-routing.yml` | issue comment created, manual | Filters for explicit `@Clarification` comments on `needs-human-review` issues, uses DeepSeek for synthesis, posts a GitHub comment, and sends Slack. |
 | `spec-ai-gate.yml` | manual, repository dispatch | Records Stage 7/9 AI gate decisions and dispatches `stage-approval.yml` for clean approvals. |
 | `stage10-authorization-request.yml` | label, hourly, manual, repository dispatch | Sends Stage 10 resource authorization Slack notifications and records resource decisions. |
 | `stage11-review-request.yml` | label, hourly, manual | Sends implementation review handoff notifications and records the Stage 11 notification marker. |
@@ -65,8 +65,9 @@ closed.
 - `DUUMBI_AGENT_DISPATCH_CHANNEL_ID`: optional agent dispatch channel; falls
   back to `SLACK_REVIEW_CHANNEL_ID`.
 - `GH_PROJECT_PAT`: PAT that can read and update GitHub Project V2.
-- `DEEPSEEK_API_KEY`: DeepSeek API key used only by `triage-queue-refill.yml`
-  when the `Needs Human Acceptance` queue is below target.
+- `DEEPSEEK_API_KEY`: DeepSeek API key used by `triage-queue-refill.yml`
+  when the `Needs Human Acceptance` queue is below target, and by
+  `clarification-routing.yml` for explicit `@Clarification` synthesis.
 - `DEEPSEEK_MODEL`: optional repository variable for the refill model; defaults
   to `deepseek-v4-pro`.
 - `DUUMBI_PROJECT_NUMBER`: repository variable for the Project V2 number used by
@@ -77,15 +78,18 @@ closed.
   personal-account project and `organization` for an org-owned project. When
   omitted, the workflow infers the repository owner type from the GitHub event.
 
-## Stage 4 Refill LLM Policy
+## Clarification Routing Policy
 
-`clarification-routing.yml` ignores general `@Codex` and `@Copilot` issue
-comments. It only processes comments whose visible text starts with
-`@Clarification`, and only when the target issue still carries the
-`needs-human-review` Stage 5 label. The workflow calls DeepSeek for a bounded
-JSON clarification synthesis, writes the synthesis as an issue comment, and
-sends a Slack notification when Slack secrets are configured. It does not update
-labels, Project V2 status, specs, PRs, or source code.
+`clarification-routing.yml` is registered on all created issue comments and
+filters in code. It ignores general `@Codex` and `@Copilot` issue comments. It
+only processes comments whose visible text starts with `@Clarification`, and
+only when the target issue still carries the `needs-human-review` Stage 5 label.
+The workflow calls DeepSeek for a bounded JSON clarification synthesis, writes
+the synthesis as an issue comment, and sends a Slack notification when Slack
+secrets are configured. It does not update labels, Project V2 status, specs,
+PRs, or source code.
+
+## Stage 4 Refill LLM Policy
 
 `triage-queue-refill.yml` runs at most six times per day. It first reads Project
 V2 with `GH_PROJECT_PAT`; if at least three open issues are already in

--- a/scripts/github-actions/clarification-routing.mjs
+++ b/scripts/github-actions/clarification-routing.mjs
@@ -202,7 +202,16 @@ export function createGithubApi({ fetchImpl = fetch, token, owner, repo }) {
       return rest("GET", `/repos/${owner}/${repo}/issues/${issueNumber}`);
     },
     async listIssueComments(issueNumber) {
-      return rest("GET", `/repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=100`);
+      const comments = [];
+      for (let page = 1;; page += 1) {
+        const pageComments = await rest("GET", `/repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=100&page=${page}`);
+        if (!Array.isArray(pageComments)) {
+          throw new Error("GitHub issue comments response was not an array.");
+        }
+        comments.push(...pageComments);
+        if (pageComments.length < 100) break;
+      }
+      return comments;
     },
     async createIssueComment(issueNumber, body) {
       return rest("POST", `/repos/${owner}/${repo}/issues/${issueNumber}/comments`, { body });

--- a/scripts/github-actions/clarification-routing.mjs
+++ b/scripts/github-actions/clarification-routing.mjs
@@ -316,18 +316,22 @@ async function postSlack({ fetchImpl, env, text, warnings }) {
   const channel = env.DUUMBI_AGENT_DISPATCH_CHANNEL_ID || env.SLACK_REVIEW_CHANNEL_ID;
   if (!token || !channel) return "not_configured";
 
-  const response = await fetchImpl("https://slack.com/api/chat.postMessage", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json; charset=utf-8",
-    },
-    body: JSON.stringify({ channel, text }),
-  });
-  const { json } = await readJsonResponse(response);
-  if (response.ok && json.ok) return "posted";
+  try {
+    const response = await fetchImpl("https://slack.com/api/chat.postMessage", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify({ channel, text }),
+    });
+    const { json } = await readJsonResponse(response);
+    if (response.ok && json.ok) return "posted";
 
-  warnings.push(`slack_notification_failed:${json.error || response.status}`);
+    warnings.push(`slack_notification_failed:${json.error || response.status}`);
+  } catch (error) {
+    warnings.push(`slack_notification_failed:${truncateText(error.message || error, 160)}`);
+  }
   return "failed";
 }
 

--- a/scripts/github-actions/clarification-routing.mjs
+++ b/scripts/github-actions/clarification-routing.mjs
@@ -1,0 +1,607 @@
+import fsModule from "node:fs";
+import pathModule from "node:path";
+
+import {
+  DEFAULT_DEEPSEEK_MODEL,
+  callDeepSeek,
+  estimateDeepSeekCostUsd,
+  normalizeText,
+  truncateText,
+} from "./triage-queue-refill.mjs";
+
+export const WORKFLOW_FILE = ".github/workflows/clarification-routing.yml";
+export const HUMAN_ACCEPTANCE_LABEL = "needs-human-review";
+export const CLARIFICATION_PREFIX_PATTERN = /^@Clarification\b/i;
+export const MARKER_PREFIX = "<!-- duumbi-clarification-routing:v2";
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function labelsForIssue(issue) {
+  return (issue?.labels || [])
+    .map((label) => (typeof label === "string" ? label : label?.name))
+    .filter(Boolean);
+}
+
+function stripJsonFence(value) {
+  const text = normalizeText(value);
+  const fenceMatch = text.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  return fenceMatch ? fenceMatch[1].trim() : text;
+}
+
+function normalizeStringArray(value, maxItemLength = 1000) {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => truncateText(item, maxItemLength)).filter(Boolean);
+}
+
+function markdownList(items, fallback = "- none") {
+  const values = normalizeStringArray(items);
+  return values.length ? values.map((item) => `- ${item}`).join("\n") : fallback;
+}
+
+async function readJsonResponse(response) {
+  const text = await response.text();
+  try {
+    return { text, json: text ? JSON.parse(text) : {} };
+  } catch (error) {
+    throw new Error(`Response was not JSON: ${truncateText(error.message, 160)}; body=${truncateText(text, 240)}`);
+  }
+}
+
+export function parseClarificationDecision(content) {
+  const text = stripJsonFence(content);
+  try {
+    const parsed = JSON.parse(text);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("Decision must be a JSON object.");
+    }
+    return parsed;
+  } catch (firstError) {
+    const start = text.indexOf("{");
+    const end = text.lastIndexOf("}");
+    if (start >= 0 && end > start) {
+      try {
+        const parsed = JSON.parse(text.slice(start, end + 1));
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed;
+      } catch {
+        // Fall through to the original parse error.
+      }
+    }
+    throw new Error(`DeepSeek clarification decision was not valid JSON: ${firstError.message}`);
+  }
+}
+
+export function validateClarificationDecision(decision) {
+  const recommendation = normalizeText(decision?.recommendation);
+  const validRecommendations = new Set(["ready_for_human_acceptance", "needs_more_clarification"]);
+  if (!validRecommendations.has(recommendation)) {
+    throw new Error(`DeepSeek clarification recommendation is not supported: ${recommendation || "<missing>"}`);
+  }
+
+  const refinedSummary = truncateText(decision.refined_summary, 3000);
+  if (!refinedSummary) {
+    throw new Error("DeepSeek clarification decision is missing refined_summary.");
+  }
+
+  const sourceCommentUrls = normalizeStringArray(decision.source_comment_urls, 500);
+  if (sourceCommentUrls.length === 0) {
+    throw new Error("DeepSeek clarification decision is missing source_comment_urls.");
+  }
+
+  return {
+    recommendation,
+    refined_summary: refinedSummary,
+    clarified_requirements: normalizeStringArray(decision.clarified_requirements),
+    acceptance_criteria: normalizeStringArray(decision.acceptance_criteria),
+    remaining_questions: normalizeStringArray(decision.remaining_questions),
+    rationale: truncateText(decision.rationale || "", 2000),
+    source_comment_urls: sourceCommentUrls,
+  };
+}
+
+export function buildClarificationMessages(contextPayload) {
+  const schema = {
+    recommendation: "ready_for_human_acceptance | needs_more_clarification",
+    refined_summary: "short issue refinement based on the clarification comment",
+    clarified_requirements: ["specific requirement inferred from the issue and clarification"],
+    acceptance_criteria: ["observable acceptance criterion suitable for human acceptance"],
+    remaining_questions: ["question that still blocks acceptance, empty when ready"],
+    rationale: "short factual rationale",
+    source_comment_urls: ["source GitHub comment URL used for the refinement"],
+  };
+
+  return [
+    {
+      role: "system",
+      content: [
+        "You are the DUUMBI Stage 5 clarification evaluator.",
+        "Return exactly one valid JSON object and no markdown.",
+        "Use the issue and explicit @Clarification comment to refine the task for human acceptance.",
+        "Do not approve the issue, create specs, create PRs, modify source code, or start implementation.",
+        "If material ambiguity remains, use needs_more_clarification and list the blocking questions.",
+        "If the issue is clear enough for human acceptance, use ready_for_human_acceptance.",
+        `Expected JSON schema example: ${JSON.stringify(schema)}`,
+      ].join("\n"),
+    },
+    {
+      role: "user",
+      content: JSON.stringify(contextPayload, null, 2),
+    },
+  ];
+}
+
+export function buildClarificationComment(decision, { marker, sourceCommentUrl }) {
+  return [
+    marker,
+    "## Clarification Synthesis",
+    "",
+    `**Recommendation:** ${decision.recommendation === "ready_for_human_acceptance" ? "Ready for human acceptance" : "Needs more clarification"}`,
+    `**Source comment:** ${sourceCommentUrl}`,
+    "",
+    "### Refined Summary",
+    "",
+    decision.refined_summary,
+    "",
+    "### Clarified Requirements",
+    "",
+    markdownList(decision.clarified_requirements),
+    "",
+    "### Acceptance Criteria",
+    "",
+    markdownList(decision.acceptance_criteria),
+    "",
+    "### Remaining Questions",
+    "",
+    markdownList(decision.remaining_questions),
+    "",
+    "### Rationale",
+    "",
+    decision.rationale || "DeepSeek evaluated the explicit clarification comment against the current issue context.",
+  ].join("\n");
+}
+
+export function buildSlackText({ issue, issueNumber, issueUrl, sourceCommentUrl, decision }) {
+  return [
+    "*DUUMBI Clarification Routing*",
+    `*Issue:* <${issueUrl}|#${issueNumber} ${issue.title}>`,
+    `*Comment:* ${sourceCommentUrl}`,
+    `*Recommendation:* ${decision.recommendation === "ready_for_human_acceptance" ? "Ready for human acceptance" : "Needs more clarification"}`,
+    "",
+    `*Refined summary:* ${truncateText(decision.refined_summary, 900)}`,
+    "",
+    "*Remaining questions:*",
+    markdownList(decision.remaining_questions),
+  ].join("\n");
+}
+
+export function createGithubApi({ fetchImpl = fetch, token, owner, repo }) {
+  const authHeaders = {
+    Authorization: `bearer ${token}`,
+    "Content-Type": "application/json",
+    "User-Agent": "duumbi-clarification-routing",
+  };
+
+  const rest = async (method, urlPath, body = null) => {
+    const response = await fetchImpl(`https://api.github.com${urlPath}`, {
+      method,
+      headers: authHeaders,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    const { text, json } = await readJsonResponse(response);
+    if (!response.ok) {
+      throw new Error(`GitHub REST ${method} ${urlPath} failed: ${response.status} ${truncateText(text, 240)}`);
+    }
+    return json;
+  };
+
+  return {
+    owner,
+    repo,
+    async getIssue(issueNumber) {
+      return rest("GET", `/repos/${owner}/${repo}/issues/${issueNumber}`);
+    },
+    async listIssueComments(issueNumber) {
+      return rest("GET", `/repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=100`);
+    },
+    async createIssueComment(issueNumber, body) {
+      return rest("POST", `/repos/${owner}/${repo}/issues/${issueNumber}/comments`, { body });
+    },
+  };
+}
+
+function providerUsageNotCalled(reason) {
+  return {
+    available: false,
+    reason,
+    provider: null,
+    model: null,
+    request_count: null,
+    prompt_tokens: null,
+    completion_tokens: null,
+    total_tokens: null,
+    estimated_cost_usd: null,
+    latency_ms: null,
+    failure_count: null,
+  };
+}
+
+function providerUsageFromDeepSeek(model, usage, latencyMs) {
+  return {
+    available: true,
+    reason: "deepseek_api_call",
+    provider: "deepseek",
+    model,
+    request_count: 1,
+    prompt_tokens: Number.isFinite(Number(usage.prompt_tokens)) ? Number(usage.prompt_tokens) : null,
+    completion_tokens: Number.isFinite(Number(usage.completion_tokens)) ? Number(usage.completion_tokens) : null,
+    total_tokens: Number.isFinite(Number(usage.total_tokens)) ? Number(usage.total_tokens) : null,
+    estimated_cost_usd: estimateDeepSeekCostUsd(model, usage),
+    latency_ms: Number.isFinite(latencyMs) ? latencyMs : null,
+    failure_count: 0,
+  };
+}
+
+export function buildWorkflowMetrics({
+  context,
+  conclusion,
+  decision = null,
+  counts,
+  providerUsage,
+  warnings = [],
+  issueNumber = null,
+  generatedAt = nowIso(),
+}) {
+  return {
+    schema_version: "duumbi.workflow_metrics.v1",
+    generated_at: generatedAt,
+    source: "github_actions",
+    repository: `${context.repo.owner}/${context.repo.repo}`,
+    workflow: {
+      name: context.workflow,
+      file: WORKFLOW_FILE,
+      run_id: context.runId,
+      run_attempt: Number(process.env.GITHUB_RUN_ATTEMPT || 1),
+      event_name: context.eventName,
+      actor: context.actor,
+      ref: context.ref,
+      sha: context.sha,
+      conclusion,
+      started_at: generatedAt,
+      completed_at: generatedAt,
+      duration_ms: null,
+    },
+    correlation: {
+      issue_number: issueNumber,
+      pr_number: null,
+      stage: "clarification-routing",
+      decision,
+      project_status: null,
+    },
+    counts,
+    provider_usage: providerUsage,
+    privacy: {
+      metadata_only: true,
+      raw_prompts_included: false,
+      raw_completions_included: false,
+      raw_slack_payloads_included: false,
+      secrets_included: false,
+    },
+    warnings,
+  };
+}
+
+function buildIgnoredResult(reason) {
+  return {
+    ok: true,
+    ignored: true,
+    reason,
+    decision: "ignored",
+    issueNumber: null,
+    model: null,
+  };
+}
+
+async function postSlack({ fetchImpl, env, text, warnings }) {
+  const token = env.SLACK_BOT_TOKEN;
+  const channel = env.DUUMBI_AGENT_DISPATCH_CHANNEL_ID || env.SLACK_REVIEW_CHANNEL_ID;
+  if (!token || !channel) return "not_configured";
+
+  const response = await fetchImpl("https://slack.com/api/chat.postMessage", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json; charset=utf-8",
+    },
+    body: JSON.stringify({ channel, text }),
+  });
+  const { json } = await readJsonResponse(response);
+  if (response.ok && json.ok) return "posted";
+
+  warnings.push(`slack_notification_failed:${json.error || response.status}`);
+  return "failed";
+}
+
+async function writeSummary(summary, result) {
+  if (!summary) return;
+  const table = [
+    [{ data: "Field", header: true }, { data: "Value", header: true }],
+    ["Issue", result.issueNumber ? `#${result.issueNumber}` : "none"],
+    ["Decision", result.decision || "none"],
+    ["Ignored", String(Boolean(result.ignored))],
+    ["Reason", result.reason || "none"],
+    ["Slack dispatch", result.slackNotification || "not_sent"],
+    ["Model", result.model || "not_called"],
+  ];
+  await summary
+    .addHeading("DUUMBI Clarification Routing", 2)
+    .addTable(table)
+    .write();
+}
+
+function buildContextFromGitHubEnv(env = process.env) {
+  const eventPath = env.GITHUB_EVENT_PATH;
+  const payload = eventPath ? JSON.parse(fsModule.readFileSync(eventPath, "utf8")) : {};
+  const [owner, repo] = String(env.GITHUB_REPOSITORY || "/").split("/");
+  return {
+    workflow: env.GITHUB_WORKFLOW || "Clarification Routing",
+    runId: Number(env.GITHUB_RUN_ID || 0),
+    eventName: env.GITHUB_EVENT_NAME || "",
+    actor: env.GITHUB_ACTOR || "unknown",
+    ref: env.GITHUB_REF || "",
+    sha: env.GITHUB_SHA || "",
+    repo: { owner, repo },
+    payload,
+  };
+}
+
+function summaryFromEnv(env = process.env, fs = fsModule) {
+  if (!env.GITHUB_STEP_SUMMARY) return null;
+  return {
+    rows: [],
+    addHeading(text, level) {
+      fs.appendFileSync(env.GITHUB_STEP_SUMMARY, `${"#".repeat(level)} ${text}\n\n`);
+      return this;
+    },
+    addTable(rows) {
+      const [header, ...bodyRows] = rows;
+      fs.appendFileSync(env.GITHUB_STEP_SUMMARY, `| ${header.map((cell) => cell.data || cell).join(" | ")} |\n`);
+      fs.appendFileSync(env.GITHUB_STEP_SUMMARY, `| ${header.map(() => "---").join(" | ")} |\n`);
+      for (const row of bodyRows) {
+        fs.appendFileSync(env.GITHUB_STEP_SUMMARY, `| ${row.join(" | ")} |\n`);
+      }
+      fs.appendFileSync(env.GITHUB_STEP_SUMMARY, "\n");
+      return this;
+    },
+    async write() {
+      return undefined;
+    },
+  };
+}
+
+export async function runClarificationRouting({
+  env = process.env,
+  context,
+  core,
+  summary,
+  fetchImpl = fetch,
+  fs = fsModule,
+  path = pathModule,
+  workspace = process.cwd(),
+} = {}) {
+  const ctx = context || buildContextFromGitHubEnv(env);
+  const warnings = [];
+  const metricsPath = env.DUUMBI_METRICS_PATH || "duumbi-workflow-metrics.json";
+  const writeMetrics = (metrics) => {
+    fs.writeFileSync(path.resolve(workspace, metricsPath), `${JSON.stringify(metrics, null, 2)}\n`);
+  };
+
+  let result = {
+    ok: false,
+    ignored: false,
+    reason: null,
+    decision: null,
+    issueNumber: null,
+    model: null,
+    slackNotification: "not_sent",
+  };
+
+  const finishIgnored = async (reason, issueNumber = null) => {
+    result = { ...result, ...buildIgnoredResult(reason), issueNumber };
+    writeMetrics(buildWorkflowMetrics({
+      context: ctx,
+      conclusion: "success",
+      decision: "ignored",
+      issueNumber,
+      counts: {
+        issues_considered: issueNumber ? 1 : 0,
+        issues_queued: 0,
+        slack_notifications_attempted: 0,
+        artifact_links_found: null,
+        artifact_links_missing: null,
+      },
+      providerUsage: providerUsageNotCalled(reason),
+      warnings,
+    }));
+    await writeSummary(summary, result);
+    core?.info?.(`Clarification routing ignored: ${reason}.`);
+    return result;
+  };
+
+  try {
+    const isCommentEvent = ctx.eventName === "issue_comment";
+    const issuePayload = isCommentEvent ? ctx.payload.issue : null;
+    const manualInputs = ctx.payload.inputs || {};
+    const issueNumber = isCommentEvent ? Number(issuePayload?.number || 0) : Number(manualInputs.issue_number || 0);
+    const sourceCommentUrl = isCommentEvent
+      ? String(ctx.payload.comment?.html_url || "")
+      : String(manualInputs.comment_url || "manual workflow dispatch");
+    const commentBody = isCommentEvent ? String(ctx.payload.comment?.body || "") : String(manualInputs.comment_body || "@Clarification");
+
+    if (isCommentEvent && issuePayload?.pull_request) {
+      return finishIgnored("pull_request_comment", issueNumber || null);
+    }
+    if (!Number.isInteger(issueNumber) || issueNumber < 1) {
+      throw new Error(`Invalid issue number: ${issueNumber || "<missing>"}`);
+    }
+    result = { ...result, issueNumber };
+    if (!CLARIFICATION_PREFIX_PATTERN.test(commentBody.trimStart())) {
+      return finishIgnored("missing_clarification_prefix", issueNumber);
+    }
+
+    const token = env.GITHUB_TOKEN;
+    if (!token) {
+      throw new Error("GITHUB_TOKEN is not configured; failing closed before clarification routing.");
+    }
+
+    const api = createGithubApi({
+      fetchImpl,
+      token,
+      owner: ctx.repo.owner,
+      repo: ctx.repo.repo,
+    });
+    const issue = await api.getIssue(issueNumber);
+    const labels = labelsForIssue(issue);
+    if (!labels.includes(HUMAN_ACCEPTANCE_LABEL)) {
+      return finishIgnored("missing_needs_human_review_label", issueNumber);
+    }
+
+    const marker = `${MARKER_PREFIX} issue=${issueNumber} comment=${sourceCommentUrl} -->`;
+    const comments = await api.listIssueComments(issueNumber);
+    if (comments.some((comment) => String(comment.body || "").includes(marker))) {
+      return finishIgnored("duplicate_clarification_marker", issueNumber);
+    }
+
+    const deepSeekApiKey = env.DEEPSEEK_API_KEY;
+    if (!deepSeekApiKey) {
+      throw new Error("DEEPSEEK_API_KEY is not configured; failing closed before clarification synthesis.");
+    }
+
+    const issueUrl = issue.html_url || `https://github.com/${ctx.repo.owner}/${ctx.repo.repo}/issues/${issueNumber}`;
+    const contextPayload = {
+      generated_at: nowIso(),
+      repository: `${ctx.repo.owner}/${ctx.repo.repo}`,
+      stage: "clarification-routing",
+      target_issue: {
+        number: issueNumber,
+        title: truncateText(issue.title, 240),
+        url: issueUrl,
+        labels,
+        body: truncateText(issue.body || "", 6000),
+      },
+      source_clarification_comment: {
+        url: sourceCommentUrl,
+        body: truncateText(commentBody, 4000),
+      },
+      recent_comments: comments.slice(-12).map((comment) => ({
+        url: comment.html_url,
+        author: comment.user?.login || null,
+        body: truncateText(comment.body || "", 2000),
+        created_at: comment.created_at || null,
+      })),
+      policy: {
+        required_issue_label: HUMAN_ACCEPTANCE_LABEL,
+        trigger_prefix: "@Clarification",
+        forbidden: [
+          "Do not approve the issue.",
+          "Do not change labels.",
+          "Do not update Project V2.",
+          "Do not create product specs.",
+          "Do not create technical specs.",
+          "Do not create PRs.",
+          "Do not modify source code.",
+          "Do not start implementation.",
+        ],
+      },
+    };
+
+    const messages = buildClarificationMessages(contextPayload);
+    const deepSeekResponse = await callDeepSeek({
+      fetchImpl,
+      apiKey: deepSeekApiKey,
+      model: env.DEEPSEEK_MODEL || DEFAULT_DEEPSEEK_MODEL,
+      messages,
+    });
+    const decision = validateClarificationDecision(parseClarificationDecision(deepSeekResponse.content));
+
+    await api.createIssueComment(issueNumber, buildClarificationComment(decision, {
+      marker,
+      sourceCommentUrl,
+    }));
+
+    const slackNotification = await postSlack({
+      fetchImpl,
+      env,
+      text: buildSlackText({ issue, issueNumber, issueUrl, sourceCommentUrl, decision }),
+      warnings,
+    });
+
+    result = {
+      ok: true,
+      ignored: false,
+      reason: null,
+      decision: decision.recommendation,
+      issueNumber,
+      model: deepSeekResponse.model,
+      slackNotification,
+    };
+
+    writeMetrics(buildWorkflowMetrics({
+      context: ctx,
+      conclusion: "success",
+      decision: decision.recommendation,
+      issueNumber,
+      counts: {
+        issues_considered: 1,
+        issues_queued: 0,
+        slack_notifications_attempted: slackNotification === "posted" ? 1 : 0,
+        artifact_links_found: decision.source_comment_urls.length,
+        artifact_links_missing: decision.source_comment_urls.length ? 0 : 1,
+      },
+      providerUsage: providerUsageFromDeepSeek(deepSeekResponse.model, deepSeekResponse.usage, deepSeekResponse.latencyMs),
+      warnings,
+    }));
+    await writeSummary(summary, result);
+    core?.info?.(`Clarification routing decision: ${decision.recommendation} for issue #${issueNumber}.`);
+    return result;
+  } catch (error) {
+    const message = truncateText(error.message || error, 500);
+    warnings.push(message);
+    writeMetrics(buildWorkflowMetrics({
+      context: ctx,
+      conclusion: "blocked",
+      decision: "blocked",
+      issueNumber: result.issueNumber,
+      counts: {
+        issues_considered: result.issueNumber ? 1 : null,
+        issues_queued: 0,
+        slack_notifications_attempted: 0,
+        artifact_links_found: null,
+        artifact_links_missing: null,
+      },
+      providerUsage: providerUsageNotCalled("clarification_routing_blocked"),
+      warnings,
+    }));
+    await writeSummary(summary, { ...result, decision: "blocked", reason: message });
+    core?.setFailed?.(message);
+    return { ...result, ok: false, error: message };
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const core = {
+    info(message) {
+      console.log(message);
+    },
+    setFailed(message) {
+      console.error(message);
+      process.exitCode = 1;
+    },
+  };
+  await runClarificationRouting({
+    env: process.env,
+    context: buildContextFromGitHubEnv(process.env),
+    core,
+    summary: summaryFromEnv(process.env),
+  });
+}

--- a/scripts/github-actions/clarification-routing.test.mjs
+++ b/scripts/github-actions/clarification-routing.test.mjs
@@ -1,0 +1,336 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  HUMAN_ACCEPTANCE_LABEL,
+  MARKER_PREFIX,
+  parseClarificationDecision,
+  runClarificationRouting,
+  validateClarificationDecision,
+} from "./clarification-routing.mjs";
+
+function response(body, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+function makeContext({
+  body = "@Clarification Please refine this issue.",
+  issueNumber = 584,
+  pullRequest = false,
+} = {}) {
+  return {
+    workflow: "Clarification Routing",
+    runId: 12345,
+    eventName: "issue_comment",
+    actor: "tester",
+    ref: "refs/heads/main",
+    sha: "abc123",
+    repo: { owner: "hgahub", repo: "duumbi" },
+    payload: {
+      issue: {
+        number: issueNumber,
+        pull_request: pullRequest ? { url: "https://api.github.com/repos/hgahub/duumbi/pulls/584" } : undefined,
+      },
+      comment: {
+        html_url: `https://github.com/hgahub/duumbi/issues/${issueNumber}#issuecomment-1`,
+        body,
+      },
+    },
+  };
+}
+
+function makeCore() {
+  return {
+    failed: null,
+    infos: [],
+    info(message) {
+      this.infos.push(message);
+    },
+    setFailed(message) {
+      this.failed = message;
+    },
+  };
+}
+
+function makeSummary() {
+  return {
+    rows: [],
+    addHeading() {
+      return this;
+    },
+    addTable(rows) {
+      this.rows = rows;
+      return this;
+    },
+    async write() {
+      return undefined;
+    },
+  };
+}
+
+function makeWorkspace(prefix = "duumbi-clarification-routing-") {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function makeFetch({
+  labels = [HUMAN_ACCEPTANCE_LABEL],
+  comments = [],
+  decision = {
+    recommendation: "ready_for_human_acceptance",
+    refined_summary: "Clarified issue summary.",
+    clarified_requirements: ["Keep the route bounded to Stage 5."],
+    acceptance_criteria: ["A synthesis comment is posted."],
+    remaining_questions: [],
+    rationale: "The clarification is sufficient.",
+    source_comment_urls: ["https://github.com/hgahub/duumbi/issues/584#issuecomment-1"],
+  },
+  slackOk = true,
+} = {}) {
+  const calls = [];
+  const fetchImpl = async (url, options = {}) => {
+    const body = options.body ? JSON.parse(options.body) : null;
+    calls.push({ url, method: options.method || "GET", body });
+
+    if (url.endsWith("/repos/hgahub/duumbi/issues/584")) {
+      return response({
+        number: 584,
+        title: "Clarify Stage 5 issue",
+        body: "Original issue body.",
+        html_url: "https://github.com/hgahub/duumbi/issues/584",
+        labels: labels.map((name) => ({ name })),
+      });
+    }
+
+    if (url.endsWith("/repos/hgahub/duumbi/issues/584/comments?per_page=100")) {
+      return response(comments);
+    }
+
+    if (url.endsWith("/repos/hgahub/duumbi/issues/584/comments")) {
+      return response({ id: 1000, body: body.body });
+    }
+
+    if (url === "https://api.deepseek.com/chat/completions") {
+      return response({
+        model: "deepseek-v4-pro",
+        choices: [{ message: { content: typeof decision === "string" ? decision : JSON.stringify(decision) } }],
+        usage: { prompt_tokens: 900, completion_tokens: 180, total_tokens: 1080 },
+      });
+    }
+
+    if (url === "https://slack.com/api/chat.postMessage") {
+      return response(slackOk ? { ok: true, ts: "123.456" } : { ok: false, error: "channel_not_found" });
+    }
+
+    throw new Error(`Unexpected fetch: ${url}`);
+  };
+
+  return { fetchImpl, calls };
+}
+
+test("runClarificationRouting ignores @Copilot issue comments", async () => {
+  const workspace = makeWorkspace("duumbi-clarification-copilot-");
+  const { fetchImpl, calls } = makeFetch();
+  const core = makeCore();
+
+  const result = await runClarificationRouting({
+    env: {
+      GITHUB_TOKEN: "token",
+      DEEPSEEK_API_KEY: "deepseek",
+      DUUMBI_METRICS_PATH: "metrics.json",
+    },
+    context: makeContext({ body: "@Copilot Foglald össze röviden." }),
+    core,
+    summary: makeSummary(),
+    fetchImpl,
+    workspace,
+  });
+
+  assert.equal(result.ignored, true);
+  assert.equal(result.reason, "missing_clarification_prefix");
+  assert.equal(calls.length, 0);
+  assert.equal(core.failed, null);
+  const metrics = JSON.parse(fs.readFileSync(path.join(workspace, "metrics.json"), "utf8"));
+  assert.equal(metrics.provider_usage.reason, "missing_clarification_prefix");
+});
+
+test("runClarificationRouting ignores @Codex issue comments", async () => {
+  const workspace = makeWorkspace("duumbi-clarification-codex-");
+  const { fetchImpl, calls } = makeFetch();
+  const core = makeCore();
+
+  const result = await runClarificationRouting({
+    env: {
+      GITHUB_TOKEN: "token",
+      DEEPSEEK_API_KEY: "deepseek",
+      DUUMBI_METRICS_PATH: "metrics.json",
+    },
+    context: makeContext({ body: "@Codex Is this scope right?" }),
+    core,
+    summary: makeSummary(),
+    fetchImpl,
+    workspace,
+  });
+
+  assert.equal(result.ignored, true);
+  assert.equal(result.reason, "missing_clarification_prefix");
+  assert.equal(calls.length, 0);
+  assert.equal(core.failed, null);
+});
+
+test("runClarificationRouting requires needs-human-review label", async () => {
+  const workspace = makeWorkspace("duumbi-clarification-label-");
+  const { fetchImpl, calls } = makeFetch({ labels: ["enhancement"] });
+  const core = makeCore();
+
+  const result = await runClarificationRouting({
+    env: {
+      GITHUB_TOKEN: "token",
+      DEEPSEEK_API_KEY: "deepseek",
+      DUUMBI_METRICS_PATH: "metrics.json",
+    },
+    context: makeContext(),
+    core,
+    summary: makeSummary(),
+    fetchImpl,
+    workspace,
+  });
+
+  assert.equal(result.ignored, true);
+  assert.equal(result.reason, "missing_needs_human_review_label");
+  assert.equal(calls.some((call) => call.url === "https://api.deepseek.com/chat/completions"), false);
+  assert.equal(core.failed, null);
+});
+
+test("runClarificationRouting ignores duplicate clarification markers", async () => {
+  const workspace = makeWorkspace("duumbi-clarification-duplicate-");
+  const marker = `${MARKER_PREFIX} issue=584 comment=https://github.com/hgahub/duumbi/issues/584#issuecomment-1 -->`;
+  const { fetchImpl, calls } = makeFetch({
+    comments: [{ html_url: "https://github.com/hgahub/duumbi/issues/584#issuecomment-2", body: `${marker}\nAlready handled.` }],
+  });
+  const core = makeCore();
+
+  const result = await runClarificationRouting({
+    env: {
+      GITHUB_TOKEN: "token",
+      DEEPSEEK_API_KEY: "deepseek",
+      DUUMBI_METRICS_PATH: "metrics.json",
+    },
+    context: makeContext(),
+    core,
+    summary: makeSummary(),
+    fetchImpl,
+    workspace,
+  });
+
+  assert.equal(result.ignored, true);
+  assert.equal(result.reason, "duplicate_clarification_marker");
+  assert.equal(calls.some((call) => call.url === "https://api.deepseek.com/chat/completions"), false);
+  assert.equal(core.failed, null);
+});
+
+test("runClarificationRouting posts synthesis comment and Slack notification", async () => {
+  const workspace = makeWorkspace("duumbi-clarification-success-");
+  const { fetchImpl, calls } = makeFetch({
+    comments: [
+      {
+        html_url: "https://github.com/hgahub/duumbi/issues/584#issuecomment-0",
+        body: "Previous discussion.",
+        user: { login: "dev" },
+        created_at: "2026-05-25T00:00:00Z",
+      },
+    ],
+  });
+  const core = makeCore();
+
+  const result = await runClarificationRouting({
+    env: {
+      GITHUB_TOKEN: "token",
+      DEEPSEEK_API_KEY: "deepseek",
+      SLACK_BOT_TOKEN: "slack",
+      SLACK_REVIEW_CHANNEL_ID: "C123",
+      DUUMBI_METRICS_PATH: "metrics.json",
+    },
+    context: makeContext(),
+    core,
+    summary: makeSummary(),
+    fetchImpl,
+    workspace,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.ignored, false);
+  assert.equal(result.decision, "ready_for_human_acceptance");
+  assert.equal(result.slackNotification, "posted");
+  assert.equal(core.failed, null);
+
+  const deepSeekCalls = calls.filter((call) => call.url === "https://api.deepseek.com/chat/completions");
+  assert.equal(deepSeekCalls.length, 1);
+  assert.equal(deepSeekCalls[0].body.response_format.type, "json_object");
+
+  const commentCalls = calls.filter((call) => call.url.endsWith("/repos/hgahub/duumbi/issues/584/comments") && call.method === "POST");
+  assert.equal(commentCalls.length, 1);
+  assert.match(commentCalls[0].body.body, /Clarification Synthesis/);
+  assert.match(commentCalls[0].body.body, /duumbi-clarification-routing:v2/);
+
+  const slackCalls = calls.filter((call) => call.url === "https://slack.com/api/chat.postMessage");
+  assert.equal(slackCalls.length, 1);
+  assert.equal(slackCalls[0].body.channel, "C123");
+
+  const metrics = JSON.parse(fs.readFileSync(path.join(workspace, "metrics.json"), "utf8"));
+  assert.equal(metrics.counts.slack_notifications_attempted, 1);
+  assert.equal(metrics.provider_usage.provider, "deepseek");
+  assert.equal(metrics.privacy.raw_prompts_included, false);
+});
+
+test("runClarificationRouting fails closed on invalid DeepSeek JSON", async () => {
+  const workspace = makeWorkspace("duumbi-clarification-invalid-json-");
+  const { fetchImpl } = makeFetch({ decision: "not-json" });
+  const core = makeCore();
+
+  const result = await runClarificationRouting({
+    env: {
+      GITHUB_TOKEN: "token",
+      DEEPSEEK_API_KEY: "deepseek",
+      DUUMBI_METRICS_PATH: "metrics.json",
+    },
+    context: makeContext(),
+    core,
+    summary: makeSummary(),
+    fetchImpl,
+    workspace,
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(core.failed, /not valid JSON/);
+  const metrics = JSON.parse(fs.readFileSync(path.join(workspace, "metrics.json"), "utf8"));
+  assert.equal(metrics.workflow.conclusion, "blocked");
+});
+
+test("clarification decision validation rejects unsafe model output", () => {
+  assert.throws(() => parseClarificationDecision("not-json"), /not valid JSON/);
+  assert.throws(
+    () => validateClarificationDecision({ recommendation: "approve" }),
+    /not supported/,
+  );
+  assert.throws(
+    () => validateClarificationDecision({
+      recommendation: "ready_for_human_acceptance",
+      source_comment_urls: ["https://github.com/hgahub/duumbi/issues/584#issuecomment-1"],
+    }),
+    /refined_summary/,
+  );
+  assert.throws(
+    () => validateClarificationDecision({
+      recommendation: "ready_for_human_acceptance",
+      refined_summary: "Clear enough.",
+    }),
+    /source_comment_urls/,
+  );
+});

--- a/scripts/github-actions/clarification-routing.test.mjs
+++ b/scripts/github-actions/clarification-routing.test.mjs
@@ -108,8 +108,11 @@ function makeFetch({
       });
     }
 
-    if (url.endsWith("/repos/hgahub/duumbi/issues/584/comments?per_page=100")) {
-      return response(comments);
+    if (url.includes("/repos/hgahub/duumbi/issues/584/comments?per_page=100")) {
+      const parsed = new URL(url);
+      const page = Number(parsed.searchParams.get("page") || 1);
+      const start = (page - 1) * 100;
+      return response(comments.slice(start, start + 100));
     }
 
     if (url.endsWith("/repos/hgahub/duumbi/issues/584/comments")) {
@@ -231,6 +234,39 @@ test("runClarificationRouting ignores duplicate clarification markers", async ()
 
   assert.equal(result.ignored, true);
   assert.equal(result.reason, "duplicate_clarification_marker");
+  assert.equal(calls.some((call) => call.url === "https://api.deepseek.com/chat/completions"), false);
+  assert.equal(core.failed, null);
+});
+
+test("runClarificationRouting paginates comments before duplicate detection", async () => {
+  const workspace = makeWorkspace("duumbi-clarification-pagination-");
+  const marker = `${MARKER_PREFIX} issue=584 comment=https://github.com/hgahub/duumbi/issues/584#issuecomment-1 -->`;
+  const comments = Array.from({ length: 120 }, (_value, index) => ({
+    html_url: `https://github.com/hgahub/duumbi/issues/584#issuecomment-${index}`,
+    body: index === 115 ? `${marker}\nAlready handled on a later page.` : `Comment ${index}`,
+  }));
+  const { fetchImpl, calls } = makeFetch({ comments });
+  const core = makeCore();
+
+  const result = await runClarificationRouting({
+    env: {
+      GITHUB_TOKEN: "token",
+      DEEPSEEK_API_KEY: "deepseek",
+      DUUMBI_METRICS_PATH: "metrics.json",
+    },
+    context: makeContext(),
+    core,
+    summary: makeSummary(),
+    fetchImpl,
+    workspace,
+  });
+
+  assert.equal(result.ignored, true);
+  assert.equal(result.reason, "duplicate_clarification_marker");
+  assert.equal(
+    calls.filter((call) => call.url.includes("/repos/hgahub/duumbi/issues/584/comments?per_page=100")).length,
+    2,
+  );
   assert.equal(calls.some((call) => call.url === "https://api.deepseek.com/chat/completions"), false);
   assert.equal(core.failed, null);
 });

--- a/scripts/github-actions/clarification-routing.test.mjs
+++ b/scripts/github-actions/clarification-routing.test.mjs
@@ -325,6 +325,82 @@ test("runClarificationRouting posts synthesis comment and Slack notification", a
   assert.equal(metrics.privacy.raw_prompts_included, false);
 });
 
+test("runClarificationRouting keeps GitHub synthesis when Slack fetch fails", async () => {
+  const workspace = makeWorkspace("duumbi-clarification-slack-fetch-fail-");
+  const { fetchImpl: baseFetch, calls } = makeFetch();
+  const fetchImpl = async (url, options = {}) => {
+    if (url === "https://slack.com/api/chat.postMessage") {
+      throw new Error("network unavailable");
+    }
+    return baseFetch(url, options);
+  };
+  const core = makeCore();
+
+  const result = await runClarificationRouting({
+    env: {
+      GITHUB_TOKEN: "token",
+      DEEPSEEK_API_KEY: "deepseek",
+      SLACK_BOT_TOKEN: "slack",
+      SLACK_REVIEW_CHANNEL_ID: "C123",
+      DUUMBI_METRICS_PATH: "metrics.json",
+    },
+    context: makeContext(),
+    core,
+    summary: makeSummary(),
+    fetchImpl,
+    workspace,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.slackNotification, "failed");
+  assert.equal(core.failed, null);
+  assert.equal(calls.some((call) => call.url.endsWith("/repos/hgahub/duumbi/issues/584/comments") && call.method === "POST"), true);
+
+  const metrics = JSON.parse(fs.readFileSync(path.join(workspace, "metrics.json"), "utf8"));
+  assert.equal(metrics.workflow.conclusion, "success");
+  assert.equal(metrics.counts.slack_notifications_attempted, 0);
+  assert.match(metrics.warnings.join("\n"), /slack_notification_failed:network unavailable/);
+});
+
+test("runClarificationRouting keeps GitHub synthesis when Slack returns non-json", async () => {
+  const workspace = makeWorkspace("duumbi-clarification-slack-non-json-");
+  const { fetchImpl: baseFetch } = makeFetch();
+  const fetchImpl = async (url, options = {}) => {
+    if (url === "https://slack.com/api/chat.postMessage") {
+      return {
+        ok: true,
+        status: 200,
+        text: async () => "not-json",
+      };
+    }
+    return baseFetch(url, options);
+  };
+  const core = makeCore();
+
+  const result = await runClarificationRouting({
+    env: {
+      GITHUB_TOKEN: "token",
+      DEEPSEEK_API_KEY: "deepseek",
+      SLACK_BOT_TOKEN: "slack",
+      SLACK_REVIEW_CHANNEL_ID: "C123",
+      DUUMBI_METRICS_PATH: "metrics.json",
+    },
+    context: makeContext(),
+    core,
+    summary: makeSummary(),
+    fetchImpl,
+    workspace,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.slackNotification, "failed");
+  assert.equal(core.failed, null);
+
+  const metrics = JSON.parse(fs.readFileSync(path.join(workspace, "metrics.json"), "utf8"));
+  assert.equal(metrics.workflow.conclusion, "success");
+  assert.match(metrics.warnings.join("\n"), /slack_notification_failed:Response was not JSON/);
+});
+
 test("runClarificationRouting fails closed on invalid DeepSeek JSON", async () => {
   const workspace = makeWorkspace("duumbi-clarification-invalid-json-");
   const { fetchImpl } = makeFetch({ decision: "not-json" });

--- a/scripts/github-actions/triage-queue-refill.mjs
+++ b/scripts/github-actions/triage-queue-refill.mjs
@@ -685,48 +685,91 @@ export async function callDeepSeek({
   model = DEFAULT_DEEPSEEK_MODEL,
   messages,
   timeoutMs = 120_000,
+  emptyContentRetries = 2,
 }) {
   const started = Date.now();
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const response = await fetchImpl("https://api.deepseek.com/chat/completions", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        model,
-        messages,
-        response_format: { type: "json_object" },
-        temperature: 0.2,
-        max_tokens: 2500,
-      }),
-      signal: controller.signal,
-    });
-    const { text, json } = await readJsonResponse(response);
-    if (!response.ok) {
-      throw new Error(`DeepSeek API failed: ${response.status} ${truncateText(text, 240)}`);
+  const maxAttempts = Math.max(1, 1 + Number(emptyContentRetries || 0));
+  const baseMessages = Array.isArray(messages) ? messages : [];
+  const retryInstruction = [
+    "Retry instruction: the previous DeepSeek JSON-mode response returned empty content.",
+    "Return one non-empty JSON object only.",
+    "Do not return an empty string, markdown, prose outside JSON, or whitespace-only content.",
+  ].join("\n");
+  let lastEmptyDetails = null;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    const retryMessages = attempt === 1
+      ? baseMessages
+      : baseMessages[0]?.role === "system"
+        ? [
+            { ...baseMessages[0], content: `${baseMessages[0].content || ""}\n\n${retryInstruction}` },
+            ...baseMessages.slice(1),
+          ]
+        : [{ role: "system", content: retryInstruction }, ...baseMessages];
+
+    try {
+      const response = await fetchImpl("https://api.deepseek.com/chat/completions", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model,
+          messages: retryMessages,
+          response_format: { type: "json_object" },
+          temperature: 0.2,
+          max_tokens: 2500,
+        }),
+        signal: controller.signal,
+      });
+      const { text, json } = await readJsonResponse(response);
+      if (!response.ok) {
+        throw new Error(`DeepSeek API failed: ${response.status} ${truncateText(text, 240)}`);
+      }
+      const choice = json.choices?.[0] || {};
+      const content = choice.message?.content;
+      if (normalizeText(content)) {
+        return {
+          model: json.model || model,
+          content,
+          usage: json.usage || {},
+          latencyMs: Date.now() - started,
+        };
+      }
+
+      lastEmptyDetails = {
+        attempt,
+        maxAttempts,
+        model: json.model || model,
+        finishReason: choice.finish_reason || null,
+        usage: json.usage || {},
+      };
+      if (attempt < maxAttempts) {
+        continue;
+      }
+    } catch (error) {
+      if (error?.name === "AbortError") {
+        throw new Error(`DeepSeek API timed out after ${timeoutMs}ms`);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
     }
-    const content = json.choices?.[0]?.message?.content;
-    if (!normalizeText(content)) {
-      throw new Error("DeepSeek returned empty decision content.");
-    }
-    return {
-      model: json.model || model,
-      content,
-      usage: json.usage || {},
-      latencyMs: Date.now() - started,
-    };
-  } catch (error) {
-    if (error?.name === "AbortError") {
-      throw new Error(`DeepSeek API timed out after ${timeoutMs}ms`);
-    }
-    throw error;
-  } finally {
-    clearTimeout(timeout);
   }
+
+  const usage = lastEmptyDetails?.usage || {};
+  throw new Error([
+    "DeepSeek returned empty decision content after JSON-mode retries.",
+    `attempts=${lastEmptyDetails?.maxAttempts || maxAttempts}`,
+    `model=${lastEmptyDetails?.model || model}`,
+    `finish_reason=${lastEmptyDetails?.finishReason || "unknown"}`,
+    `prompt_tokens=${usage.prompt_tokens ?? "unknown"}`,
+    `completion_tokens=${usage.completion_tokens ?? "unknown"}`,
+    `total_tokens=${usage.total_tokens ?? "unknown"}`,
+  ].join(" "));
 }
 
 export function buildWorkflowMetrics({

--- a/scripts/github-actions/triage-queue-refill.test.mjs
+++ b/scripts/github-actions/triage-queue-refill.test.mjs
@@ -260,6 +260,55 @@ test("callDeepSeek fails with a bounded timeout", async () => {
   );
 });
 
+test("callDeepSeek retries empty JSON-mode content with reinforced prompt", async () => {
+  const calls = [];
+  const fetchImpl = async (_url, options) => {
+    const body = JSON.parse(options.body);
+    calls.push(body);
+    if (calls.length === 1) {
+      return response({
+        model: "deepseek-v4-pro",
+        choices: [{ finish_reason: "stop", message: { content: "" } }],
+        usage: { prompt_tokens: 10, completion_tokens: 0, total_tokens: 10 },
+      });
+    }
+    return response({
+      model: "deepseek-v4-pro",
+      choices: [{ finish_reason: "stop", message: { content: "{\"action\":\"no_action\"}" } }],
+      usage: { prompt_tokens: 20, completion_tokens: 5, total_tokens: 25 },
+    });
+  };
+
+  const result = await callDeepSeek({
+    fetchImpl,
+    apiKey: "deepseek-key",
+    messages: [{ role: "user", content: "{}" }],
+  });
+
+  assert.equal(result.content, "{\"action\":\"no_action\"}");
+  assert.equal(calls.length, 2);
+  assert.equal(calls[1].messages[0].role, "system");
+  assert.match(calls[1].messages[0].content, /previous DeepSeek JSON-mode response returned empty content/);
+});
+
+test("callDeepSeek reports model finish reason and token usage after empty retries", async () => {
+  const fetchImpl = async () => response({
+    model: "deepseek-v4-pro",
+    choices: [{ finish_reason: "length", message: { content: "" } }],
+    usage: { prompt_tokens: 33, completion_tokens: 0, total_tokens: 33 },
+  });
+
+  await assert.rejects(
+    () => callDeepSeek({
+      fetchImpl,
+      apiKey: "deepseek-key",
+      messages: [{ role: "user", content: "{}" }],
+      emptyContentRetries: 1,
+    }),
+    /attempts=2 model=deepseek-v4-pro finish_reason=length prompt_tokens=33 completion_tokens=0 total_tokens=33/,
+  );
+});
+
 test("runTriageQueueRefill exits without model call when the queue is full", async () => {
   const project = projectWithItems([
     issueItem({ number: 1, status: HUMAN_ACCEPTANCE_STATUS }),


### PR DESCRIPTION
## Summary

This changes Clarification Routing from a broad `@Codex` / `@Copilot` issue-comment handoff into an explicit `@Clarification` workflow.

## What changed

- Processes only comments whose visible text starts with `@Clarification`.
- Requires the target issue to carry the Stage 5 `needs-human-review` label.
- Calls DeepSeek for a bounded JSON clarification synthesis.
- Posts the synthesis back to the GitHub issue and sends Slack when configured.
- Keeps the workflow fail-closed: no labels, Project V2 status, specs, PRs, source code, or implementation work are changed.
- Adds focused `node:test` coverage for ignored mentions, label guards, duplicate markers, successful synthesis, Slack notification, and invalid JSON handling.

## Why

The previous trigger fired on any issue comment mentioning `@Codex` or `@Copilot`, which made ordinary developer questions look like clarification-routing work. The new contract makes developer discussion safe and reserves automation for an explicit `@Clarification` command.

## Validation

- `node --test scripts/github-actions/clarification-routing.test.mjs scripts/github-actions/triage-queue-refill.test.mjs`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/clarification-routing.yml"); puts "yaml ok"'`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clarification routing automation for issues marked with `needs-human-review` label that receive `@Clarification` comments.
  * Synthesized clarification responses are automatically posted to the issue and optionally sent to Slack.
  * Automatic duplicate detection prevents redundant clarification processing.

* **Documentation**
  * Updated clarification routing documentation to reflect the new workflow behavior and routing model.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hgahub/duumbi/pull/626?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->