### PR TITLE
🛠️ fix: harden DUUMBI spec review gates

### DIFF
--- a/.agents/skills/duumbi-delivery-autopilot/SKILL.md
+++ b/.agents/skills/duumbi-delivery-autopilot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: duumbi-delivery-autopilot
-description: "Run DUUMBI delivery autopilot from one Spec Needed issue: draft product and technical specs, use Copilot plus Codex AI gates for Stage 7 and Stage 9, merge spec-only PRs when gates are clean, then enter Stage 10 Ralph-cycle implementation without bypassing resource gates."
+description: "Run DUUMBI delivery autopilot from one Spec Needed issue: draft product and technical specs, use configured automated reviews plus Codex AI gates for Stage 7 and Stage 9, merge spec-only PRs when gates are clean, then enter Stage 10 Ralph-cycle implementation without bypassing resource gates."
 ---
 
 You are the DUUMBI Delivery Autopilot Coordinator.
@@ -13,11 +13,13 @@ This skill covers:
 
 - verifying one issue is accepted and in `Spec Needed`
 - running Stage 6 product spec draft through `duumbi-spec-draft`
-- waiting for or verifying Copilot review on the product spec PR
+- waiting for or verifying actual configured automated reviewer submissions on
+  the product spec PR
 - running Stage 7 product spec review through `duumbi-spec-review` in AI-gate mode
 - merging the product spec-only PR only after a clean Stage 7 AI gate
 - running Stage 8 technical spec draft through `duumbi-tech-spec-draft`
-- waiting for or verifying Copilot review on the technical spec PR
+- waiting for or verifying actual configured automated reviewer submissions on
+  the technical spec PR
 - running Stage 9 technical spec review through `duumbi-tech-spec-review` in AI-gate mode
 - merging the technical spec-only PR only after a clean Stage 9 AI gate
 - entering Stage 10 through `duumbi-implementation` and bounded `duumbi-ralph-cycle` runs
@@ -26,7 +28,7 @@ This skill covers:
 This skill does not:
 
 - accept Stage 5 work
-- bypass Copilot review or CI/check evidence
+- bypass configured automated review or CI/check evidence
 - approve specs when AI gate requirements are missing
 - broaden product or technical scope
 - exceed Ralph-cycle resource gates
@@ -49,7 +51,7 @@ Stage 7 and Stage 9 may be approved by AI only when all gate requirements in `du
 
 Fail closed when:
 
-- Copilot review is absent or unresolved
+- configured automated review evidence is absent, request-only, or unresolved
 - checks are failing, pending, or missing without a documented not-applicable reason
 - blocking findings exist
 - unresolved product, architecture, security, migration, cost, scope, or verification questions remain
@@ -61,19 +63,19 @@ Durable decision comments must use:
 - `## Stage 7 AI Gate Decision`
 - `## Stage 9 AI Gate Decision`
 
-Each AI gate decision must link the issue, spec PR, Copilot review evidence, checks, findings, and next state.
+Each AI gate decision must link the issue, spec PR, configured automated review evidence, checks, findings, and next state.
 
 ## Operating Flow
 
 1. Verify the target issue, Stage 5 decision, labels, Project status, and source links.
 2. Run Stage 6 with `duumbi-spec-draft`.
-3. Verify the product spec PR exists, is spec-only, and has Copilot review requested.
-4. Wait for Copilot review and checks when they are not complete. If waiting is not possible in the current environment, stop with the next prompt.
+3. Verify the product spec PR exists, is spec-only, and has configured automated review requested.
+4. Wait for actual configured automated reviewer submissions and checks when they are not complete. A successful review-request check is not review evidence. If waiting is not possible in the current environment, stop with the next prompt.
 5. Run Stage 7 in AI-gate mode. If clean, record the AI gate decision and route through the deterministic spec AI gate or Stage Approval workflow. If not clean, stop with findings.
 6. Merge the product spec-only PR after the Stage 7 AI gate approval is recorded.
 7. Run Stage 8 with `duumbi-tech-spec-draft`.
-8. Verify the technical spec PR exists, is spec-only, and has Copilot review requested.
-9. Wait for Copilot review and checks when they are not complete. If waiting is not possible, stop with the next prompt.
+8. Verify the technical spec PR exists, is spec-only, and has configured automated review requested.
+9. Wait for actual configured automated reviewer submissions and checks when they are not complete. Resolve all review threads, including outdated threads after fixes. If waiting is not possible, stop with the next prompt.
 10. Run Stage 9 in AI-gate mode. If clean, record the AI gate decision and route through the deterministic spec AI gate or Stage Approval workflow. If not clean, stop with findings.
 11. Merge the technical spec-only PR after the Stage 9 AI gate approval is recorded.
 12. Run Stage 10 coordination with `duumbi-implementation`.
@@ -86,7 +88,7 @@ Before merging a spec-only PR:
 
 - verify the PR is not an implementation PR
 - verify the execution issue is referenced only with non-closing language
-- verify CI/check state and Copilot review are acceptable for the AI gate
+- verify CI/check state and configured automated review evidence are acceptable for the AI gate
 - verify the Stage 7 or Stage 9 AI gate decision comment exists
 - use squash merge by default
 
@@ -116,14 +118,14 @@ Delivery autopilot complete:
 **Spec PR merges:** <merged PRs or none>
 **Stage 10 state:** <Ready for Build | In Progress | Cycle Authorization | In Review | Blocked | not reached>
 **Ralph cycles processed:** <count or none>
