### PR TITLE
[codex] Merge reviewed spec PRs on approval

### DIFF
--- a/.agents/skills/duumbi-spec-draft/SKILL.md
+++ b/.agents/skills/duumbi-spec-draft/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: duumbi-spec-draft
-description: "Run DUUMBI Stage 6 Spec Preparation: turn one accepted GitHub Issue in Spec Needed into an English product spec as either a GitHub issue comment or source-repo specs/DUUMBI-<issue-number>/PRODUCT.md draft PR, then route to Spec Review or Needs Clarification without creating technical specs or implementation changes."
+description: "Run DUUMBI Stage 6 Spec Preparation: turn one accepted GitHub Issue in Spec Needed into an English product spec as either a GitHub issue comment or source-repo specs/DUUMBI-<issue-number>/PRODUCT.md review-ready PR, then route to Spec Review or Needs Clarification without creating technical specs or implementation changes."
 ---
 
 You are the DUUMBI Product Spec Draft Agent.
@@ -18,7 +18,8 @@ This skill covers:
 - drafting an English product spec
 - adding English Gherkin-style BDD scenarios that express observable behavior
 - writing the product spec as a GitHub issue comment for small issues
-- creating `specs/DUUMBI-<issue-number>/PRODUCT.md` in the relevant source repository and opening a draft PR for larger, architectural, cross-module, or durable specs
+- creating `specs/DUUMBI-<issue-number>/PRODUCT.md` in the relevant source repository and opening a review-ready PR for larger, architectural, cross-module, or durable specs
+- marking the file-based spec PR ready for review, requesting configured automated review, addressing blocking review feedback, and reaching green checks before Slack approval is requested
 - linking the spec artifact back to the GitHub Issue
 - moving the issue to `Spec Review`, or to `Needs Clarification` when blocked
 - keeping the execution issue open by avoiding GitHub auto-close keywords in spec-only PR titles, bodies, and commit messages
@@ -88,7 +89,7 @@ Non-blocking uncertainty may remain in the spec under `Open Questions`.
 
 Use a GitHub issue comment when the issue is small, low-risk, and not expected to need long-lived versioned spec history.
 
-Use a source-repo file and draft PR when the work is:
+Use a source-repo file and review-ready PR when the work is:
 
 - architectural
 - cross-module
@@ -107,8 +108,11 @@ For file-based specs:
 
 - create a branch in the relevant source repository
 - create or update only the spec file and minimal supporting metadata if required by the source repo
-- open a draft PR
-- link the draft PR and spec path from the GitHub Issue
+- open the PR as a draft while the first artifact is being assembled
+- mark the PR ready for review after the spec artifact is complete and local checks are complete
+- request or wait for the configured automated reviewers when available, including Copilot review
+- inspect review feedback and check results, fix blocking findings inside the spec file, and repeat until the PR is review-clean
+- link the review-ready PR and spec path from the GitHub Issue
 - treat the PR as a spec-review artifact only; it must not close the execution issue when merged or closed
 - do not use GitHub auto-close keywords such as `Closes #<issue>`, `Fixes #<issue>`, `Resolves #<issue>`, `Close #<issue>`, `Fix #<issue>`, or `Resolve #<issue>` in the PR title, PR body, branch name, commit message, or spec text when referring to the execution issue
 - use non-closing references such as `Related to #<issue>`, `Spec for #<issue>`, or `Supports #<issue>` instead
@@ -174,6 +178,7 @@ After a successful spec artifact exists:
 - add existing `spec-review` label when available
 - do not mark the product spec approved
 - do not close the execution issue; it must remain open until Stage 12 closure verifies merged implementation evidence
+- for file-based specs, add `spec-review` only after the PR is no longer draft, checks are green, configured automated review is complete, and blocking review threads are resolved; the Stage 7 Slack approval will merge the spec PR if approved
 
 When blocked:
 
@@ -192,8 +197,8 @@ After processing, report:
 Product spec draft complete:
 
 **Issue:** <link>
-**Spec artifact:** <issue comment link or PRODUCT.md path + draft PR link, or none>
-**Placement:** <GitHub issue comment | source repo draft PR | blocked>
+**Spec artifact:** <issue comment link or PRODUCT.md path + review-ready PR link, or none>
+**Placement:** <GitHub issue comment | source repo review-ready PR | blocked>
 **GitHub status:** <Spec Review | Needs Clarification | unchanged>
 **Context checked:** <issue, decision comment, DUUMBI notes, related GitHub/source context>
 **BDD scenarios:** <summary or none>
@@ -208,6 +213,7 @@ Product spec draft complete:
 - Do not bury blocking questions in a draft spec.
 - Do not create technical specs, implementation code, PRs for implementation, or Ralph cycles.
 - Do not approve your own product spec.
+- Do not request Slack approval for a file-based product spec while its PR is still draft, missing checks, missing configured automated review, or has unresolved blocking feedback.
 - Do not use GitHub auto-close keywords in spec-only PRs; only Stage 12 closure may close the execution issue.
 - Keep the spec traceable to source links and decisions.
 - Stop and ask the user if a requested write exceeds Stage 6.

--- a/.agents/skills/duumbi-spec-review/SKILL.md
+++ b/.agents/skills/duumbi-spec-review/SKILL.md
@@ -12,13 +12,13 @@ Your job is to handle Stage 7, the product spec approval gate. You review a Stag
 This skill covers:
 
 - reading one GitHub Issue in `Spec Review`
-- reading the linked product spec artifact from a GitHub issue comment or source-repo `specs/DUUMBI-<issue-number>/PRODUCT.md` draft PR
+- reading the linked product spec artifact from a GitHub issue comment or source-repo `specs/DUUMBI-<issue-number>/PRODUCT.md` review-ready PR
 - inspecting Stage 5 acceptance, Stage 6 spec draft context, source links, relevant PRD/Glossary/Atlas notes, and related GitHub items
 - preparing a structured product spec review report
 - separating blocking findings from non-blocking improvements
 - processing explicit human decisions on the product spec
 - processing AI gate decisions only when the full AI Gate Requirements below are satisfied
-- writing a structured GitHub review comment, and a draft PR comment when the spec is file-based
+- writing a structured GitHub review comment, and a PR comment when the spec is file-based
 - updating existing GitHub labels and Project status after an explicit decision
 
 This skill does not:
@@ -39,6 +39,7 @@ The AI gate is allowed only for Stage 7 product spec approval and only when invo
 Before approving through the AI gate, verify all of these facts:
 
 - the product spec PR is a spec-only PR and contains no implementation code
+- the product spec PR is open, non-draft, review-clean, and ready for approval merge
 - Copilot review was requested and has no unresolved blocking feedback
 - relevant checks are complete and passing, or the PR is documentation-only and checks are explicitly not applicable
 - the product spec satisfies the Review Checklist below
@@ -53,7 +54,7 @@ If any requirement is missing, fail closed: record a review report, route to `Sp
 - GitHub Issues and Project fields hold workflow state.
 - The product spec artifact is the object being reviewed.
 - The durable Stage 7 decision record is a structured GitHub issue comment.
-- For file-based specs, also comment on the draft PR when available so review context stays with the spec diff.
+- For file-based specs, also comment on the PR when available so review context stays with the spec diff.
 - Obsidian Atlas provides context, but should not mirror live review state.
 
 ## Language Rules
@@ -79,10 +80,12 @@ When the prompt contains an explicit **Approve** decision (e.g. `Human decision:
 1. `gh issue view <N> --json number,title,labels,body` — verify `spec-review` label is present
 2. `gh issue view <N> --comments --json comments` — find the Stage 6 Product Spec Draft artifact link
 3. Construct and post the Stage 7 Decision Comment on the issue
