### PR TITLE
[codex] Retry malformed triage refill JSON

### DIFF
--- a/scripts/github-actions/triage-queue-refill.mjs
+++ b/scripts/github-actions/triage-queue-refill.mjs
@@ -879,10 +879,14 @@ function providerUsageFromDeepSeek(model, usage, latencyMs) {
 function combineDeepSeekUsage(responses) {
   const usage = {
     request_count: responses.length,
+    prompt_cache_hit_tokens: 0,
+    prompt_cache_miss_tokens: 0,
     prompt_tokens: 0,
     completion_tokens: 0,
     total_tokens: 0,
   };
+  let hasPromptCacheHitTokens = false;
+  let hasPromptCacheMissTokens = false;
   let hasPromptTokens = false;
   let hasCompletionTokens = false;
   let hasTotalTokens = false;
@@ -890,9 +894,19 @@ function combineDeepSeekUsage(responses) {
 
   for (const response of responses) {
     const current = response?.usage || {};
+    const promptCacheHitTokens = Number(current.prompt_cache_hit_tokens);
+    const promptCacheMissTokens = Number(current.prompt_cache_miss_tokens);
     const promptTokens = Number(current.prompt_tokens);
     const completionTokens = Number(current.completion_tokens);
     const totalTokens = Number(current.total_tokens);
+    if (Number.isFinite(promptCacheHitTokens)) {
+      usage.prompt_cache_hit_tokens += promptCacheHitTokens;
+      hasPromptCacheHitTokens = true;
+    }
+    if (Number.isFinite(promptCacheMissTokens)) {
+      usage.prompt_cache_miss_tokens += promptCacheMissTokens;
+      hasPromptCacheMissTokens = true;
+    }
     if (Number.isFinite(promptTokens)) {
       usage.prompt_tokens += promptTokens;
       hasPromptTokens = true;
@@ -914,6 +928,8 @@ function combineDeepSeekUsage(responses) {
   return {
     usage: {
       ...usage,
+      prompt_cache_hit_tokens: hasPromptCacheHitTokens ? usage.prompt_cache_hit_tokens : null,
+      prompt_cache_miss_tokens: hasPromptCacheMissTokens ? usage.prompt_cache_miss_tokens : null,
       prompt_tokens: hasPromptTokens ? usage.prompt_tokens : null,
       completion_tokens: hasCompletionTokens ? usage.completion_tokens : null,
       total_tokens: hasTotalTokens ? usage.total_tokens : null,

--- a/scripts/github-actions/triage-queue-refill.mjs
+++ b/scripts/github-actions/triage-queue-refill.mjs
@@ -317,6 +317,29 @@ function stripJsonFence(value) {
   return fenceMatch ? fenceMatch[1].trim() : text;
 }
 
+function buildJsonRepairMessages({ baseMessages, invalidContent, parseError }) {
+  return [
+    {
+      role: "system",
+      content: [
+        "You are repairing one DUUMBI Stage 4 triage decision.",
+        "Return exactly one valid strict JSON object and no markdown.",
+        "Do not include comments, trailing commas, prose outside JSON, or JSON5 syntax.",
+        "Preserve the intended decision if it can be recovered safely.",
+        `Previous parser error: ${truncateText(parseError?.message || parseError, 300)}`,
+      ].join("\n"),
+    },
+    ...baseMessages,
+    {
+      role: "user",
+      content: [
+        "Repair this malformed decision into one valid JSON object:",
+        truncateText(invalidContent, 4000),
+      ].join("\n\n"),
+    },
+  ];
+}
+
 export function parseTriageDecision(content) {
   const text = stripJsonFence(content);
   try {
@@ -843,7 +866,7 @@ function providerUsageFromDeepSeek(model, usage, latencyMs) {
     reason: "deepseek_api_call",
     provider: "deepseek",
     model,
-    request_count: 1,
+    request_count: Number.isFinite(Number(usage.request_count)) ? Number(usage.request_count) : 1,
     prompt_tokens: Number.isFinite(Number(usage.prompt_tokens)) ? Number(usage.prompt_tokens) : null,
     completion_tokens: Number.isFinite(Number(usage.completion_tokens)) ? Number(usage.completion_tokens) : null,
     total_tokens: Number.isFinite(Number(usage.total_tokens)) ? Number(usage.total_tokens) : null,
@@ -851,6 +874,89 @@ function providerUsageFromDeepSeek(model, usage, latencyMs) {
     latency_ms: Number.isFinite(latencyMs) ? latencyMs : null,
     failure_count: 0,
   };
+}
+
+function combineDeepSeekUsage(responses) {
+  const usage = {
+    request_count: responses.length,
+    prompt_tokens: 0,
+    completion_tokens: 0,
+    total_tokens: 0,
+  };
+  let hasPromptTokens = false;
+  let hasCompletionTokens = false;
+  let hasTotalTokens = false;
+  let latencyMs = 0;
+
+  for (const response of responses) {
+    const current = response?.usage || {};
+    const promptTokens = Number(current.prompt_tokens);
+    const completionTokens = Number(current.completion_tokens);
+    const totalTokens = Number(current.total_tokens);
+    if (Number.isFinite(promptTokens)) {
+      usage.prompt_tokens += promptTokens;
+      hasPromptTokens = true;
+    }
+    if (Number.isFinite(completionTokens)) {
+      usage.completion_tokens += completionTokens;
+      hasCompletionTokens = true;
+    }
+    if (Number.isFinite(totalTokens)) {
+      usage.total_tokens += totalTokens;
+      hasTotalTokens = true;
+    }
+    const currentLatencyMs = Number(response?.latencyMs);
+    if (Number.isFinite(currentLatencyMs)) {
+      latencyMs += currentLatencyMs;
+    }
+  }
+
+  return {
+    usage: {
+      ...usage,
+      prompt_tokens: hasPromptTokens ? usage.prompt_tokens : null,
+      completion_tokens: hasCompletionTokens ? usage.completion_tokens : null,
+      total_tokens: hasTotalTokens ? usage.total_tokens : null,
+    },
+    latencyMs: latencyMs || null,
+  };
+}
+
+async function getParsedTriageDecision({ fetchImpl, apiKey, model, messages, core, warnings = [] }) {
+  const responses = [];
+  const firstResponse = await callDeepSeek({
+    fetchImpl,
+    apiKey,
+    model,
+    messages,
+  });
+  responses.push(firstResponse);
+
+  try {
+    return {
+      parsedDecision: parseTriageDecision(firstResponse.content),
+      responses,
+    };
+  } catch (error) {
+    const warning = `DeepSeek decision was malformed; retrying strict JSON repair once: ${truncateText(error.message, 240)}`;
+    warnings.push(warning);
+    core?.warning?.(warning);
+    const repairResponse = await callDeepSeek({
+      fetchImpl,
+      apiKey,
+      model,
+      messages: buildJsonRepairMessages({
+        baseMessages: messages,
+        invalidContent: firstResponse.content,
+        parseError: error,
+      }),
+    });
+    responses.push(repairResponse);
+    return {
+      parsedDecision: parseTriageDecision(repairResponse.content),
+      responses,
+    };
+  }
 }
 
 async function applyTriageDecision({ api, project, decision }) {
@@ -1025,16 +1131,19 @@ export async function runTriageQueueRefill({
       warnings,
     });
     const messages = buildDeepSeekMessages(triageContext);
-    const deepSeekResponse = await callDeepSeek({
+    const { parsedDecision, responses: deepSeekResponses } = await getParsedTriageDecision({
       fetchImpl,
       apiKey: deepSeekApiKey,
       model: deepSeekModel,
       messages,
+      core,
+      warnings,
     });
-    const parsedDecision = parseTriageDecision(deepSeekResponse.content);
     const decision = validateTriageDecision(parsedDecision, triageContext);
     const applied = await applyTriageDecision({ api, project, decision });
     const queued = applied.issueNumber ? 1 : 0;
+    const lastDeepSeekResponse = deepSeekResponses.at(-1);
+    const combinedDeepSeekUsage = combineDeepSeekUsage(deepSeekResponses);
 
     result = {
       ...result,
@@ -1042,7 +1151,7 @@ export async function runTriageQueueRefill({
       decision: decision.action,
       issueNumber: applied.issueNumber,
       issueUrl: applied.issueUrl,
-      model: deepSeekResponse.model,
+      model: lastDeepSeekResponse.model,
     };
 
     const metrics = buildWorkflowMetrics({
@@ -1057,7 +1166,11 @@ export async function runTriageQueueRefill({
         artifact_links_found: decision.source_links?.length || null,
         artifact_links_missing: decision.source_links?.length ? 0 : null,
       },
-      providerUsage: providerUsageFromDeepSeek(deepSeekResponse.model, deepSeekResponse.usage, deepSeekResponse.latencyMs),
+      providerUsage: providerUsageFromDeepSeek(
+        lastDeepSeekResponse.model,
+        combinedDeepSeekUsage.usage,
+        combinedDeepSeekUsage.latencyMs,
+      ),
       warnings,
     });
     writeMetrics(metrics);

--- a/scripts/github-actions/triage-queue-refill.test.mjs
+++ b/scripts/github-actions/triage-queue-refill.test.mjs
@@ -134,6 +134,7 @@ function makeFetch({
   failAddToProject = false,
   failExistingLabel = false,
   deepSeekContents = null,
+  deepSeekUsages = null,
 }) {
   const calls = [];
   let deepSeekCallCount = 0;
@@ -176,14 +177,17 @@ function makeFetch({
     }
 
     if (url === "https://api.deepseek.com/chat/completions") {
-      const content = Array.isArray(deepSeekContents)
-        ? deepSeekContents[Math.min(deepSeekCallCount, deepSeekContents.length - 1)]
+      const content = Array.isArray(deepSeekContents) && deepSeekContents.length > 0
+        ? deepSeekContents[deepSeekCallCount % deepSeekContents.length]
         : JSON.stringify(decision);
+      const usage = Array.isArray(deepSeekUsages) && deepSeekUsages.length > 0
+        ? deepSeekUsages[deepSeekCallCount % deepSeekUsages.length]
+        : { prompt_tokens: 1000, completion_tokens: 200, total_tokens: 1200 };
       deepSeekCallCount += 1;
       return response({
         model: "deepseek-v4-pro",
         choices: [{ message: { content } }],
-        usage: { prompt_tokens: 1000, completion_tokens: 200, total_tokens: 1200 },
+        usage,
       });
     }
 
@@ -540,6 +544,22 @@ test("runTriageQueueRefill retries once when DeepSeek returns malformed JSON", a
       "{\n  \"action\": \"route_existing_issue\",\n  \"issue\": { // invalid json\n  }\n}",
       JSON.stringify(decision),
     ],
+    deepSeekUsages: [
+      {
+        prompt_cache_hit_tokens: 100,
+        prompt_cache_miss_tokens: 900,
+        prompt_tokens: 1000,
+        completion_tokens: 200,
+        total_tokens: 1200,
+      },
+      {
+        prompt_cache_hit_tokens: 50,
+        prompt_cache_miss_tokens: 950,
+        prompt_tokens: 1000,
+        completion_tokens: 200,
+        total_tokens: 1200,
+      },
+    ],
   });
   const core = makeCore();
 
@@ -560,7 +580,7 @@ test("runTriageQueueRefill retries once when DeepSeek returns malformed JSON", a
   assert.equal(core.failed, null);
   assert.equal(result.decision, "route_existing_issue");
   assert.equal(result.issueNumber, 10);
-  assert.match(core.warnings[0], /retrying strict JSON repair once/);
+  assert.equal(core.warnings.some((warning) => /retrying strict JSON repair once/.test(warning)), true);
   assert.equal(calls.filter((call) => call.url === "https://api.deepseek.com/chat/completions").length, 2);
 
   const repairRequest = calls.filter((call) => call.url === "https://api.deepseek.com/chat/completions")[1];
@@ -571,6 +591,7 @@ test("runTriageQueueRefill retries once when DeepSeek returns malformed JSON", a
   assert.equal(metrics.provider_usage.request_count, 2);
   assert.equal(metrics.provider_usage.prompt_tokens, 2000);
   assert.equal(metrics.provider_usage.completion_tokens, 400);
+  assert.equal(metrics.provider_usage.estimated_cost_usd, 0.00115329);
   assert.equal(metrics.warnings.some((warning) => /retrying strict JSON repair once/.test(warning)), true);
 });
 

--- a/scripts/github-actions/triage-queue-refill.test.mjs
+++ b/scripts/github-actions/triage-queue-refill.test.mjs
@@ -128,8 +128,15 @@ function makeWorkspace() {
   return workspace;
 }
 
-function makeFetch({ project, decision, failAddToProject = false, failExistingLabel = false }) {
+function makeFetch({
+  project,
+  decision,
+  failAddToProject = false,
+  failExistingLabel = false,
+  deepSeekContents = null,
+}) {
   const calls = [];
+  let deepSeekCallCount = 0;
   const fetchImpl = async (url, options = {}) => {
     const body = options.body ? JSON.parse(options.body) : {};
     calls.push({ url, method: options.method || "GET", body });
@@ -169,9 +176,13 @@ function makeFetch({ project, decision, failAddToProject = false, failExistingLa
     }
 
     if (url === "https://api.deepseek.com/chat/completions") {
+      const content = Array.isArray(deepSeekContents)
+        ? deepSeekContents[Math.min(deepSeekCallCount, deepSeekContents.length - 1)]
+        : JSON.stringify(decision);
+      deepSeekCallCount += 1;
       return response({
         model: "deepseek-v4-pro",
-        choices: [{ message: { content: JSON.stringify(decision) } }],
+        choices: [{ message: { content } }],
         usage: { prompt_tokens: 1000, completion_tokens: 200, total_tokens: 1200 },
       });
     }
@@ -507,6 +518,60 @@ test("runTriageQueueRefill routes one eligible Todo issue to human acceptance", 
   assert.equal(metrics.counts.issues_queued, 1);
   assert.equal(metrics.counts.slack_notifications_attempted, 0);
   assert.equal(metrics.provider_usage.provider, "deepseek");
+});
+
+test("runTriageQueueRefill retries once when DeepSeek returns malformed JSON", async () => {
+  const project = projectWithItems([
+    issueItem({ number: 1, status: HUMAN_ACCEPTANCE_STATUS }),
+    issueItem({ number: 2, status: HUMAN_ACCEPTANCE_STATUS }),
+    issueItem({ number: 10, status: TODO_STATUS }),
+  ]);
+  const decision = {
+    action: "route_existing_issue",
+    existing_issue_number: 10,
+    source_links: ["duumbi-vault/Duumbi/00 Inbox (ToProcess)/candidate.md"],
+    rationale: "Best next actionable candidate.",
+  };
+  const workspace = makeWorkspace();
+  const { fetchImpl, calls } = makeFetch({
+    project,
+    decision,
+    deepSeekContents: [
+      "{\n  \"action\": \"route_existing_issue\",\n  \"issue\": { // invalid json\n  }\n}",
+      JSON.stringify(decision),
+    ],
+  });
+  const core = makeCore();
+
+  const result = await runTriageQueueRefill({
+    env: {
+      GH_PROJECT_PAT: "pat",
+      DEEPSEEK_API_KEY: "deepseek-key",
+      DUUMBI_PROJECT_NUMBER: "1",
+      DUUMBI_METRICS_PATH: "metrics.json",
+    },
+    context: makeContext(),
+    core,
+    summary: makeSummary(),
+    fetchImpl,
+    workspace,
+  });
+
+  assert.equal(core.failed, null);
+  assert.equal(result.decision, "route_existing_issue");
+  assert.equal(result.issueNumber, 10);
+  assert.match(core.warnings[0], /retrying strict JSON repair once/);
+  assert.equal(calls.filter((call) => call.url === "https://api.deepseek.com/chat/completions").length, 2);
+
+  const repairRequest = calls.filter((call) => call.url === "https://api.deepseek.com/chat/completions")[1];
+  assert.match(repairRequest.body.messages[0].content, /valid strict JSON object/);
+  assert.match(repairRequest.body.messages.at(-1).content, /Repair this malformed decision/);
+
+  const metrics = JSON.parse(fs.readFileSync(path.join(workspace, "metrics.json"), "utf8"));
+  assert.equal(metrics.provider_usage.request_count, 2);
+  assert.equal(metrics.provider_usage.prompt_tokens, 2000);
+  assert.equal(metrics.provider_usage.completion_tokens, 400);
+  assert.equal(metrics.warnings.some((warning) => /retrying strict JSON repair once/.test(warning)), true);
 });
 
 test("runTriageQueueRefill blocks before status update when existing issue label fails", async () => {


### PR DESCRIPTION
## Summary

- Add a one-time strict JSON repair retry when the triage refill DeepSeek response is malformed.
- Preserve existing fail-closed validation after parsing so unsafe or semantically invalid decisions still block.
- Aggregate provider usage metrics across the original call and repair retry.
- Add a regression test for malformed-then-repaired DeepSeek output.

## Root Cause

The scheduled Triage Queue Refill run failed because DeepSeek returned non-strict JSON even though the workflow requested JSON mode. The script treated the first malformed non-empty completion as fatal, so the action blocked before routing or creating any issue.

## Validation

- `node --test scripts/github-actions/*.test.mjs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic retry mechanism for JSON parsing failures in triage processing.

* **Enhancements**
  * Improved metrics tracking to accurately aggregate data from multiple API requests.
  * Enhanced reliability of triage queue refill workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hgahub/duumbi/pull/627?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->