-**Checks and Copilot evidence:** <summary>
+**Checks and automated review evidence:** <summary>
 **Open blockers:** <none or list>
 **Next prompt:** <copy-ready prompt if stopped>
 ```
 
 ## Safety Rules
 
-- Do not infer clean Copilot review from absence of a visible comment; verify review state when possible.
+- Do not infer clean automated review from absence of a visible comment or from a successful reviewer-request check; verify reviewer submissions and review-thread state when possible.
 - Do not self-approve specs outside the AI gate.
 - Do not continue after a failed gate.
 - Do not merge implementation PRs.

--- a/.agents/skills/duumbi-delivery-autopilot/SKILL.md
+++ b/.agents/skills/duumbi-delivery-autopilot/SKILL.md
@@ -13,12 +13,12 @@ This skill covers:
 
 - verifying one issue is accepted and in `Spec Needed`
 - running Stage 6 product spec draft through `duumbi-spec-draft`
-- waiting for or verifying actual configured automated reviewer submissions on
+- waiting for or verifying actual non-dismissed configured automated reviewer submissions on
   the product spec PR
 - running Stage 7 product spec review through `duumbi-spec-review` in AI-gate mode
 - merging the product spec-only PR only after a clean Stage 7 AI gate
 - running Stage 8 technical spec draft through `duumbi-tech-spec-draft`
-- waiting for or verifying actual configured automated reviewer submissions on
+- waiting for or verifying actual non-dismissed configured automated reviewer submissions on
   the technical spec PR
 - running Stage 9 technical spec review through `duumbi-tech-spec-review` in AI-gate mode
 - merging the technical spec-only PR only after a clean Stage 9 AI gate
@@ -70,12 +70,12 @@ Each AI gate decision must link the issue, spec PR, configured automated review 
 1. Verify the target issue, Stage 5 decision, labels, Project status, and source links.
 2. Run Stage 6 with `duumbi-spec-draft`.
 3. Verify the product spec PR exists, is spec-only, and has configured automated review requested.
-4. Wait for actual configured automated reviewer submissions and checks when they are not complete. A successful review-request check is not review evidence. If waiting is not possible in the current environment, stop with the next prompt.
+4. Wait for actual non-dismissed configured automated reviewer submissions and checks when they are not complete. A successful review-request check is not review evidence. If waiting is not possible in the current environment, stop with the next prompt.
 5. Run Stage 7 in AI-gate mode. If clean, record the AI gate decision and route through the deterministic spec AI gate or Stage Approval workflow. If not clean, stop with findings.
 6. Merge the product spec-only PR after the Stage 7 AI gate approval is recorded.
 7. Run Stage 8 with `duumbi-tech-spec-draft`.
 8. Verify the technical spec PR exists, is spec-only, and has configured automated review requested.
-9. Wait for actual configured automated reviewer submissions and checks when they are not complete. Resolve all review threads, including outdated threads after fixes. If waiting is not possible, stop with the next prompt.
+9. Wait for actual non-dismissed configured automated reviewer submissions and checks when they are not complete. Resolve all review threads, including outdated threads after fixes. If waiting is not possible, stop with the next prompt.
 10. Run Stage 9 in AI-gate mode. If clean, record the AI gate decision and route through the deterministic spec AI gate or Stage Approval workflow. If not clean, stop with findings.
 11. Merge the technical spec-only PR after the Stage 9 AI gate approval is recorded.
 12. Run Stage 10 coordination with `duumbi-implementation`.

--- a/.agents/skills/duumbi-spec-draft/SKILL.md
+++ b/.agents/skills/duumbi-spec-draft/SKILL.md
@@ -19,7 +19,7 @@ This skill covers:
 - adding English Gherkin-style BDD scenarios that express observable behavior
 - writing the product spec as a GitHub issue comment for small issues
 - creating `specs/DUUMBI-<issue-number>/PRODUCT.md` in the relevant source repository and opening a review-ready PR for larger, architectural, cross-module, or durable specs
-- marking the file-based spec PR ready for review, requesting configured automated review, addressing blocking review feedback, and reaching green checks before Slack approval is requested
+- marking the file-based spec PR ready for review, requesting configured automated review, waiting for actual reviewer submissions, addressing blocking review feedback, resolving review threads, and reaching green checks before Slack approval is requested
 - linking the spec artifact back to the GitHub Issue
 - moving the issue to `Spec Review`, or to `Needs Clarification` when blocked
 - keeping the execution issue open by avoiding GitHub auto-close keywords in spec-only PR titles, bodies, and commit messages
@@ -110,7 +110,11 @@ For file-based specs:
 - create or update only the spec file and minimal supporting metadata if required by the source repo
 - open the PR as a draft while the first artifact is being assembled
 - mark the PR ready for review after the spec artifact is complete and local checks are complete
-- request or wait for the configured automated reviewers when available, including Copilot review
+- request or wait for the configured automated reviewers when available. In this
+  repository the default required reviewers are `copilot-pull-request-reviewer`
+  and `chatgpt-codex-connector` unless repository configuration states
+  otherwise. Do not treat a successful reviewer-request check as completed
+  review evidence.
 - inspect review feedback and check results, fix blocking findings inside the spec file, and repeat until the PR is review-clean
 - link the review-ready PR and spec path from the GitHub Issue
 - treat the PR as a spec-review artifact only; it must not close the execution issue when merged or closed
@@ -178,7 +182,7 @@ After a successful spec artifact exists:
 - add existing `spec-review` label when available
 - do not mark the product spec approved
 - do not close the execution issue; it must remain open until Stage 12 closure verifies merged implementation evidence
-- for file-based specs, add `spec-review` only after the PR is no longer draft, checks are green, configured automated review is complete, and blocking review threads are resolved; the Stage 7 Slack approval will merge the spec PR if approved
+- for file-based specs, add `spec-review` only after the PR is no longer draft, checks are green, actual configured automated reviewer submissions exist, and every review thread is resolved, including outdated threads after fixes; the Stage 7 Slack approval will merge the spec PR if approved
 
 When blocked:
 
@@ -213,7 +217,7 @@ Product spec draft complete:
 - Do not bury blocking questions in a draft spec.
 - Do not create technical specs, implementation code, PRs for implementation, or Ralph cycles.
 - Do not approve your own product spec.
-- Do not request Slack approval for a file-based product spec while its PR is still draft, missing checks, missing configured automated review, or has unresolved blocking feedback.
+- Do not request Slack approval for a file-based product spec while its PR is still draft, missing checks, missing actual configured automated review evidence, or has any unresolved review thread.
 - Do not use GitHub auto-close keywords in spec-only PRs; only Stage 12 closure may close the execution issue.
 - Keep the spec traceable to source links and decisions.
 - Stop and ask the user if a requested write exceeds Stage 6.

--- a/.agents/skills/duumbi-spec-draft/SKILL.md
+++ b/.agents/skills/duumbi-spec-draft/SKILL.md
@@ -182,7 +182,7 @@ After a successful spec artifact exists:
 - add existing `spec-review` label when available
 - do not mark the product spec approved
 - do not close the execution issue; it must remain open until Stage 12 closure verifies merged implementation evidence
-- for file-based specs, add `spec-review` only after the PR is no longer draft, checks are green, actual configured automated reviewer submissions exist, and every review thread is resolved, including outdated threads after fixes; the Stage 7 Slack approval will merge the spec PR if approved
+- for file-based specs, add `spec-review` only after the PR is no longer draft, checks are green, actual non-dismissed configured automated reviewer submissions exist, and every review thread is resolved, including outdated threads after fixes; the Stage 7 Slack approval will merge the spec PR if approved
 
 When blocked:
 
@@ -217,7 +217,7 @@ Product spec draft complete:
 - Do not bury blocking questions in a draft spec.
 - Do not create technical specs, implementation code, PRs for implementation, or Ralph cycles.
 - Do not approve your own product spec.
-- Do not request Slack approval for a file-based product spec while its PR is still draft, missing checks, missing actual configured automated review evidence, or has any unresolved review thread.
+- Do not request Slack approval for a file-based product spec while its PR is still draft, missing checks, missing actual non-dismissed configured automated review evidence, or has any unresolved review thread.
 - Do not use GitHub auto-close keywords in spec-only PRs; only Stage 12 closure may close the execution issue.
 - Keep the spec traceable to source links and decisions.
 - Stop and ask the user if a requested write exceeds Stage 6.

--- a/.agents/skills/duumbi-spec-review/SKILL.md
+++ b/.agents/skills/duumbi-spec-review/SKILL.md
@@ -40,7 +40,13 @@ Before approving through the AI gate, verify all of these facts:
 
 - the product spec PR is a spec-only PR and contains no implementation code
 - the product spec PR is open, non-draft, review-clean, and ready for approval merge
-- Copilot review was requested and has no unresolved blocking feedback
+- each configured automated reviewer has submitted actual review evidence; in
+  this repository the default required reviewers are
+  `copilot-pull-request-reviewer` and `chatgpt-codex-connector` unless
+  repository configuration states otherwise
+- do not treat a successful reviewer-request check as completed review evidence
+- no latest automated or human review is `CHANGES_REQUESTED`
+- no review thread remains unresolved, including outdated threads after a fix
 - relevant checks are complete and passing, or the PR is documentation-only and checks are explicitly not applicable
 - the product spec satisfies the Review Checklist below
 - no unresolved product, scope, architecture, security, migration, cost, or user-facing trade-off question remains
@@ -80,7 +86,7 @@ When the prompt contains an explicit **Approve** decision (e.g. `Human decision:
 1. `gh issue view <N> --json number,title,labels,body` — verify `spec-review` label is present
 2. `gh issue view <N> --comments --json comments` — find the Stage 6 Product Spec Draft artifact link
 3. Construct and post the Stage 7 Decision Comment on the issue