-4. Post a short pointer comment on the draft PR (if identifiable)
-5. Update labels: remove `needs-spec` and `spec-review`, add `product-spec-approved` and `needs-tech-spec`
-6. Attempt Project V2 status update to `Technical Spec Needed`
-7. Report the final state
+4. If the artifact is a PR, verify it is open, non-draft, changes only `specs/DUUMBI-<N>/PRODUCT.md`, has green checks, completed configured automated review, no blocking review decisions, and no unresolved review threads
+5. If the artifact is a PR, squash-merge it with non-closing issue references such as `Related to #<N>`; do not close the execution issue
+6. Post a short pointer comment on the PR (if identifiable)
+7. Update labels: remove `needs-spec` and `spec-review`, add `product-spec-approved` and `needs-tech-spec`
+8. Attempt Project V2 status update to `Technical Spec Needed`
+9. Report the final state
 
 Do NOT read the full PRODUCT.md, run the review checklist, read unrelated skills, or re-fetch content already in context. Use `wait` mode for all `gh`/`git` commands.
 
@@ -92,7 +95,7 @@ Before reviewing:
 
 - GitHub issue title, body, comments, labels, Project status, and linked artifacts
 - Stage 5 human acceptance decision
-- Stage 6 product spec artifact and any draft PR
+- Stage 6 product spec artifact and any review-ready PR
 - Stage 4 triage context and source links when needed
 - related GitHub Issues, PRs, Discussions, and prior specs
 - active DUUMBI PRD, Glossary, Agentic Development Map, workflow, and directly relevant Dots, Maps, or Works
@@ -191,13 +194,15 @@ For every explicit decision, write this structured GitHub issue comment:
 **Next state:** <Technical Spec Needed | Spec Needed | Needs Clarification | Closed | Deferred>
 ```
 
-For file-based specs, also comment on the draft PR with the same decision or a short pointer back to the issue decision comment.
+For file-based specs, also comment on the PR with the same decision or a short pointer back to the issue decision comment.
 
 ## Outcome Rules
 
 For `Approve`:
 
 - require explicit human approval or a fully satisfied AI gate
+- for file-based specs, require an open non-draft spec-only PR with green checks, completed configured automated review, no blocking review decisions, and no unresolved review threads
+- for file-based specs, squash-merge the product spec PR before moving the issue to `Technical Spec Needed`
 - write the decision comment
 - set Project Status to `Technical Spec Needed` when available
 - remove existing `needs-spec` when available
@@ -240,6 +245,7 @@ Product spec review complete:
 **Spec artifact:** <comment link or PRODUCT.md path / PR link>
 **Recommendation or decision:** <value>
 **Review comment:** <link or "posted">
+**Spec PR merge:** <merge SHA, "not applicable", or "not merged">
 **GitHub status:** <Technical Spec Needed | Spec Needed | Needs Clarification | Closed | Deferred | unchanged>
 **Labels changed:** <added/removed/none>
 **BDD readiness:** <ready | missing | blocked>

--- a/.agents/skills/duumbi-tech-spec-draft/SKILL.md
+++ b/.agents/skills/duumbi-tech-spec-draft/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: duumbi-tech-spec-draft
-description: "Run DUUMBI Stage 8 Technical Specification Preparation: turn one approved product spec in Technical Spec Needed into an English agent-facing specs/DUUMBI-<issue-number>/TECHNICAL.md draft PR with bounded Ralph-cycle instructions, then route to Technical Spec Review or Needs Clarification without modifying implementation code."
+description: "Run DUUMBI Stage 8 Technical Specification Preparation: turn one approved product spec in Technical Spec Needed into an English agent-facing specs/DUUMBI-<issue-number>/TECHNICAL.md review-ready PR with bounded Ralph-cycle instructions, then route to Technical Spec Review or Needs Clarification without modifying implementation code."
 ---
 
 You are the DUUMBI Technical Spec Draft Agent.
@@ -19,8 +19,9 @@ This skill covers:
 - mapping product-spec BDD scenarios to concrete verification evidence
 - defining at least one live LLM-backed E2E path through the canonical interface when the work touches LLM behavior
 - defining the Ralph Cycle resource policy, approval thresholds, and autonomous batch cap
-- opening a draft PR for the technical spec artifact
-- linking the technical spec draft PR back to the GitHub Issue
+- opening a PR for the technical spec artifact
+- marking the technical spec PR ready for review, requesting configured automated review, addressing blocking review feedback, and reaching green checks before Slack approval is requested
+- linking the technical spec review-ready PR back to the GitHub Issue
 - moving the issue to `Technical Spec Review`, or to `Needs Clarification` when blocked
 - keeping the execution issue open by avoiding GitHub auto-close keywords in spec-only PR titles, bodies, and commit messages
 
@@ -29,7 +30,7 @@ This skill does not:
 - approve technical specs
 - modify implementation code, tests, migrations, generated outputs, or runtime assets
 - run Ralph cycles or implementation commands
-- create implementation branches beyond the spec draft PR
+- create implementation branches beyond the technical spec PR
 - create product specs or approve product specs
 - create new GitHub labels or Project fields
 - create Obsidian artifacts during normal operation
@@ -105,7 +106,7 @@ Forbidden writes:
 - product spec approval
 - technical spec approval
 - Ralph-cycle execution
-- implementation PRs or branches beyond the technical spec draft PR
+- implementation PRs or branches beyond the technical spec PR
 
 Do not create new GitHub labels or Project fields. If a desired write is unavailable, mention it in the final report.
 
@@ -125,7 +126,13 @@ Create or update:
 specs/DUUMBI-<issue-number>/TECHNICAL.md
 ```
 
-Open a draft PR for the technical spec artifact and link it from the GitHub Issue.
+Open a PR for the technical spec artifact and link it from the GitHub Issue. Use draft
+state while assembling the first artifact, then mark it ready for review, request
+or wait for configured automated reviewers including Copilot when available,
+address blocking review feedback inside `TECHNICAL.md`, and continue until checks
+are green and blocking review threads are resolved. Only then route the issue to
+`Technical Spec Review`; Stage 9 Slack approval will merge the spec PR if
+approved.
 
 ## Technical Spec Contract
 
@@ -228,12 +235,13 @@ Every technical spec must include a bounded resource policy:
 
 After a successful technical spec artifact exists:
 
-- link the draft PR and `TECHNICAL.md` path from the GitHub Issue
+- link the review-ready PR and `TECHNICAL.md` path from the GitHub Issue
 - set Project Status to `Technical Spec Review` when available
 - keep or add existing `needs-tech-spec` as appropriate
 - add existing `technical-spec-review` label when available
 - do not mark the technical spec approved
 - do not close the execution issue; it must remain open until Stage 12 closure verifies merged implementation evidence
+- add `technical-spec-review` only after the PR is no longer draft, checks are green, configured automated review is complete, and blocking review threads are resolved
 
 When blocked:
 
@@ -251,7 +259,7 @@ Technical spec draft complete:
 
 **Issue:** <link>
 **Technical spec:** <TECHNICAL.md path or none>
-**Draft PR:** <link or none>
+**Review-ready PR:** <link or none>
 **GitHub status:** <Technical Spec Review | Needs Clarification | unchanged>
 **Affected areas:** <summary>
 **Verification plan:** <summary>
@@ -270,6 +278,7 @@ Technical spec draft complete:
 - Do not modify implementation code, tests, migrations, generated outputs, or runtime assets.
 - Do not run Ralph cycles or implementation commands.
 - Do not approve your own technical spec.
+- Do not request Slack approval for a technical spec while its PR is still draft, missing checks, missing configured automated review, or has unresolved blocking feedback.
 - Do not use GitHub auto-close keywords in spec-only PRs; only Stage 12 closure may close the execution issue.
 - Keep the technical spec traceable to the approved product spec and source evidence.
 - Stop and ask the user if a requested write exceeds Stage 8.

--- a/.agents/skills/duumbi-tech-spec-review/SKILL.md
+++ b/.agents/skills/duumbi-tech-spec-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: duumbi-tech-spec-review
-description: "Run DUUMBI Stage 9 Technical Specification Review Gate: review one TECHNICAL.md draft from Technical Spec Review, prepare implementability findings, process explicit human or AI-gate approval/revision decisions, update GitHub state, and route to Ready for Build, Technical Spec Needed, or Needs Clarification without editing the technical spec or starting implementation."
+description: "Run DUUMBI Stage 9 Technical Specification Review Gate: review one TECHNICAL.md artifact from Technical Spec Review, prepare implementability findings, process explicit human or AI-gate approval/revision decisions, merge the reviewed spec PR when approved, update GitHub state, and route to Ready for Build, Technical Spec Needed, or Needs Clarification without editing the technical spec or starting implementation."
 ---
 
 You are the DUUMBI Technical Spec Review Agent.