-4. If the artifact is a PR, verify it is open, non-draft, changes only `specs/DUUMBI-<N>/PRODUCT.md`, has green checks, completed configured automated review, no blocking review decisions, and no unresolved review threads
+4. If the artifact is a PR, verify it is open, non-draft, changes only `specs/DUUMBI-<N>/PRODUCT.md`, has green checks, actual configured automated reviewer submissions, no blocking review decisions, and no unresolved review threads, including outdated unresolved threads
 5. If the artifact is a PR, squash-merge it with non-closing issue references such as `Related to #<N>`; do not close the execution issue
 6. Post a short pointer comment on the PR (if identifiable)
 7. Update labels: remove `needs-spec` and `spec-review`, add `product-spec-approved` and `needs-tech-spec`
@@ -201,7 +207,7 @@ For file-based specs, also comment on the PR with the same decision or a short p
 For `Approve`:
 
 - require explicit human approval or a fully satisfied AI gate
-- for file-based specs, require an open non-draft spec-only PR with green checks, completed configured automated review, no blocking review decisions, and no unresolved review threads
+- for file-based specs, require an open non-draft spec-only PR with green checks, actual configured automated reviewer submissions, no blocking review decisions, and no unresolved review threads
 - for file-based specs, squash-merge the product spec PR before moving the issue to `Technical Spec Needed`
 - write the decision comment
 - set Project Status to `Technical Spec Needed` when available

--- a/.agents/skills/duumbi-spec-review/SKILL.md
+++ b/.agents/skills/duumbi-spec-review/SKILL.md
@@ -40,8 +40,8 @@ Before approving through the AI gate, verify all of these facts:
 
 - the product spec PR is a spec-only PR and contains no implementation code
 - the product spec PR is open, non-draft, review-clean, and ready for approval merge
-- each configured automated reviewer has submitted actual review evidence; in
-  this repository the default required reviewers are
+- each configured automated reviewer has submitted actual, non-dismissed review
+  evidence; in this repository the default required reviewers are
   `copilot-pull-request-reviewer` and `chatgpt-codex-connector` unless
   repository configuration states otherwise
 - do not treat a successful reviewer-request check as completed review evidence
@@ -86,7 +86,7 @@ When the prompt contains an explicit **Approve** decision (e.g. `Human decision:
 1. `gh issue view <N> --json number,title,labels,body` — verify `spec-review` label is present
 2. `gh issue view <N> --comments --json comments` — find the Stage 6 Product Spec Draft artifact link
 3. Construct and post the Stage 7 Decision Comment on the issue
-4. If the artifact is a PR, verify it is open, non-draft, changes only `specs/DUUMBI-<N>/PRODUCT.md`, has green checks, actual configured automated reviewer submissions, no blocking review decisions, and no unresolved review threads, including outdated unresolved threads
+4. If the artifact is a PR, verify it is open, non-draft, changes only `specs/DUUMBI-<N>/PRODUCT.md`, has green checks, actual non-dismissed configured automated reviewer submissions, no blocking review decisions, and no unresolved review threads, including outdated unresolved threads
 5. If the artifact is a PR, squash-merge it with non-closing issue references such as `Related to #<N>`; do not close the execution issue
 6. Post a short pointer comment on the PR (if identifiable)
 7. Update labels: remove `needs-spec` and `spec-review`, add `product-spec-approved` and `needs-tech-spec`
@@ -207,7 +207,7 @@ For file-based specs, also comment on the PR with the same decision or a short p
 For `Approve`:
 
 - require explicit human approval or a fully satisfied AI gate
-- for file-based specs, require an open non-draft spec-only PR with green checks, actual configured automated reviewer submissions, no blocking review decisions, and no unresolved review threads
+- for file-based specs, require an open non-draft spec-only PR with green checks, actual non-dismissed configured automated reviewer submissions, no blocking review decisions, and no unresolved review threads
 - for file-based specs, squash-merge the product spec PR before moving the issue to `Technical Spec Needed`
 - write the decision comment
 - set Project Status to `Technical Spec Needed` when available

--- a/.agents/skills/duumbi-tech-spec-draft/SKILL.md
+++ b/.agents/skills/duumbi-tech-spec-draft/SKILL.md
@@ -150,8 +150,8 @@ are verified:
   references
 - CI/checks and status contexts are complete and passing, or explicitly
   not applicable for a docs-only diff
-- each configured automated reviewer has submitted actual review evidence;
-  review-request workflow success is not enough
+- each configured automated reviewer has submitted actual, non-dismissed review
+  evidence; review-request workflow success is not enough
 - no latest review is `CHANGES_REQUESTED`
 - no review thread remains unresolved, including outdated threads after a push
 - every blocking review finding has been addressed in the technical spec or the
@@ -310,7 +310,7 @@ Technical spec draft complete:
 - Do not modify implementation code, tests, migrations, generated outputs, or runtime assets.
 - Do not run Ralph cycles or implementation commands.
 - Do not approve your own technical spec.
-- Do not request Slack approval for a technical spec while its PR is still draft, missing checks, missing actual configured automated review evidence, or has any unresolved review thread.
+- Do not request Slack approval for a technical spec while its PR is still draft, missing checks, missing actual non-dismissed configured automated review evidence, or has any unresolved review thread.
 - Do not use GitHub auto-close keywords in spec-only PRs; only Stage 12 closure may close the execution issue.
 - Keep the technical spec traceable to the approved product spec and source evidence.
 - Stop and ask the user if a requested write exceeds Stage 8.

--- a/.agents/skills/duumbi-tech-spec-draft/SKILL.md
+++ b/.agents/skills/duumbi-tech-spec-draft/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: duumbi-tech-spec-draft
-description: "Run DUUMBI Stage 8 Technical Specification Preparation: turn one approved product spec in Technical Spec Needed into an English agent-facing specs/DUUMBI-<issue-number>/TECHNICAL.md review-ready PR with bounded Ralph-cycle instructions, then route to Technical Spec Review or Needs Clarification without modifying implementation code."
+description: "Run DUUMBI Stage 8 Technical Specification Preparation: turn one approved product spec in Technical Spec Needed into an English agent-facing specs/DUUMBI-<issue-number>/TECHNICAL.md review-clean PR with bounded Ralph-cycle instructions, then route to Technical Spec Review or Needs Clarification without modifying implementation code."
 ---
 
 You are the DUUMBI Technical Spec Draft Agent.
@@ -20,9 +20,10 @@ This skill covers:
 - defining at least one live LLM-backed E2E path through the canonical interface when the work touches LLM behavior
 - defining the Ralph Cycle resource policy, approval thresholds, and autonomous batch cap
 - opening a PR for the technical spec artifact
-- marking the technical spec PR ready for review, requesting configured automated review, addressing blocking review feedback, and reaching green checks before Slack approval is requested
+- marking the technical spec PR ready for review, requesting configured automated review, waiting for actual reviewer submissions, addressing blocking review feedback, resolving review threads, and reaching green checks before Slack approval is requested
 - linking the technical spec review-ready PR back to the GitHub Issue
 - moving the issue to `Technical Spec Review`, or to `Needs Clarification` when blocked
+- when the initiating prompt explicitly asks to continue through `Ready for Build`, handing off to `duumbi-tech-spec-review` after Stage 8 is review-clean so Stage 9 can process an explicit human or AI-gate approval, merge the spec PR, and advance the issue
 - keeping the execution issue open by avoiding GitHub auto-close keywords in spec-only PR titles, bodies, and commit messages
 
 This skill does not:
@@ -35,7 +36,7 @@ This skill does not:
 - create new GitHub labels or Project fields
 - create Obsidian artifacts during normal operation
 
-Stage 9 owns technical spec review and approval. Stage 10 owns implementation.
+Stage 9 owns technical spec review, approval, spec PR merge, and `Ready for Build` routing. Stage 10 owns implementation. This skill may hand off to Stage 9 when the user prompt explicitly requests the end-to-end Stage 8-to-Ready continuation, but it must not self-approve the technical spec.
 
 ## Source Of Truth Rules
 
@@ -128,11 +129,38 @@ specs/DUUMBI-<issue-number>/TECHNICAL.md
 
 Open a PR for the technical spec artifact and link it from the GitHub Issue. Use draft
 state while assembling the first artifact, then mark it ready for review, request
-or wait for configured automated reviewers including Copilot when available,
-address blocking review feedback inside `TECHNICAL.md`, and continue until checks
-are green and blocking review threads are resolved. Only then route the issue to
-`Technical Spec Review`; Stage 9 Slack approval will merge the spec PR if
-approved.
+or wait for configured automated reviewers. In this repository the default
+configured automated reviewers are `copilot-pull-request-reviewer` and
+`chatgpt-codex-connector` unless repository configuration states otherwise.
+Do not treat a successful "Request Copilot Review" check as completed review
+evidence; it only proves the request was sent. Address blocking review feedback
+inside `TECHNICAL.md`, push the fix, and continue until checks are green and all
+review threads are resolved, including threads that became outdated after the
+fix. Only then route the issue to `Technical Spec Review`; Stage 9 Slack or AI
+approval will merge the spec PR if approved.
+
+## Review-Clean Definition
+
+A file-based Stage 8 technical spec PR is review-clean only when all of these
+are verified:
+
+- the PR is open, non-draft, spec-only, and changes only
+  `specs/DUUMBI-<issue-number>/TECHNICAL.md`
+- the PR title, body, commits, and spec text use only non-closing issue
+  references
+- CI/checks and status contexts are complete and passing, or explicitly
+  not applicable for a docs-only diff
+- each configured automated reviewer has submitted actual review evidence;
+  review-request workflow success is not enough
+- no latest review is `CHANGES_REQUESTED`
+- no review thread remains unresolved, including outdated threads after a push
+- every blocking review finding has been addressed in the technical spec or the
+  issue has been routed back to `Needs Clarification`
+
+If a reviewer comments after you thought the PR was ready, reopen the Stage 8
+loop: inspect the finding, patch only `TECHNICAL.md`, push, wait for checks and
+configured review evidence again, resolve the thread after verifying the fix,
+and only then continue.
 
 ## Technical Spec Contract
 
@@ -241,7 +269,11 @@ After a successful technical spec artifact exists:
 - add existing `technical-spec-review` label when available
 - do not mark the technical spec approved
 - do not close the execution issue; it must remain open until Stage 12 closure verifies merged implementation evidence
-- add `technical-spec-review` only after the PR is no longer draft, checks are green, configured automated review is complete, and blocking review threads are resolved
+- add `technical-spec-review` only after the PR satisfies the Review-Clean Definition above
+- if the user prompt requests continuation through `Ready for Build`, invoke
+  Stage 9 with `duumbi-tech-spec-review` after adding `technical-spec-review`;
+  Stage 9 must revalidate the PR, require explicit approval or a satisfied AI
+  gate, merge the spec PR, update GitHub state, and send the next prompt
 
 When blocked:
 
@@ -278,7 +310,7 @@ Technical spec draft complete:
 - Do not modify implementation code, tests, migrations, generated outputs, or runtime assets.
 - Do not run Ralph cycles or implementation commands.
 - Do not approve your own technical spec.
-- Do not request Slack approval for a technical spec while its PR is still draft, missing checks, missing configured automated review, or has unresolved blocking feedback.
+- Do not request Slack approval for a technical spec while its PR is still draft, missing checks, missing actual configured automated review evidence, or has any unresolved review thread.
 - Do not use GitHub auto-close keywords in spec-only PRs; only Stage 12 closure may close the execution issue.
 - Keep the technical spec traceable to the approved product spec and source evidence.
 - Stop and ask the user if a requested write exceeds Stage 8.

--- a/.agents/skills/duumbi-tech-spec-review/SKILL.md
+++ b/.agents/skills/duumbi-tech-spec-review/SKILL.md
@@ -36,13 +36,20 @@ Stage 8 owns technical spec drafting and revision. Stage 10 owns Ralph-cycle imp
 
 ## AI Gate Requirements
 
-The AI gate is allowed only for Stage 9 technical spec approval and only when invoked by a delivery-autopilot or spec-ai-gate workflow prompt that explicitly requests AI-gated review.
+The AI gate is allowed only for Stage 9 technical spec approval and only when invoked by a delivery-autopilot prompt, a spec-ai-gate workflow prompt, or a generated Stage 8-to-Ready prompt that explicitly requests AI-gated review.
 
 Before approving through the AI gate, verify all of these facts:
 
 - the technical spec PR is a spec-only PR and contains no implementation code or test edits
 - the technical spec PR is open, non-draft, review-clean, and ready for approval merge
-- Copilot review was requested and has no unresolved blocking feedback
+- each configured automated reviewer has submitted actual review evidence; in
+  this repository the default required reviewers are
+  `copilot-pull-request-reviewer` and `chatgpt-codex-connector` unless
+  repository configuration states otherwise
+- do not treat a successful review-request check, including `Request Copilot
+  Review`, as completed review evidence
+- no latest automated or human review is `CHANGES_REQUESTED`
+- no review thread remains unresolved, including outdated threads after a fix
 - relevant checks are complete and passing, or the PR is documentation-only and checks are explicitly not applicable
 - the technical spec satisfies the Review Checklist below
 - the Ralph Cycle resource policy includes the USD 2, 10 external call, scope-expansion, risky-dependency, migration, security, blocker, and product/architecture decision gates
@@ -83,7 +90,7 @@ When the prompt contains an explicit **Approve** decision (e.g. `Human decision:
 
 1. `gh issue view <N> --json number,title,labels,body` — verify `technical-spec-review` label is present
 2. `gh issue view <N> --comments --json comments` — find the Stage 8 Technical Spec Draft artifact link and product spec link from existing comments (search for "Stage 8 Technical Spec Draft" and "Stage 6 Product Spec Draft")
-3. Verify the technical spec PR is open, non-draft, changes only `specs/DUUMBI-<N>/TECHNICAL.md`, has green checks, completed configured automated review, no blocking review decisions, and no unresolved review threads
+3. Verify the technical spec PR is open, non-draft, changes only `specs/DUUMBI-<N>/TECHNICAL.md`, has green checks, actual configured automated reviewer submissions, no blocking review decisions, and no unresolved review threads, including outdated unresolved threads
 4. Squash-merge the technical spec PR with non-closing issue references such as `Related to #<N>`; do not close the execution issue
 5. Construct and post the Stage 9 Decision Comment on the issue (use the Decision Comment template below)
 6. Post a short pointer comment on the tech spec PR
@@ -233,7 +240,10 @@ For file-based technical specs, also comment on the PR with the same decision or
 For `Approve`:
 
 - require explicit human approval or a fully satisfied AI gate
-- require an open non-draft spec-only PR with green checks, completed configured automated review, no blocking review decisions, and no unresolved review threads
+- require an open non-draft spec-only PR with green checks, actual configured automated reviewer submissions, no blocking review decisions, and no unresolved review threads
+- fail closed if the only automated-review evidence is a successful reviewer
+  request workflow; the reviewer must have submitted a review or equivalent
+  configured evidence
 - squash-merge the technical spec PR before moving the issue to `Ready for Build`
 - write the decision comment
 - comment on the technical spec PR when available

--- a/.agents/skills/duumbi-tech-spec-review/SKILL.md
+++ b/.agents/skills/duumbi-tech-spec-review/SKILL.md
@@ -42,8 +42,8 @@ Before approving through the AI gate, verify all of these facts:
 
 - the technical spec PR is a spec-only PR and contains no implementation code or test edits
 - the technical spec PR is open, non-draft, review-clean, and ready for approval merge
-- each configured automated reviewer has submitted actual review evidence; in
-  this repository the default required reviewers are
+- each configured automated reviewer has submitted actual, non-dismissed review
+  evidence; in this repository the default required reviewers are
   `copilot-pull-request-reviewer` and `chatgpt-codex-connector` unless
   repository configuration states otherwise
 - do not treat a successful review-request check, including `Request Copilot
@@ -90,7 +90,7 @@ When the prompt contains an explicit **Approve** decision (e.g. `Human decision:
 
 1. `gh issue view <N> --json number,title,labels,body` — verify `technical-spec-review` label is present
 2. `gh issue view <N> --comments --json comments` — find the Stage 8 Technical Spec Draft artifact link and product spec link from existing comments (search for "Stage 8 Technical Spec Draft" and "Stage 6 Product Spec Draft")
-3. Verify the technical spec PR is open, non-draft, changes only `specs/DUUMBI-<N>/TECHNICAL.md`, has green checks, actual configured automated reviewer submissions, no blocking review decisions, and no unresolved review threads, including outdated unresolved threads
+3. Verify the technical spec PR is open, non-draft, changes only `specs/DUUMBI-<N>/TECHNICAL.md`, has green checks, actual non-dismissed configured automated reviewer submissions, no blocking review decisions, and no unresolved review threads, including outdated unresolved threads
 4. Squash-merge the technical spec PR with non-closing issue references such as `Related to #<N>`; do not close the execution issue
 5. Construct and post the Stage 9 Decision Comment on the issue (use the Decision Comment template below)
 6. Post a short pointer comment on the tech spec PR
@@ -240,7 +240,7 @@ For file-based technical specs, also comment on the PR with the same decision or
 For `Approve`:
 
 - require explicit human approval or a fully satisfied AI gate
-- require an open non-draft spec-only PR with green checks, actual configured automated reviewer submissions, no blocking review decisions, and no unresolved review threads
+- require an open non-draft spec-only PR with green checks, actual non-dismissed configured automated reviewer submissions, no blocking review decisions, and no unresolved review threads
 - fail closed if the only automated-review evidence is a successful reviewer
   request workflow; the reviewer must have submitted a review or equivalent
   configured evidence

--- a/.github/workflows/spec-ai-gate.yml
+++ b/.github/workflows/spec-ai-gate.yml
@@ -26,7 +26,12 @@ on:
         required: true
         type: string
       copilot_evidence:
-        description: Link or summary of Copilot review evidence
+        description: 'Deprecated: link or summary of automated review evidence'
+        required: false
+        type: string
+        default: ''
+      automated_review_evidence:
+        description: Link or summary of configured automated review evidence
         required: false
         type: string
         default: ''
@@ -63,7 +68,13 @@ jobs:
             const prNumber = Number(raw.pr_number || 0);
             const decision = String(raw.decision || "");
             const rationale = String(raw.rationale || "");
-            const copilotEvidence = String(raw.copilot_evidence || raw.copilotEvidence || "");
+            const automatedReviewEvidence = String(
+              raw.automated_review_evidence ||
+              raw.automatedReviewEvidence ||
+              raw.copilot_evidence ||
+              raw.copilotEvidence ||
+              "",
+            );
             const validStages = new Set(["7", "9"]);
             const validDecisions = new Set(["approve", "request-changes", "needs-clarification", "reject"]);
             if (!validStages.has(stage)) throw new Error(`Unsupported spec AI gate stage: ${stage}`);
@@ -89,9 +100,9 @@ jobs:
               `**Decision:** ${decision}`,
               `**Reviewer source:** Codex AI Gate`,
               `**Spec PR:** ${prUrl}`,
-              `**Copilot evidence:** ${copilotEvidence || "verified by invoking agent; no link provided"}`,
+              `**Automated review evidence:** ${automatedReviewEvidence || "verified by invoking agent; no link provided"}`,
               `**Rationale:** ${rationale}`,
-              `**Gate policy:** fail-closed if Copilot review, checks, scope, or blocking findings are missing`,
+              `**Gate policy:** fail-closed if configured automated review, checks, scope, or blocking findings are missing`,
               `**Next state:** ${nextState}`,
             ].join("\n");
 
@@ -186,8 +197,8 @@ jobs:
                 issues_considered: 1,
                 issues_queued: null,
                 slack_notifications_attempted: 0,
-                artifact_links_found: copilotEvidence ? 1 : 0,
-                artifact_links_missing: copilotEvidence ? 0 : 1,
+                artifact_links_found: automatedReviewEvidence ? 1 : 0,
+                artifact_links_missing: automatedReviewEvidence ? 0 : 1,
               },
               provider_usage: {
                 available: false,

--- a/.github/workflows/spec-review-request.yml
+++ b/.github/workflows/spec-review-request.yml
@@ -154,9 +154,14 @@ jobs:
                 .map((reviewer) => reviewer.trim())
                 .filter(Boolean);
 
+            const validReviewEvidenceStates = new Set(["APPROVED", "COMMENTED", "CHANGES_REQUESTED"]);
+
             const missingRequiredReviewers = (latestReviews) => {
               const reviewActors = new Set(
-                latestReviews.map((review) => String(review.user?.login || "").toLowerCase()).filter(Boolean),
+                latestReviews
+                  .filter((review) => validReviewEvidenceStates.has(String(review.state || "").toUpperCase()))
+                  .map((review) => String(review.user?.login || "").toLowerCase())
+                  .filter(Boolean),
               );
               return requiredAutomatedReviewers().filter((reviewer) => !reviewActors.has(reviewer.toLowerCase()));
             };

--- a/.github/workflows/spec-review-request.yml
+++ b/.github/workflows/spec-review-request.yml
@@ -56,6 +56,7 @@ jobs:
           INPUT_ISSUE_URL: ${{ inputs.issue_url || '' }}
           INPUT_ISSUE_NUMBER: ${{ inputs.issue_number || '' }}
           INPUT_STATUS: ${{ inputs.status || '' }}
+          DUUMBI_REQUIRED_SPEC_REVIEWERS: ${{ vars.DUUMBI_REQUIRED_SPEC_REVIEWERS || 'copilot-pull-request-reviewer,chatgpt-codex-connector' }}
         with:
           script: |
             const marker = "<!-- duumbi-spec-review-slack-notified -->";
@@ -147,6 +148,19 @@ jobs:
               return [...latest.values()];
             };
 