@@ -12,14 +12,14 @@ Your job is to handle Stage 9, the technical spec approval gate. You review a St
 This skill covers:
 
 - reading one GitHub Issue in `Technical Spec Review`
-- reading the linked `specs/DUUMBI-<issue-number>/TECHNICAL.md` draft PR
+- reading the linked `specs/DUUMBI-<issue-number>/TECHNICAL.md` review-ready PR
 - verifying the approved product spec, Stage 7 approval, Stage 8 technical spec draft context, source links, relevant repo `AGENTS.md`, and related GitHub items
 - inspecting directly relevant source code, tests, commands, docs, generated artifact paths, schemas, contracts, CI paths, and UI/API surfaces when needed to assess implementability
 - preparing a structured technical spec review report
 - separating blocking findings from non-blocking improvements
 - processing explicit human decisions on the technical spec
 - processing AI gate decisions only when the full AI Gate Requirements below are satisfied
-- writing a structured GitHub review comment, and a draft PR comment when the technical spec is file-based
+- writing a structured GitHub review comment, and a PR comment when the technical spec is file-based
 - updating existing GitHub labels and Project status after an explicit decision
 
 This skill does not:
@@ -41,6 +41,7 @@ The AI gate is allowed only for Stage 9 technical spec approval and only when in
 Before approving through the AI gate, verify all of these facts:
 
 - the technical spec PR is a spec-only PR and contains no implementation code or test edits
+- the technical spec PR is open, non-draft, review-clean, and ready for approval merge
 - Copilot review was requested and has no unresolved blocking feedback
 - relevant checks are complete and passing, or the PR is documentation-only and checks are explicitly not applicable
 - the technical spec satisfies the Review Checklist below
@@ -56,7 +57,7 @@ If any requirement is missing, fail closed: record a review report, route to `Te
 - GitHub Issues and Project fields hold workflow state.
 - The technical spec artifact is the object being reviewed.
 - The durable Stage 9 decision record is a structured GitHub issue comment.
-- For file-based technical specs, also comment on the draft PR when available so review context stays with the spec diff.
+- For file-based technical specs, also comment on the PR when available so review context stays with the spec diff.
 - Obsidian Atlas provides context, but should not mirror live review state.
 
 ## Language Rules
@@ -70,11 +71,11 @@ If any requirement is missing, fail closed: record a review report, route to `Te
 Use this skill for one issue that:
 
 - is in `Technical Spec Review`
-- has a linked Stage 8 technical spec draft PR
+- has a linked Stage 8 technical spec review-ready PR
 - has a linked `specs/DUUMBI-<issue-number>/TECHNICAL.md`
 - is ready for technical review before implementation
 
-If the issue is not in `Technical Spec Review`, the approved product spec is missing, or the technical spec draft PR is missing, stop and report the missing gate.
+If the issue is not in `Technical Spec Review`, the approved product spec is missing, or the technical spec PR is missing, stop and report the missing gate.
 
 ## Approval Fast Path
 