+            const requiredAutomatedReviewers = () =>
+              String(process.env.DUUMBI_REQUIRED_SPEC_REVIEWERS || "copilot-pull-request-reviewer,chatgpt-codex-connector")
+                .split(",")
+                .map((reviewer) => reviewer.trim())
+                .filter(Boolean);
+
+            const missingRequiredReviewers = (latestReviews) => {
+              const reviewActors = new Set(
+                latestReviews.map((review) => String(review.user?.login || "").toLowerCase()).filter(Boolean),
+              );
+              return requiredAutomatedReviewers().filter((reviewer) => !reviewActors.has(reviewer.toLowerCase()));
+            };
+
             const findUnresolvedReviewThreads = async (pullNumber) => {
               const unresolved = [];
               let cursor = null;
@@ -170,8 +184,9 @@ jobs:
                 );
                 const threads = data.repository?.pullRequest?.reviewThreads;
                 for (const thread of threads?.nodes || []) {
-                  if (!thread.isResolved && !thread.isOutdated) {
-                    unresolved.push(thread.comments?.nodes?.[0]?.url || `review thread on PR #${pullNumber}`);
+                  if (!thread.isResolved) {
+                    const state = thread.isOutdated ? "outdated unresolved" : "active unresolved";
+                    unresolved.push(`${thread.comments?.nodes?.[0]?.url || `review thread on PR #${pullNumber}`} (${state})`);
                   }
                 }
                 cursor = threads?.pageInfo?.hasNextPage ? threads.pageInfo.endCursor : null;
@@ -243,14 +258,15 @@ jobs:
                 per_page: 100,
               });
               const latestReviews = latestReviewsByActor(reviews);
-              const copilotReviews = latestReviews.filter((review) => /copilot/i.test(review.user?.login || ""));
               const blockingReviews = latestReviews.filter((review) => review.state === "CHANGES_REQUESTED");
-              const successfulCopilotCheck = checkRuns.some((check) =>
-                /copilot/i.test(check.name || "") &&
-                check.status === "completed" &&
-                ["success", "neutral", "skipped"].includes(check.conclusion)
-              );
-              if (copilotReviews.length === 0 && !successfulCopilotCheck) return { ready: false, prNumber, summary: "Copilot review evidence has not completed" };
+              const missingReviewers = missingRequiredReviewers(latestReviews);
+              if (missingReviewers.length > 0) {
+                return {
+                  ready: false,
+                  prNumber,
+                  summary: `required automated review evidence missing from ${missingReviewers.join(", ")}; review-request checks do not count`,
+                };
+              }
               if (blockingReviews.length > 0) return { ready: false, prNumber, summary: "blocking review decision remains" };
 
               const unresolvedThreads = await findUnresolvedReviewThreads(prNumber);

--- a/.github/workflows/stage-approval.yml
+++ b/.github/workflows/stage-approval.yml
@@ -341,9 +341,14 @@ jobs:
                 .map((reviewer) => reviewer.trim())
                 .filter(Boolean);
 
+            const validReviewEvidenceStates = new Set(['APPROVED', 'COMMENTED', 'CHANGES_REQUESTED']);
+
             const missingRequiredReviewers = (latestReviews) => {
               const reviewActors = new Set(
-                latestReviews.map((review) => String(review.user?.login || '').toLowerCase()).filter(Boolean),
+                latestReviews
+                  .filter((review) => validReviewEvidenceStates.has(String(review.state || '').toUpperCase()))
+                  .map((review) => String(review.user?.login || '').toLowerCase())
+                  .filter(Boolean),
               );
               return requiredAutomatedReviewers().filter((reviewer) => !reviewActors.has(reviewer.toLowerCase()));
             };

--- a/.github/workflows/stage-approval.yml
+++ b/.github/workflows/stage-approval.yml
@@ -59,6 +59,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_REVIEW_CHANNEL_ID: ${{ secrets.SLACK_REVIEW_CHANNEL_ID }}
           INPUT_SLACK_RESPONSE_URL: ${{ github.event.client_payload.slack_response_url || '' }}
+          DUUMBI_REQUIRED_SPEC_REVIEWERS: ${{ vars.DUUMBI_REQUIRED_SPEC_REVIEWERS || 'copilot-pull-request-reviewer,chatgpt-codex-connector' }}
         with:
           script: |
             // ── Inputs ──────────────────────────────────────────────
@@ -252,7 +253,7 @@ jobs:
                   `Target issue: ${issueUrl}`,
                   `Expected artifact: specs/DUUMBI-${issueNumber}/PRODUCT.md, unless the skill determines that an issue-comment spec is sufficient.`,
                   '',
-                  'Goal: Verify Stage 5 acceptance, inspect active DUUMBI context and relevant source context, draft the product spec in English with BDD Scenarios, open a spec PR if file-based, mark it ready for review, address blocking review feedback until checks and configured automated review are clean, link it from the issue, and move the issue to Spec Review only after it is ready for approval merge.',
+                  'Goal: Verify Stage 5 acceptance, inspect active DUUMBI context and relevant source context, draft the product spec in English with BDD Scenarios, open a spec PR if file-based, mark it ready for review, wait for actual configured automated reviewer submissions, address blocking review feedback until checks and automated reviews are clean, resolve review threads after verifying the fixes, link it from the issue, and move the issue to Spec Review only after it is ready for approval merge.',
                   '',
                   `Spec-only PR rule: use non-closing issue references such as "Related to #${issueNumber}" or "Spec for #${issueNumber}". Include a workflow note that this PR must leave the execution issue open.`,
                   '',
@@ -262,17 +263,17 @@ jobs:
 
               if (stage === '7') {
                 return [
-                  'Run DUUMBI Stage 8 Technical Spec Draft with duumbi-tech-spec-draft.',
+                  'Run DUUMBI Stage 8 Technical Spec Draft with duumbi-tech-spec-draft, then run Stage 9 Technical Spec Review with duumbi-tech-spec-review in AI-gate mode when the gate requirements are satisfied; otherwise stop and request human approval.',
                   '',
                   `Target issue: ${issueUrl}`,
                   `Product spec artifact: ${knownProductSpec}`,
                   `Expected artifact: specs/DUUMBI-${issueNumber}/TECHNICAL.md`,
                   '',
-                  'Goal: Verify product spec approval, inspect repo AGENTS.md and affected source areas, draft an agent-facing technical spec with BDD-to-test mapping, live E2E plan, and Ralph Cycle resource policy, open a technical spec PR, mark it ready for review, address blocking review feedback until checks and configured automated review are clean, link it from the issue, and move the issue to Technical Spec Review only after it is ready for approval merge.',
+                  'Goal: Verify product spec approval, inspect repo AGENTS.md and affected source areas, draft an agent-facing technical spec with BDD-to-test mapping, live E2E plan, and Ralph Cycle resource policy, open a technical spec PR, mark it ready for review, wait for actual configured automated reviewer submissions, address blocking review feedback until checks and automated reviews are clean, resolve review threads after verifying the fixes, link it from the issue, move the issue to Technical Spec Review only after it is ready for approval merge, then record Stage 9 approval through the configured AI or human gate, merge the spec PR, move the issue to Ready for Build, and send the Stage 10 prompt.',
                   '',
                   `Spec-only PR rule: use non-closing issue references such as "Related to #${issueNumber}" or "Technical spec for #${issueNumber}". Include a workflow note that this PR must leave the execution issue open.`,
                   '',
-                  'Do not modify implementation code, tests, generated artifacts, runtime assets, or product specs. Do not approve the technical spec or run Ralph cycles.',
+                  'Do not modify implementation code, tests, generated artifacts, runtime assets, or product specs. Do not bypass Stage 9 approval, do not approve if the AI/human gate is missing, and do not run Ralph cycles.',
                 ].join('\n');
               }
 