@@ -82,11 +83,13 @@ When the prompt contains an explicit **Approve** decision (e.g. `Human decision:
 
 1. `gh issue view <N> --json number,title,labels,body` — verify `technical-spec-review` label is present
 2. `gh issue view <N> --comments --json comments` — find the Stage 8 Technical Spec Draft artifact link and product spec link from existing comments (search for "Stage 8 Technical Spec Draft" and "Stage 6 Product Spec Draft")
-3. Construct and post the Stage 9 Decision Comment on the issue (use the Decision Comment template below)
-4. Post a short pointer comment on the tech spec PR (if identifiable from the artifact URL)
-5. Update labels: remove `needs-tech-spec` and `technical-spec-review`, add `tech-spec-approved`
-6. Attempt Project V2 status update to `Ready for Build` (if `GH_PROJECT_PAT` is available, use `GH_TOKEN=$GH_PROJECT_PAT gh api graphql`; otherwise skip and note in the report)
-7. Report the final state
+3. Verify the technical spec PR is open, non-draft, changes only `specs/DUUMBI-<N>/TECHNICAL.md`, has green checks, completed configured automated review, no blocking review decisions, and no unresolved review threads
+4. Squash-merge the technical spec PR with non-closing issue references such as `Related to #<N>`; do not close the execution issue
+5. Construct and post the Stage 9 Decision Comment on the issue (use the Decision Comment template below)
+6. Post a short pointer comment on the tech spec PR
+7. Update labels: remove `needs-tech-spec` and `technical-spec-review`, add `tech-spec-approved`
+8. Attempt Project V2 status update to `Ready for Build` (if `GH_PROJECT_PAT` is available, use `GH_TOKEN=$GH_PROJECT_PAT gh api graphql`; otherwise skip and note in the report)
+9. Report the final state
 
 Do NOT:
 - Read the full TECHNICAL.md content (the human already reviewed and approved it)
@@ -106,7 +109,7 @@ Before reviewing:
 - Stage 5 human acceptance decision
 - Stage 7 product spec approval decision
 - approved product spec artifact
-- Stage 8 technical spec artifact and draft PR
+- Stage 8 technical spec artifact and review-ready PR
 - Stage 4 triage context and source links when needed
 - related GitHub Issues, PRs, Discussions, and prior specs
 - active DUUMBI PRD, Glossary, Agentic Development Map, workflow, and directly relevant Dots, Maps, or Works
@@ -223,15 +226,17 @@ For every explicit decision, write this structured GitHub issue comment:
 **Next state:** <Ready for Build | Technical Spec Needed | Needs Clarification | Closed | Deferred>
 ```
 
-For file-based technical specs, also comment on the draft PR with the same decision or a short pointer back to the issue decision comment.
+For file-based technical specs, also comment on the PR with the same decision or a short pointer back to the issue decision comment.
 
 ## Outcome Rules
 
 For `Approve`:
 
 - require explicit human approval or a fully satisfied AI gate
+- require an open non-draft spec-only PR with green checks, completed configured automated review, no blocking review decisions, and no unresolved review threads
+- squash-merge the technical spec PR before moving the issue to `Ready for Build`
 - write the decision comment
-- comment on the technical spec draft PR when available
+- comment on the technical spec PR when available
 - set Project Status to `Ready for Build` when available
 - remove existing `needs-tech-spec` when available
 - add existing `tech-spec-approved` when available
@@ -274,7 +279,8 @@ Technical spec review complete:
 **Product spec:** <PRODUCT.md path / comment link>
 **Recommendation or decision:** <value>
 **Review comment:** <link or "posted">
-**Draft PR comment:** <link, "posted", or "not applicable">
+**Spec PR merge:** <merge SHA or "not merged">
+**PR comment:** <link, "posted", or "not applicable">
 **GitHub status:** <Ready for Build | Technical Spec Needed | Needs Clarification | Closed | Deferred | unchanged>
 **Labels changed:** <added/removed/none>
 **BDD/live E2E readiness:** <ready | missing | blocked>

--- a/.github/workflows/spec-review-request.yml
+++ b/.github/workflows/spec-review-request.yml
@@ -23,7 +23,10 @@ on:
 
 permissions:
   actions: read
+  checks: read
   contents: read
+  pull-requests: read
+  statuses: read
 
 concurrency:
   group: spec-review-${{ github.event.issue.number || inputs.issue_number || github.event_name }}
@@ -34,8 +37,11 @@ jobs:
     name: Notify Slack
     runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
       issues: read
+      pull-requests: read
+      statuses: read
     outputs:
       issue_numbers: ${{ steps.request.outputs.issue_numbers }}
       should_notify: ${{ steps.request.outputs.should_notify }}
@@ -129,9 +135,132 @@ jobs:
               return stage6Comment.html_url;
             };
 
+            const latestReviewsByActor = (reviews) => {
+              const latest = new Map();
+              for (const review of reviews) {
+                const actor = review.user?.login || `review-${review.id}`;
+                const previous = latest.get(actor);
+                const submitted = Date.parse(review.submitted_at || 0);
+                const previousSubmitted = Date.parse(previous?.submitted_at || 0);
+                if (!previous || submitted >= previousSubmitted) latest.set(actor, review);
+              }
+              return [...latest.values()];
+            };
+
+            const findUnresolvedReviewThreads = async (pullNumber) => {
+              const unresolved = [];
+              let cursor = null;
+              do {
+                const data = await github.graphql(`
+                  query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+                    repository(owner: $owner, name: $repo) {
+                      pullRequest(number: $number) {
+                        reviewThreads(first: 100, after: $cursor) {
+                          pageInfo { hasNextPage endCursor }
+                          nodes {
+                            isResolved
+                            isOutdated
+                            comments(first: 1) { nodes { url } }
+                          }
+                        }
+                      }
+                    }
+                  }`,
+                  { owner: context.repo.owner, repo: context.repo.repo, number: pullNumber, cursor },
+                );
+                const threads = data.repository?.pullRequest?.reviewThreads;
+                for (const thread of threads?.nodes || []) {
+                  if (!thread.isResolved && !thread.isOutdated) {
+                    unresolved.push(thread.comments?.nodes?.[0]?.url || `review thread on PR #${pullNumber}`);
+                  }
+                }
+                cursor = threads?.pageInfo?.hasNextPage ? threads.pageInfo.endCursor : null;
+              } while (cursor);
+              return unresolved;
+            };
+
+            const specPrReadiness = async (issueNumber, specArtifact) => {
+              const prMatch = specArtifact.match(/\/pull\/(\d+)/);
+              if (!prMatch) {
+                return {
+                  ready: true,
+                  prNumber: 0,
+                  summary: "issue-comment product spec; no PR merge required",
+                };
+              }
+
+              const prNumber = Number(prMatch[1]);
+              const expectedPath = `specs/DUUMBI-${issueNumber}/PRODUCT.md`;
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              });
+              if (pr.state !== "open") return { ready: false, prNumber, summary: "PR is not open" };
+              if (pr.draft) return { ready: false, prNumber, summary: "PR is still draft" };
+
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                per_page: 100,
+              });
+              if (files.length !== 1 || files.some((file) => file.filename !== expectedPath || file.status === "removed")) {
+                return {
+                  ready: false,
+                  prNumber,
+                  summary: `PR must change only ${expectedPath}`,
+                };
+              }
+
+              const checkRuns = await github.paginate(
+                github.rest.checks.listForRef,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: pr.head.sha,
+                  per_page: 100,
+                },
+                (response) => response.data.check_runs,
+              );
+              const badChecks = checkRuns.filter((check) =>
+                check.status !== "completed" || !["success", "neutral", "skipped"].includes(check.conclusion)
+              );
+              const { data: combinedStatus } = await github.rest.repos.getCombinedStatusForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: pr.head.sha,
+              });
+              const statuses = combinedStatus.statuses || [];
+              const badStatuses = statuses.filter((statusContext) => statusContext.state !== "success");
+              if (checkRuns.length + statuses.length === 0) return { ready: false, prNumber, summary: "no checks or status contexts found" };
+              if (badChecks.length > 0 || badStatuses.length > 0) return { ready: false, prNumber, summary: "checks or status contexts are not green" };
+
+              const reviews = await github.paginate(github.rest.pulls.listReviews, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                per_page: 100,
+              });
+              const latestReviews = latestReviewsByActor(reviews);
+              const copilotReviews = latestReviews.filter((review) => /copilot/i.test(review.user?.login || ""));
+              const blockingReviews = latestReviews.filter((review) => review.state === "CHANGES_REQUESTED");
+              if (copilotReviews.length === 0) return { ready: false, prNumber, summary: "Copilot review has not completed" };
+              if (blockingReviews.length > 0) return { ready: false, prNumber, summary: "blocking review decision remains" };
+
+              const unresolvedThreads = await findUnresolvedReviewThreads(prNumber);
+              if (unresolvedThreads.length > 0) return { ready: false, prNumber, summary: "unresolved review threads remain" };
+
+              return {
+                ready: true,
+                prNumber,
+                summary: `PR #${prNumber} is review-clean and ready for approval merge`,
+              };
+            };
+
             const workflowDispatchUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/stage-approval.yml`;
 
-            const buildSlackMessage = (issue, triggeredBy, specArtifact) => {
+            const buildSlackMessage = (issue, triggeredBy, specArtifact, readiness) => {
               const issueUrl = issue.html_url || issueUrlFor(issue.number);
               const labelNames = labelsFor(issue);
               const labels = labelNames.join(", ") || "none";
@@ -150,14 +279,18 @@ jobs:
                 pr_number: prNum,
               });
 
+              const readinessLine = readiness.prNumber
+                ? `*Spec PR readiness:* <https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${readiness.prNumber}|PR #${readiness.prNumber}> is review-clean and will be squash-merged on approval\n`
+                : `*Spec PR readiness:* ${sanitizeSlackField(readiness.summary)}\n`;
+
               return {
-                text: `DUUMBI issue #${issue.number} needs product spec review approval: ${title}`,
+                text: `DUUMBI issue #${issue.number} product spec is ready to approve: ${title}`,
                 blocks: [
                   {
                     type: "section",
                     text: {
                       type: "mrkdwn",
-                      text: `*DUUMBI issue needs product spec review approval*\n*Issue:* <${issueUrl}|#${issue.number} ${title}>\n*Spec artifact:* <${specArtifact}|Stage 6 Product Spec Draft>\n*Trigger:* \`spec-review\` label\n*Status:* Spec Review\n*Labels:* ${safeLabels}\n*Triggered by:* ${safeTriggeredBy}\n*Correlation:* \`${correlationId}\``,
+                      text: `*DUUMBI product spec ready for approval*\n*Issue:* <${issueUrl}|#${issue.number} ${title}>\n*Spec artifact:* <${specArtifact}|Stage 6 Product Spec Draft>\n${readinessLine}*Trigger:* \`spec-review\` label\n*Status:* Spec Review\n*Labels:* ${safeLabels}\n*Triggered by:* ${safeTriggeredBy}\n*Correlation:* \`${correlationId}\``,
                     },
                   },
                   {
@@ -172,7 +305,7 @@ jobs:
                         value: buttonValue("approve"),
                         confirm: {
                           title: { type: "plain_text", text: "Approve Product Spec" },
-                          text: { type: "mrkdwn", text: `Approve Stage 7 Product Spec Review for issue #${issue.number}?\nThis will set the issue to *Technical Spec Needed*.` },
+                          text: { type: "mrkdwn", text: `Approve Stage 7 Product Spec Review for issue #${issue.number}?\nIf a spec PR is linked, this will merge it and then set the issue to *Technical Spec Needed*.` },
                           confirm: { type: "plain_text", text: "Approve" },
                           deny: { type: "plain_text", text: "Cancel" },
                         },
@@ -284,21 +417,40 @@ jobs:
             }
 
             const slackMessages = [];
+            const notifiedIssues = [];
             let artifactLinksFound = 0;
             let artifactLinksMissing = 0;
             for (const issue of issuesToNotify) {
               const specArtifact = await findSpecArtifact(issue.number);
               if (specArtifact.startsWith("<missing:")) {
                 artifactLinksMissing += 1;
+                core.info(`Skipping issue #${issue.number}: missing Stage 6 product spec artifact.`);
+                continue;
               } else {
                 artifactLinksFound += 1;
               }
-              slackMessages.push(buildSlackMessage(issue, triggeredBy, specArtifact));
+              const readiness = await specPrReadiness(issue.number, specArtifact);
+              if (!readiness.ready) {
+                core.info(`Skipping issue #${issue.number}: product spec PR not ready for approval (${readiness.summary}).`);
+                continue;
+              }
+              slackMessages.push(buildSlackMessage(issue, triggeredBy, specArtifact, readiness));
+              notifiedIssues.push(issue);
+            }
+
+            if (slackMessages.length === 0) {
+              core.info("No product spec review notifications are ready to send.");
+              core.setOutput("issue_numbers", "[]");
+              core.setOutput("issues_queued_count", "0");
+              core.setOutput("artifact_links_found", String(artifactLinksFound));
+              core.setOutput("artifact_links_missing", String(artifactLinksMissing));
+              core.setOutput("should_notify", "false");
+              return;
             }
 
             core.setOutput("slack_messages", JSON.stringify(slackMessages));
-            core.setOutput("issue_numbers", JSON.stringify(issuesToNotify.map((issue) => issue.number)));
-            core.setOutput("issues_queued_count", String(issuesToNotify.length));
+            core.setOutput("issue_numbers", JSON.stringify(notifiedIssues.map((issue) => issue.number)));
+            core.setOutput("issues_queued_count", String(notifiedIssues.length));
             core.setOutput("artifact_links_found", String(artifactLinksFound));
             core.setOutput("artifact_links_missing", String(artifactLinksMissing));
             core.setOutput("should_notify", "true");

--- a/.github/workflows/stage-approval.yml
+++ b/.github/workflows/stage-approval.yml
@@ -37,9 +37,11 @@ on:
 
 permissions:
   actions: read
-  contents: read
+  checks: read
+  contents: write
   issues: write
   pull-requests: write
+  statuses: read
 
 concurrency:
   group: stage-approval-${{ github.event.inputs.issue_number || github.event.client_payload.issue_number || 'dispatch' }}
@@ -80,6 +82,7 @@ jobs:
             const { owner, repo } = context.repo;
             const issueUrl = `https://github.com/${owner}/${repo}/issues/${issueNumber}`;
             const today = new Date().toISOString().split('T')[0];
+            let specPrMerge = null;
 
             core.info(`Stage ${stage} | ${decision} | issue #${issueNumber}`);
 
@@ -249,7 +252,7 @@ jobs:
                   `Target issue: ${issueUrl}`,
                   `Expected artifact: specs/DUUMBI-${issueNumber}/PRODUCT.md, unless the skill determines that an issue-comment spec is sufficient.`,
                   '',
-                  'Goal: Verify Stage 5 acceptance, inspect active DUUMBI context and relevant source context, draft the product spec in English with BDD Scenarios, open a draft spec PR if file-based, link it from the issue, and move the issue to Spec Review.',
+                  'Goal: Verify Stage 5 acceptance, inspect active DUUMBI context and relevant source context, draft the product spec in English with BDD Scenarios, open a spec PR if file-based, mark it ready for review, address blocking review feedback until checks and configured automated review are clean, link it from the issue, and move the issue to Spec Review only after it is ready for approval merge.',
                   '',
                   `Spec-only PR rule: use non-closing issue references such as "Related to #${issueNumber}" or "Spec for #${issueNumber}". Include a workflow note that this PR must leave the execution issue open.`,
                   '',
@@ -265,7 +268,7 @@ jobs:
                   `Product spec artifact: ${knownProductSpec}`,
                   `Expected artifact: specs/DUUMBI-${issueNumber}/TECHNICAL.md`,
                   '',
-                  'Goal: Verify product spec approval, inspect repo AGENTS.md and affected source areas, draft an agent-facing technical spec with BDD-to-test mapping, live E2E plan, and Ralph Cycle resource policy, open a draft PR, link it from the issue, and move the issue to Technical Spec Review.',
+                  'Goal: Verify product spec approval, inspect repo AGENTS.md and affected source areas, draft an agent-facing technical spec with BDD-to-test mapping, live E2E plan, and Ralph Cycle resource policy, open a technical spec PR, mark it ready for review, address blocking review feedback until checks and configured automated review are clean, link it from the issue, and move the issue to Technical Spec Review only after it is ready for approval merge.',
                   '',
                   `Spec-only PR rule: use non-closing issue references such as "Related to #${issueNumber}" or "Technical spec for #${issueNumber}". Include a workflow note that this PR must leave the execution issue open.`,
                   '',
@@ -292,6 +295,214 @@ jobs:
             };
             const nextCodexPrompt = buildNextCodexPrompt();
 
+            const approvalSpecPrPolicy = () => {
+              if (decision !== 'approve') return null;
+              if (stage === '7') {
+                return {
+                  stageLabel: 'Stage 7',
+                  kind: 'product spec',
+                  artifact: productSpecArtifact,
+                  allowIssueCommentArtifact: true,
+                  expectedPath: `specs/DUUMBI-${issueNumber}/PRODUCT.md`,
+                  safeCommitTitle: `Spec for #${issueNumber}: product spec`,
+                  safeCommitMessage: `Related to #${issueNumber}.\n\nSpec-only Stage 7 approval merge. The execution issue remains open for Stage 8 and later workflow stages.`,
+                };
+              }
+              if (stage === '9') {
+                return {
+                  stageLabel: 'Stage 9',
+                  kind: 'technical spec',
+                  artifact: techSpecArtifact,
+                  allowIssueCommentArtifact: false,
+                  expectedPath: `specs/DUUMBI-${issueNumber}/TECHNICAL.md`,
+                  safeCommitTitle: `Technical spec for #${issueNumber}`,
+                  safeCommitMessage: `Related to #${issueNumber}.\n\nSpec-only Stage 9 approval merge. The execution issue remains open for Stage 10 and later workflow stages.`,
+                };
+              }
+              return null;
+            };
+
+            const latestReviewsByActor = (reviews) => {
+              const latest = new Map();
+              for (const review of reviews) {
+                const actor = review.user?.login || `review-${review.id}`;
+                const previous = latest.get(actor);
+                const submitted = Date.parse(review.submitted_at || review.submittedAt || 0);
+                const previousSubmitted = Date.parse(previous?.submitted_at || previous?.submittedAt || 0);
+                if (!previous || submitted >= previousSubmitted) latest.set(actor, review);
+              }
+              return [...latest.values()];
+            };
+
+            const findUnresolvedReviewThreads = async (pullNumber) => {
+              const unresolved = [];
+              let cursor = null;
+              do {
+                const data = await github.graphql(`
+                  query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+                    repository(owner: $owner, name: $repo) {
+                      pullRequest(number: $number) {
+                        reviewThreads(first: 100, after: $cursor) {
+                          pageInfo { hasNextPage endCursor }
+                          nodes {
+                            isResolved
+                            isOutdated
+                            comments(first: 1) {
+                              nodes {
+                                url
+                                author { login }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }`,
+                  { owner, repo, number: pullNumber, cursor },
+                );
+                const threads = data.repository?.pullRequest?.reviewThreads;
+                for (const thread of threads?.nodes || []) {
+                  if (!thread.isResolved && !thread.isOutdated) {
+                    const firstComment = thread.comments?.nodes?.[0];
+                    unresolved.push(firstComment?.url || `review thread by ${firstComment?.author?.login || 'unknown'}`);
+                  }
+                }
+                cursor = threads?.pageInfo?.hasNextPage ? threads.pageInfo.endCursor : null;
+              } while (cursor);
+              return unresolved;
+            };
+
+            const validateAndMergeSpecPr = async (policy) => {
+              if (!policy) return null;
+              if (!prNumber) {
+                const artifact = String(policy.artifact || '');
+                if (policy.allowIssueCommentArtifact && artifact && !artifact.includes('/pull/') && !artifact.startsWith('<missing:')) {
+                  return {
+                    prNumber: 0,
+                    prUrl: 'not applicable',
+                    mergeSha: 'not applicable',
+                    expectedPath: policy.expectedPath,
+                    checkCount: 0,
+                    reviewCount: 0,
+                    copilotReviewCount: 0,
+                    issueCommentArtifact: true,
+                  };
+                }
+                throw new Error(`${policy.stageLabel} approval requires an associated ${policy.kind} PR so approval can merge the reviewed artifact.`);
+              }
+
+              const prUrl = `https://github.com/${owner}/${repo}/pull/${prNumber}`;
+              const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+              const alreadyMerged = pr.state !== 'open' && pr.merged;
+              if (pr.state !== 'open' && !alreadyMerged) throw new Error(`${policy.kind} PR #${prNumber} is not open.`);
+              if (!alreadyMerged && pr.draft) throw new Error(`${policy.kind} PR #${prNumber} is still draft; mark it ready for review and finish review fixes before approval.`);
+              if (pr.base?.repo?.full_name !== `${owner}/${repo}`) {
+                throw new Error(`${policy.kind} PR #${prNumber} targets ${pr.base?.repo?.full_name || 'unknown'}, not ${owner}/${repo}.`);
+              }
+
+              const closingPattern = new RegExp(`\\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s+#${issueNumber}\\b`, 'i');
+              const closingSurfaces = [
+                ['PR title', pr.title || ''],
+                ['PR body', pr.body || ''],
+              ];
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner, repo, pull_number: prNumber, per_page: 100,
+              });
+              const changedPaths = files.map((file) => file.filename);
+              const invalidFiles = files.filter((file) =>
+                file.filename !== policy.expectedPath || file.status === 'removed'
+              );
+              for (const file of files) {
+                closingSurfaces.push([`patch ${file.filename}`, file.patch || '']);
+              }
+              const commits = await github.paginate(github.rest.pulls.listCommits, {
+                owner, repo, pull_number: prNumber, per_page: 100,
+              });
+              for (const commit of commits) {
+                closingSurfaces.push([`commit ${commit.sha}`, commit.commit?.message || '']);
+              }
+              const closingHit = closingSurfaces.find(([, text]) => closingPattern.test(text));
+              if (closingHit) throw new Error(`${policy.kind} PR #${prNumber} uses an issue-closing reference in ${closingHit[0]}; use "Related to #${issueNumber}" style wording.`);
+              if (invalidFiles.length > 0 || files.length !== 1) {
+                throw new Error(`${policy.kind} PR #${prNumber} must change only ${policy.expectedPath}; found ${changedPaths.join(', ') || 'no files'}.`);
+              }
+
+              const checkRuns = await github.paginate(
+                github.rest.checks.listForRef,
+                { owner, repo, ref: pr.head.sha, per_page: 100 },
+                (response) => response.data.check_runs,
+              );
+              const badChecks = checkRuns.filter((check) =>
+                check.status !== 'completed' || !['success', 'neutral', 'skipped'].includes(check.conclusion)
+              );
+              const { data: combinedStatus } = await github.rest.repos.getCombinedStatusForRef({
+                owner, repo, ref: pr.head.sha,
+              });
+              const statuses = combinedStatus.statuses || [];
+              const badStatuses = statuses.filter((status) => status.state !== 'success');
+              if (checkRuns.length + statuses.length === 0) {
+                throw new Error(`${policy.kind} PR #${prNumber} has no check runs or status contexts; approval requires verifiable green checks.`);
+              }
+              if (badChecks.length > 0) {
+                throw new Error(`Checks are not green on ${policy.kind} PR #${prNumber}: ${badChecks.map((check) => `${check.name}:${check.status}/${check.conclusion}`).join(', ')}`);
+              }
+              if (badStatuses.length > 0) {
+                throw new Error(`Status contexts are not green on ${policy.kind} PR #${prNumber}: ${badStatuses.map((status) => `${status.context}:${status.state}`).join(', ')}`);
+              }
+
+              const reviews = await github.paginate(github.rest.pulls.listReviews, {
+                owner, repo, pull_number: prNumber, per_page: 100,
+              });
+              const latestReviews = latestReviewsByActor(reviews);
+              const blockingReviews = latestReviews.filter((review) => review.state === 'CHANGES_REQUESTED');
+              const copilotReviews = latestReviews.filter((review) => /copilot/i.test(review.user?.login || ''));
+              if (copilotReviews.length === 0) {
+                throw new Error(`${policy.kind} PR #${prNumber} has no completed Copilot review; approval waits for review and fixes.`);
+              }
+              if (blockingReviews.length > 0) {
+                throw new Error(`${policy.kind} PR #${prNumber} has blocking review decisions: ${blockingReviews.map((review) => `${review.user?.login || 'unknown'}:${review.state}`).join(', ')}`);
+              }
+
+              const unresolvedThreads = await findUnresolvedReviewThreads(prNumber);
+              if (unresolvedThreads.length > 0) {
+                throw new Error(`${policy.kind} PR #${prNumber} has unresolved review threads: ${unresolvedThreads.slice(0, 5).join(', ')}`);
+              }
+
+              if (alreadyMerged) {
+                return {
+                  prNumber,
+                  prUrl,
+                  mergeSha: pr.merge_commit_sha || '',
+                  expectedPath: policy.expectedPath,
+                  checkCount: checkRuns.length + statuses.length,
+                  reviewCount: latestReviews.length,
+                  copilotReviewCount: copilotReviews.length,
+                  alreadyMerged: true,
+                };
+              }
+
+              const merge = await github.rest.pulls.merge({
+                owner,
+                repo,
+                pull_number: prNumber,
+                merge_method: 'squash',
+                commit_title: policy.safeCommitTitle,
+                commit_message: policy.safeCommitMessage,
+              });
+
+              return {
+                prNumber,
+                prUrl,
+                mergeSha: merge.data.sha || '',
+                expectedPath: policy.expectedPath,
+                checkCount: checkRuns.length + statuses.length,
+                reviewCount: latestReviews.length,
+                copilotReviewCount: copilotReviews.length,
+              };
+            };
+
+            specPrMerge = await validateAndMergeSpecPr(approvalSpecPrPolicy());
+
             // ── Build decision comment ──────────────────────────────
             const lines = [`## ${stageConfig.title}`, ''];
             lines.push(`**Decision:** ${dc.label}`);