@@ -334,6 +335,19 @@ jobs:
               return [...latest.values()];
             };
 
+            const requiredAutomatedReviewers = () =>
+              String(process.env.DUUMBI_REQUIRED_SPEC_REVIEWERS || 'copilot-pull-request-reviewer,chatgpt-codex-connector')
+                .split(',')
+                .map((reviewer) => reviewer.trim())
+                .filter(Boolean);
+
+            const missingRequiredReviewers = (latestReviews) => {
+              const reviewActors = new Set(
+                latestReviews.map((review) => String(review.user?.login || '').toLowerCase()).filter(Boolean),
+              );
+              return requiredAutomatedReviewers().filter((reviewer) => !reviewActors.has(reviewer.toLowerCase()));
+            };
+
             const findUnresolvedReviewThreads = async (pullNumber) => {
               const unresolved = [];
               let cursor = null;
@@ -362,9 +376,10 @@ jobs:
                 );
                 const threads = data.repository?.pullRequest?.reviewThreads;
                 for (const thread of threads?.nodes || []) {
-                  if (!thread.isResolved && !thread.isOutdated) {
+                  if (!thread.isResolved) {
                     const firstComment = thread.comments?.nodes?.[0];
-                    unresolved.push(firstComment?.url || `review thread by ${firstComment?.author?.login || 'unknown'}`);
+                    const state = thread.isOutdated ? 'outdated unresolved' : 'active unresolved';
+                    unresolved.push(`${firstComment?.url || `review thread by ${firstComment?.author?.login || 'unknown'}`} (${state})`);
                   }
                 }
                 cursor = threads?.pageInfo?.hasNextPage ? threads.pageInfo.endCursor : null;
@@ -384,7 +399,7 @@ jobs:
                     expectedPath: policy.expectedPath,
                     checkCount: 0,
                     reviewCount: 0,
-                    copilotReviewCount: 0,
+                    requiredReviewers: [],
                     issueCommentArtifact: true,
                   };
                 }
@@ -455,14 +470,9 @@ jobs:
               });
               const latestReviews = latestReviewsByActor(reviews);
               const blockingReviews = latestReviews.filter((review) => review.state === 'CHANGES_REQUESTED');
-              const copilotReviews = latestReviews.filter((review) => /copilot/i.test(review.user?.login || ''));
-              const successfulCopilotCheck = checkRuns.some((check) =>
-                /copilot/i.test(check.name || '') &&
-                check.status === 'completed' &&
-                ['success', 'neutral', 'skipped'].includes(check.conclusion)
-              );
-              if (copilotReviews.length === 0 && !successfulCopilotCheck) {
-                throw new Error(`${policy.kind} PR #${prNumber} has no completed Copilot review evidence; approval waits for review and fixes.`);
+              const missingReviewers = missingRequiredReviewers(latestReviews);
+              if (missingReviewers.length > 0) {
+                throw new Error(`${policy.kind} PR #${prNumber} is missing required automated review evidence from: ${missingReviewers.join(', ')}. A review-request check is not enough; approval waits for actual reviewer submissions and fixes.`);
               }
               if (blockingReviews.length > 0) {
                 throw new Error(`${policy.kind} PR #${prNumber} has blocking review decisions: ${blockingReviews.map((review) => `${review.user?.login || 'unknown'}:${review.state}`).join(', ')}`);
@@ -481,7 +491,7 @@ jobs:
                   expectedPath: policy.expectedPath,
                   checkCount: checkRuns.length + statuses.length,
                   reviewCount: latestReviews.length,
-                  copilotReviewCount: copilotReviews.length,
+                  requiredReviewers: requiredAutomatedReviewers(),
                   alreadyMerged: true,
                 };
               }
@@ -502,7 +512,7 @@ jobs:
                 expectedPath: policy.expectedPath,
                 checkCount: checkRuns.length + statuses.length,
                 reviewCount: latestReviews.length,
-                copilotReviewCount: copilotReviews.length,
+                requiredReviewers: requiredAutomatedReviewers(),
               };
             };
 

--- a/.github/workflows/technical-spec-review-request.yml
+++ b/.github/workflows/technical-spec-review-request.yml
@@ -165,9 +165,14 @@ jobs:
                 .map((reviewer) => reviewer.trim())
                 .filter(Boolean);
 
+            const validReviewEvidenceStates = new Set(["APPROVED", "COMMENTED", "CHANGES_REQUESTED"]);
+
             const missingRequiredReviewers = (latestReviews) => {
               const reviewActors = new Set(
-                latestReviews.map((review) => String(review.user?.login || "").toLowerCase()).filter(Boolean),
+                latestReviews
+                  .filter((review) => validReviewEvidenceStates.has(String(review.state || "").toUpperCase()))
+                  .map((review) => String(review.user?.login || "").toLowerCase())
+                  .filter(Boolean),
               );
               return requiredAutomatedReviewers().filter((reviewer) => !reviewActors.has(reviewer.toLowerCase()));
             };

--- a/.github/workflows/technical-spec-review-request.yml
+++ b/.github/workflows/technical-spec-review-request.yml
@@ -56,6 +56,7 @@ jobs:
           INPUT_ISSUE_URL: ${{ inputs.issue_url || '' }}
           INPUT_ISSUE_NUMBER: ${{ inputs.issue_number || '' }}
           INPUT_STATUS: ${{ inputs.status || '' }}
+          DUUMBI_REQUIRED_SPEC_REVIEWERS: ${{ vars.DUUMBI_REQUIRED_SPEC_REVIEWERS || 'copilot-pull-request-reviewer,chatgpt-codex-connector' }}
         with:
           script: |
             const marker = "<!-- duumbi-tech-spec-review-slack-notified -->";
@@ -158,6 +159,19 @@ jobs:
               return [...latest.values()];
             };
 
+            const requiredAutomatedReviewers = () =>
+              String(process.env.DUUMBI_REQUIRED_SPEC_REVIEWERS || "copilot-pull-request-reviewer,chatgpt-codex-connector")
+                .split(",")
+                .map((reviewer) => reviewer.trim())
+                .filter(Boolean);
+
+            const missingRequiredReviewers = (latestReviews) => {
+              const reviewActors = new Set(
+                latestReviews.map((review) => String(review.user?.login || "").toLowerCase()).filter(Boolean),
+              );
+              return requiredAutomatedReviewers().filter((reviewer) => !reviewActors.has(reviewer.toLowerCase()));
+            };
+
             const findUnresolvedReviewThreads = async (pullNumber) => {
               const unresolved = [];
               let cursor = null;
@@ -181,8 +195,9 @@ jobs:
                 );
                 const threads = data.repository?.pullRequest?.reviewThreads;
                 for (const thread of threads?.nodes || []) {
-                  if (!thread.isResolved && !thread.isOutdated) {
-                    unresolved.push(thread.comments?.nodes?.[0]?.url || `review thread on PR #${pullNumber}`);
+                  if (!thread.isResolved) {
+                    const state = thread.isOutdated ? "outdated unresolved" : "active unresolved";
+                    unresolved.push(`${thread.comments?.nodes?.[0]?.url || `review thread on PR #${pullNumber}`} (${state})`);
                   }
                 }
                 cursor = threads?.pageInfo?.hasNextPage ? threads.pageInfo.endCursor : null;
@@ -254,14 +269,15 @@ jobs:
                 per_page: 100,
               });
               const latestReviews = latestReviewsByActor(reviews);
-              const copilotReviews = latestReviews.filter((review) => /copilot/i.test(review.user?.login || ""));
               const blockingReviews = latestReviews.filter((review) => review.state === "CHANGES_REQUESTED");
-              const successfulCopilotCheck = checkRuns.some((check) =>
-                /copilot/i.test(check.name || "") &&
-                check.status === "completed" &&
-                ["success", "neutral", "skipped"].includes(check.conclusion)
-              );
-              if (copilotReviews.length === 0 && !successfulCopilotCheck) return { ready: false, prNumber, summary: "Copilot review evidence has not completed" };
+              const missingReviewers = missingRequiredReviewers(latestReviews);
+              if (missingReviewers.length > 0) {
+                return {
+                  ready: false,
+                  prNumber,
+                  summary: `required automated review evidence missing from ${missingReviewers.join(", ")}; review-request checks do not count`,
+                };
+              }
               if (blockingReviews.length > 0) return { ready: false, prNumber, summary: "blocking review decision remains" };
 
               const unresolvedThreads = await findUnresolvedReviewThreads(prNumber);

--- a/docs/automation/agentic-development-orchestration.md
+++ b/docs/automation/agentic-development-orchestration.md
@@ -131,9 +131,10 @@ Stage 7 and Stage 9 AI gates may approve only when:
 
 - the PR is spec-only
 - the PR is open, non-draft, and ready for approval merge
-- actual configured automated review submissions exist. By default this means
-  `copilot-pull-request-reviewer` and `chatgpt-codex-connector`; repositories
-  can override the comma-separated list with `DUUMBI_REQUIRED_SPEC_REVIEWERS`
+- actual non-dismissed configured automated review submissions exist. By
+  default this means `copilot-pull-request-reviewer` and
+  `chatgpt-codex-connector`; repositories can override the comma-separated list
+  with `DUUMBI_REQUIRED_SPEC_REVIEWERS`
 - reviewer-request workflow success does not count as review evidence
 - automated reviews and human reviews have no blocking `CHANGES_REQUESTED`
   decision
@@ -147,7 +148,7 @@ Stage 7 and Stage 9 AI gates may approve only when:
 Stage 7 and Stage 9 human Slack approvals are merge finalizers for file-based
 specs. The review request workflows send Slack approval cards only after the
 linked PRODUCT.md or TECHNICAL.md PR is review-clean. Review-clean means the
-PR has actual configured automated reviewer submissions, green checks, no
+PR has actual non-dismissed configured automated reviewer submissions, green checks, no
 blocking review decisions, and no unresolved review threads. Approval then
 revalidates the exact PR, squash-merges the spec artifact with non-closing issue
 references, records the stage decision, and advances the issue to the next

--- a/docs/automation/agentic-development-orchestration.md
+++ b/docs/automation/agentic-development-orchestration.md
@@ -28,8 +28,9 @@ or source-repo contracts that support it.
 - `duumbi-obsidian-capture` and `duumbi-codex-intake` now search active Inbox,
   Processed Inbox, Atlas, and GitHub before creating duplicate notes.
 - `duumbi-spec-review` and `duumbi-tech-spec-review` now support bounded AI
-  gates while still failing closed on missing Copilot, checks, scope,
-  unresolved findings, or unmerged spec PR readiness.
+  gates while still failing closed on missing configured automated review
+  submissions, checks, scope, unresolved findings, or unmerged spec PR
+  readiness.
 
 ## Workflows Added
 
@@ -130,7 +131,14 @@ Stage 7 and Stage 9 AI gates may approve only when:
 
 - the PR is spec-only
 - the PR is open, non-draft, and ready for approval merge
-- Copilot review exists and has no unresolved blocking feedback
+- actual configured automated review submissions exist. By default this means
+  `copilot-pull-request-reviewer` and `chatgpt-codex-connector`; repositories
+  can override the comma-separated list with `DUUMBI_REQUIRED_SPEC_REVIEWERS`
+- reviewer-request workflow success does not count as review evidence
+- automated reviews and human reviews have no blocking `CHANGES_REQUESTED`
+  decision
+- every review thread is resolved, including threads that became outdated after
+  a fix
 - relevant checks are passing or explicitly not applicable
 - no product, architecture, security, migration, cost, scope, or verification
   question remains
@@ -138,11 +146,21 @@ Stage 7 and Stage 9 AI gates may approve only when:
 
 Stage 7 and Stage 9 human Slack approvals are merge finalizers for file-based
 specs. The review request workflows send Slack approval cards only after the
-linked PRODUCT.md or TECHNICAL.md PR is review-clean. Approval then revalidates
-the exact PR, squash-merges the spec artifact with non-closing issue references,
-records the stage decision, and advances the issue to the next workflow state.
-If the PR is draft, dirty, not spec-only, missing Copilot review, or has
-unresolved review threads, the workflow fails closed or defers notification.
+linked PRODUCT.md or TECHNICAL.md PR is review-clean. Review-clean means the
+PR has actual configured automated reviewer submissions, green checks, no
+blocking review decisions, and no unresolved review threads. Approval then
+revalidates the exact PR, squash-merges the spec artifact with non-closing issue
+references, records the stage decision, and advances the issue to the next
+workflow state. If the PR is draft, dirty, not spec-only, missing required
+reviewer submissions, or has unresolved review threads, the workflow fails
+closed or defers notification.
+
+The Stage 7 approval prompt is intentionally a Stage 8-to-Ready handoff. It
+instructs Codex to draft the technical spec, wait for configured automated
+reviewers, fix and resolve review feedback, route to `Technical Spec Review`,
+then run Stage 9 through the configured AI or human gate. Only a satisfied
+Stage 9 gate may merge the technical spec PR, move the issue to `Ready for
+Build`, and send the Stage 10 prompt.
 
 Stage 11 merge remains human-authorized. The merge workflow requires explicit
 human decision, Stage 11 review artifact, green checks, clean Copilot review,


### PR DESCRIPTION
## Summary
- require actual configured automated reviewer submissions for spec review readiness and Stage Approval merge validation
- stop treating reviewer-request checks, including Request Copilot Review, as completed review evidence
- require all review threads to be resolved, including outdated threads after fixes
- update Stage 7 generated prompt, DUUMBI skills, and automation docs for the Stage 8-to-Ready handoff

## Validation
- ruby YAML parse for stage-approval, spec-review-request, technical-spec-review-request, and spec-ai-gate workflows
- git diff --check

Related to #584.