@@ -305,6 +516,8 @@ jobs:
               lines.push(`**Review date:** ${today}`);
             } else if (stage === '7') {
               lines.push(`**Spec artifact:** ${productSpecArtifact || 'not found'}`);
+              lines.push(`**Spec PR:** ${specPrMerge?.prUrl || 'not merged'}`);
+              lines.push(`**Spec PR merge SHA:** ${specPrMerge?.mergeSha || 'not merged'}`);
               lines.push(`**Rationale:** ${rationale}`);
               lines.push(`**Blocking findings:** none`);
               lines.push(`**Non-blocking findings:** none`);
@@ -312,6 +525,8 @@ jobs:
             } else if (stage === '9') {
               lines.push(`**Technical spec:** ${techSpecArtifact || 'not found'}`);
               lines.push(`**Product spec:** ${productSpecArtifact || 'not found'}`);
+              lines.push(`**Technical spec PR:** ${specPrMerge?.prUrl || 'not merged'}`);
+              lines.push(`**Technical spec PR merge SHA:** ${specPrMerge?.mergeSha || 'not merged'}`);
               lines.push(`**Rationale:** ${rationale}`);
               lines.push(`**Blocking findings:** none`);
               lines.push(`**Non-blocking findings:** none`);
@@ -350,7 +565,8 @@ jobs:
                   `**Decision:** ${dc.label}`,
                   `**Issue:** ${issueUrl}`,
                   `**Decision comment:** ${posted.html_url}`,
-                ].join('\n');
+                  specPrMerge?.mergeSha ? `**Merge SHA:** ${specPrMerge.mergeSha}` : null,
+                ].filter(Boolean).join('\n');
                 const prComments = await github.paginate(github.rest.issues.listComments, {
                   owner, repo, issue_number: prNumber, per_page: 100,
                 });
@@ -493,6 +709,7 @@ jobs:
               `${decisionEmoji} Stage ${stage} *${dc.label}* — <${issueUrl}|#${issueNumber} ${safeTitle}>`,
               `• Decision comment: ${posted.html_url}`,
               prCommentUrl ? `• PR comment: ${prCommentUrl}` : null,
+              specPrMerge?.mergeSha ? `• Spec PR merged: ${specPrMerge.mergeSha}` : null,
               `• Labels: +[${dc.add.join(', ')}] −[${dc.remove.join(', ')}]`,
               `• Project: ${projectUpdated ? dc.projectStatus : '_not updated_'}`,
               `• Next: ${dc.nextStage}`,

--- a/.github/workflows/technical-spec-review-request.yml
+++ b/.github/workflows/technical-spec-review-request.yml
@@ -23,7 +23,10 @@ on:
 
 permissions:
   actions: read
+  checks: read
   contents: read
+  pull-requests: read
+  statuses: read
 
 concurrency:
   group: tech-spec-review-${{ github.event.issue.number || inputs.issue_number || github.event_name }}
@@ -34,8 +37,11 @@ jobs:
     name: Notify Slack
     runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
       issues: read
+      pull-requests: read
+      statuses: read
     outputs:
       issue_numbers: ${{ steps.request.outputs.issue_numbers }}
       should_notify: ${{ steps.request.outputs.should_notify }}
@@ -140,9 +146,132 @@ jobs:
               };
             };
 
+            const latestReviewsByActor = (reviews) => {
+              const latest = new Map();
+              for (const review of reviews) {
+                const actor = review.user?.login || `review-${review.id}`;
+                const previous = latest.get(actor);
+                const submitted = Date.parse(review.submitted_at || 0);
+                const previousSubmitted = Date.parse(previous?.submitted_at || 0);
+                if (!previous || submitted >= previousSubmitted) latest.set(actor, review);
+              }
+              return [...latest.values()];
+            };
+
+            const findUnresolvedReviewThreads = async (pullNumber) => {
+              const unresolved = [];
+              let cursor = null;
+              do {
+                const data = await github.graphql(`
+                  query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+                    repository(owner: $owner, name: $repo) {
+                      pullRequest(number: $number) {
+                        reviewThreads(first: 100, after: $cursor) {
+                          pageInfo { hasNextPage endCursor }
+                          nodes {
+                            isResolved
+                            isOutdated
+                            comments(first: 1) { nodes { url } }
+                          }
+                        }
+                      }
+                    }
+                  }`,
+                  { owner: context.repo.owner, repo: context.repo.repo, number: pullNumber, cursor },
+                );
+                const threads = data.repository?.pullRequest?.reviewThreads;
+                for (const thread of threads?.nodes || []) {
+                  if (!thread.isResolved && !thread.isOutdated) {
+                    unresolved.push(thread.comments?.nodes?.[0]?.url || `review thread on PR #${pullNumber}`);
+                  }
+                }
+                cursor = threads?.pageInfo?.hasNextPage ? threads.pageInfo.endCursor : null;
+              } while (cursor);
+              return unresolved;
+            };
+
+            const technicalSpecPrReadiness = async (issueNumber, technicalSpecArtifact) => {
+              const prMatch = technicalSpecArtifact.match(/\/pull\/(\d+)/);
+              if (!prMatch) {
+                return {
+                  ready: false,
+                  prNumber: 0,
+                  summary: "technical spec review requires a linked TECHNICAL.md PR",
+                };
+              }
+
+              const prNumber = Number(prMatch[1]);
+              const expectedPath = `specs/DUUMBI-${issueNumber}/TECHNICAL.md`;
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              });
+              if (pr.state !== "open") return { ready: false, prNumber, summary: "PR is not open" };
+              if (pr.draft) return { ready: false, prNumber, summary: "PR is still draft" };
+
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                per_page: 100,
+              });
+              if (files.length !== 1 || files.some((file) => file.filename !== expectedPath || file.status === "removed")) {
+                return {
+                  ready: false,
+                  prNumber,
+                  summary: `PR must change only ${expectedPath}`,
+                };
+              }
+
+              const checkRuns = await github.paginate(
+                github.rest.checks.listForRef,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: pr.head.sha,
+                  per_page: 100,
+                },
+                (response) => response.data.check_runs,
+              );
+              const badChecks = checkRuns.filter((check) =>
+                check.status !== "completed" || !["success", "neutral", "skipped"].includes(check.conclusion)
+              );
+              const { data: combinedStatus } = await github.rest.repos.getCombinedStatusForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: pr.head.sha,
+              });
+              const statuses = combinedStatus.statuses || [];
+              const badStatuses = statuses.filter((statusContext) => statusContext.state !== "success");
+              if (checkRuns.length + statuses.length === 0) return { ready: false, prNumber, summary: "no checks or status contexts found" };
+              if (badChecks.length > 0 || badStatuses.length > 0) return { ready: false, prNumber, summary: "checks or status contexts are not green" };
+
+              const reviews = await github.paginate(github.rest.pulls.listReviews, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                per_page: 100,
+              });
+              const latestReviews = latestReviewsByActor(reviews);
+              const copilotReviews = latestReviews.filter((review) => /copilot/i.test(review.user?.login || ""));
+              const blockingReviews = latestReviews.filter((review) => review.state === "CHANGES_REQUESTED");
+              if (copilotReviews.length === 0) return { ready: false, prNumber, summary: "Copilot review has not completed" };
+              if (blockingReviews.length > 0) return { ready: false, prNumber, summary: "blocking review decision remains" };
+
+              const unresolvedThreads = await findUnresolvedReviewThreads(prNumber);
+              if (unresolvedThreads.length > 0) return { ready: false, prNumber, summary: "unresolved review threads remain" };
+
+              return {
+                ready: true,
+                prNumber,
+                summary: `PR #${prNumber} is review-clean and ready for approval merge`,
+              };
+            };
+
             const workflowDispatchUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/stage-approval.yml`;
 
-            const buildSlackMessage = (issue, triggeredBy, artifacts) => {
+            const buildSlackMessage = (issue, triggeredBy, artifacts, readiness) => {
               const issueUrl = issue.html_url || issueUrlFor(issue.number);
               const labelNames = labelsFor(issue);
               const labels = labelNames.join(", ") || "none";
@@ -170,13 +299,13 @@ jobs:
               });
 
               return {
-                text: `DUUMBI issue #${issue.number} needs technical spec review approval: ${title}`,
+                text: `DUUMBI issue #${issue.number} technical spec is ready to approve: ${title}`,
                 blocks: [
                   {
                     type: "section",
                     text: {
                       type: "mrkdwn",
-                      text: `*DUUMBI issue needs technical spec review approval*\n*Issue:* <${issueUrl}|#${issue.number} ${title}>\n*Technical spec artifact:* ${technicalSpecLine}\n*Product spec artifact:* ${productSpecLine}\n*Trigger:* \`technical-spec-review\` label\n*Status:* Technical Spec Review\n*Labels:* ${safeLabels}\n*Triggered by:* ${safeTriggeredBy}\n*Correlation:* \`${correlationId}\``,
+                      text: `*DUUMBI technical spec ready for approval*\n*Issue:* <${issueUrl}|#${issue.number} ${title}>\n*Technical spec artifact:* ${technicalSpecLine}\n*Product spec artifact:* ${productSpecLine}\n*Technical spec PR readiness:* <https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${readiness.prNumber}|PR #${readiness.prNumber}> is review-clean and will be squash-merged on approval\n*Trigger:* \`technical-spec-review\` label\n*Status:* Technical Spec Review\n*Labels:* ${safeLabels}\n*Triggered by:* ${safeTriggeredBy}\n*Correlation:* \`${correlationId}\``,
                     },
                   },
                   {
@@ -191,7 +320,7 @@ jobs:
                         value: buttonValue("approve"),
                         confirm: {
                           title: { type: "plain_text", text: "Approve Technical Spec" },
-                          text: { type: "mrkdwn", text: `Approve Stage 9 Technical Spec Review for issue #${issue.number}?\nThis will set the issue to *Ready for Build*.` },
+                          text: { type: "mrkdwn", text: `Approve Stage 9 Technical Spec Review for issue #${issue.number}?\nThis will merge the technical spec PR and then set the issue to *Ready for Build*.` },
                           confirm: { type: "plain_text", text: "Approve" },
                           deny: { type: "plain_text", text: "Cancel" },
                         },
@@ -319,21 +448,40 @@ jobs:
             }
 
             const slackMessages = [];
+            const notifiedIssues = [];
             let artifactLinksFound = 0;
             let artifactLinksMissing = 0;
             for (const issue of issuesToNotify) {
               const artifacts = await findStage8Artifacts(issue.number);
               if (artifacts.technicalSpecArtifact.startsWith("<missing:")) {
                 artifactLinksMissing += 1;
+                core.info(`Skipping issue #${issue.number}: missing Stage 8 technical spec artifact.`);
+                continue;
               } else {
                 artifactLinksFound += 1;
               }
-              slackMessages.push(buildSlackMessage(issue, triggeredBy, artifacts));
+              const readiness = await technicalSpecPrReadiness(issue.number, artifacts.technicalSpecArtifact);
+              if (!readiness.ready) {
+                core.info(`Skipping issue #${issue.number}: technical spec PR not ready for approval (${readiness.summary}).`);
+                continue;
+              }
+              slackMessages.push(buildSlackMessage(issue, triggeredBy, artifacts, readiness));
+              notifiedIssues.push(issue);
+            }
+
+            if (slackMessages.length === 0) {
+              core.info("No technical spec review notifications are ready to send.");
+              core.setOutput("issue_numbers", "[]");
+              core.setOutput("issues_queued_count", "0");
+              core.setOutput("artifact_links_found", String(artifactLinksFound));
+              core.setOutput("artifact_links_missing", String(artifactLinksMissing));
+              core.setOutput("should_notify", "false");
+              return;
             }
 
             core.setOutput("slack_messages", JSON.stringify(slackMessages));
-            core.setOutput("issue_numbers", JSON.stringify(issuesToNotify.map((issue) => issue.number)));
-            core.setOutput("issues_queued_count", String(issuesToNotify.length));
+            core.setOutput("issue_numbers", JSON.stringify(notifiedIssues.map((issue) => issue.number)));
+            core.setOutput("issues_queued_count", String(notifiedIssues.length));
             core.setOutput("artifact_links_found", String(artifactLinksFound));
             core.setOutput("artifact_links_missing", String(artifactLinksMissing));
             core.setOutput("should_notify", "true");

--- a/docs/automation/agentic-development-orchestration.md
+++ b/docs/automation/agentic-development-orchestration.md
@@ -28,8 +28,8 @@ or source-repo contracts that support it.
 - `duumbi-obsidian-capture` and `duumbi-codex-intake` now search active Inbox,
   Processed Inbox, Atlas, and GitHub before creating duplicate notes.
 - `duumbi-spec-review` and `duumbi-tech-spec-review` now support bounded AI
-  gates while still failing closed on missing Copilot, checks, scope, or
-  unresolved findings.
+  gates while still failing closed on missing Copilot, checks, scope,
+  unresolved findings, or unmerged spec PR readiness.
 
 ## Workflows Added
 
@@ -129,11 +129,20 @@ Reference pricing pages:
 Stage 7 and Stage 9 AI gates may approve only when:
 
 - the PR is spec-only
+- the PR is open, non-draft, and ready for approval merge
 - Copilot review exists and has no unresolved blocking feedback
 - relevant checks are passing or explicitly not applicable
 - no product, architecture, security, migration, cost, scope, or verification
   question remains
 - the proposed spec stays inside the accepted issue scope
+
+Stage 7 and Stage 9 human Slack approvals are merge finalizers for file-based
+specs. The review request workflows send Slack approval cards only after the
+linked PRODUCT.md or TECHNICAL.md PR is review-clean. Approval then revalidates
+the exact PR, squash-merges the spec artifact with non-closing issue references,
+records the stage decision, and advances the issue to the next workflow state.
+If the PR is draft, dirty, not spec-only, missing Copilot review, or has
+unresolved review threads, the workflow fails closed or defers notification.
 
 Stage 11 merge remains human-authorized. The merge workflow requires explicit
 human decision, Stage 11 review artifact, green checks, clean Copilot review,

--- a/scripts/github-actions/stage-approval-workflow.test.mjs
+++ b/scripts/github-actions/stage-approval-workflow.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+const readRepoFile = (path) => readFileSync(join(repoRoot, path), "utf8");
+
+test("stage approval merges only reviewed spec PRs for Stage 7 and Stage 9 approvals", () => {
+  const workflow = readRepoFile(".github/workflows/stage-approval.yml");
+
+  assert.match(workflow, /contents:\s+write/);
+  assert.match(workflow, /pulls\.merge/);
+  assert.match(workflow, /specs\/DUUMBI-\$\{issueNumber\}\/PRODUCT\.md/);
+  assert.match(workflow, /specs\/DUUMBI-\$\{issueNumber\}\/TECHNICAL\.md/);
+  assert.match(workflow, /has no completed Copilot review/);
+  assert.match(workflow, /has unresolved review threads/);
+  assert.match(workflow, /must change only \$\{policy\.expectedPath\}/);
+  assert.match(workflow, /Related to #\$\{issueNumber\}/);
+});
+
+test("product spec Slack review requests wait for review-clean PRs", () => {
+  const workflow = readRepoFile(".github/workflows/spec-review-request.yml");
+
+  assert.match(workflow, /PR is still draft/);
+  assert.match(workflow, /Copilot review has not completed/);
+  assert.match(workflow, /unresolved review threads remain/);
+  assert.match(workflow, /will be squash-merged on approval/);
+  assert.match(workflow, /No product spec review notifications are ready to send/);
+});
+
+test("technical spec Slack review requests wait for review-clean PRs", () => {
+  const workflow = readRepoFile(".github/workflows/technical-spec-review-request.yml");
+
+  assert.match(workflow, /technical spec review requires a linked TECHNICAL\.md PR/);
+  assert.match(workflow, /PR is still draft/);
+  assert.match(workflow, /Copilot review has not completed/);
+  assert.match(workflow, /unresolved review threads remain/);
+  assert.match(workflow, /will be squash-merged on approval/);
+  assert.match(workflow, /No technical spec review notifications are ready to send/);
+});

--- a/scripts/slack-approval-bridge/README.md
+++ b/scripts/slack-approval-bridge/README.md
@@ -9,6 +9,8 @@ launching an agent directly. Slack shortcuts can also dispatch Stage 1 intake.
 Existing Stage 5, Stage 7, and Stage 9 buttons continue to route to
 `stage-approval.yml`. Stage 10 resource authorization buttons that include
 `action_type: "stage_10_authorization"` route to `stage-10-authorization.yml`.
+For file-based Stage 7 and Stage 9 spec approvals, `stage-approval.yml`
+revalidates the linked spec PR and squash-merges it before advancing the issue.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

- make Stage 7 and Stage 9 approval finalizers revalidate linked spec PRs and squash-merge clean PRODUCT.md / TECHNICAL.md artifacts before advancing issue state
- defer product and technical spec Slack approval cards until linked spec PRs are non-draft, spec-only, green, Copilot-reviewed, and free of unresolved review threads
- update DUUMBI Stage 6/7/8/9 skill runbooks and orchestration docs so Codex App runs review/fix loops before requesting Slack approval
- add workflow regression coverage for the new approval/notification semantics

## Validation

- `node --test scripts/github-actions/*.test.mjs`
- `node --test scripts/slack-approval-bridge/src/functions/slackApproval.test.js`
- `ruby -e 'require "yaml"; %w[.github/workflows/stage-approval.yml .github/workflows/spec-review-request.yml .github/workflows/technical-spec-review-request.yml].each { |f| YAML.load_file(f); puts "ok #{f}" }'`
- `git diff --check`

## Workflow Note

This PR updates workflow automation only. It does not close any execution issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced spec review workflows with automated PR readiness validation before approval requests
  * Stricter approval gating: specifications must be review-ready (non-draft) with completed automated reviews and resolved feedback threads
  * Explicit PR merge steps integrated into approval workflows

* **Documentation**
  * Updated spec development and review guidelines for Stages 6–9 with clearer approval criteria

* **Tests**
  * Added workflow validation test suite for approval automation

* **Chores**
  * Expanded GitHub Actions workflow permissions for enhanced PR validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hgahub/duumbi/pull/629?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->