### PR TITLE
fix: require trace graph identity for traced builds

### DIFF
--- a/src/compiler/lowering.rs
+++ b/src/compiler/lowering.rs
@@ -752,7 +752,8 @@ fn compile_function(
     });
     let function_trace_id = trace_refs
         .as_ref()
-        .map(|_| trace_id_for_function(graph, func_info) as i64);
+        .map(|_| trace_id_for_function(graph, func_info).map(|id| id as i64))
+        .transpose()?;
 
     // Import all callable function references
     let mut func_refs: HashMap<String, cranelift_codegen::ir::FuncRef> = HashMap::new();
@@ -825,7 +826,7 @@ fn compile_function(
             emit_trace_event_call(
                 &mut builder,
                 trace.block_enter,
-                trace_id_for_block(graph, func_info, block_info) as i64,
+                trace_id_for_block(graph, func_info, block_info)? as i64,
             );
         }
 
@@ -905,7 +906,7 @@ fn compile_function(
                         emit_trace_event_call(
                             &mut builder,
                             trace.block_exit,
-                            trace_id_for_block(graph, func_info, block_info) as i64,
+                            trace_id_for_block(graph, func_info, block_info)? as i64,
                         );
                     }
                     builder
@@ -1019,7 +1020,7 @@ fn compile_function(
                         emit_trace_event_call(
                             &mut builder,
                             trace.block_exit,
-                            trace_id_for_block(graph, func_info, block_info) as i64,
+                            trace_id_for_block(graph, func_info, block_info)? as i64,
                         );
                         let Some(function_id) = function_trace_id else {
                             return Err(CompileError::Cranelift {
@@ -1495,7 +1496,7 @@ fn compile_function(
                         emit_trace_event_call(
                             &mut builder,
                             trace.block_exit,
-                            trace_id_for_block(graph, func_info, block_info) as i64,
+                            trace_id_for_block(graph, func_info, block_info)? as i64,
                         );
                     }
                     builder
@@ -1621,18 +1622,34 @@ fn emit_trace_event_call(
     builder.ins().call(func_ref, &[trace_id_value]);
 }
 
-fn trace_id_for_function(graph: &SemanticGraph, func_info: &FunctionInfo) -> u64 {
-    let graph_id = crate::telemetry::function_trace_graph_id(graph, func_info);
-    crate::telemetry::trace_id(TraceMapKind::Function, &graph_id)
+fn trace_id_for_function(
+    graph: &SemanticGraph,
+    func_info: &FunctionInfo,
+) -> Result<u64, CompileError> {
+    let graph_id =
+        crate::telemetry::function_trace_graph_id(graph, func_info).map_err(|source| {
+            CompileError::Cranelift {
+                message: format!("Trace instrumentation requires graph identity: {source}"),
+            }
+        })?;
+    Ok(crate::telemetry::trace_id(
+        TraceMapKind::Function,
+        &graph_id,
+    ))
 }
 
 fn trace_id_for_block(
     graph: &SemanticGraph,
     func_info: &FunctionInfo,
     block_info: &BlockInfo,
-) -> u64 {
-    let graph_id = crate::telemetry::block_trace_graph_id(graph, func_info, block_info);
-    crate::telemetry::trace_id(TraceMapKind::Block, &graph_id)
+) -> Result<u64, CompileError> {
+    let graph_id =
+        crate::telemetry::block_trace_graph_id(graph, func_info, block_info).map_err(|source| {
+            CompileError::Cranelift {
+                message: format!("Trace instrumentation requires graph identity: {source}"),
+            }
+        })?;
+    Ok(crate::telemetry::trace_id(TraceMapKind::Block, &graph_id))
 }
 
 /// Resolves the left and right operand SSA values for a binary operation node.
@@ -2138,6 +2155,20 @@ mod tests {
     }
 
     #[test]
+    fn default_compile_allows_missing_trace_graph_identity() {
+        let module = parse_jsonld(&fixture_add()).expect("invariant: fixture must parse");
+        let mut sg = build_graph(&module).expect("invariant: fixture must build");
+        for (index, node) in sg.graph.node_weights_mut().enumerate() {
+            node.id = NodeId(format!("node-{index}"));
+        }
+
+        let obj_bytes = compile_to_object(&sg).expect("default compilation should succeed");
+
+        assert_valid_object(&obj_bytes);
+        assert!(!object_contains(&obj_bytes, "duumbi_trace_init"));
+    }
+
+    #[test]
     fn traced_compile_references_trace_hooks() {
         let module = parse_jsonld(&fixture_add()).expect("invariant: fixture must parse");
         let sg = build_graph(&module).expect("invariant: fixture must build");
@@ -2149,6 +2180,22 @@ mod tests {
         assert!(object_contains(&obj_bytes, "duumbi_trace_function_enter"));
         assert!(object_contains(&obj_bytes, "duumbi_trace_block_enter"));
         assert!(object_contains(&obj_bytes, "duumbi_trace_function_exit"));
+    }
+
+    #[test]
+    fn traced_compile_rejects_missing_trace_graph_identity() {
+        let module = parse_jsonld(&fixture_add()).expect("invariant: fixture must parse");
+        let mut sg = build_graph(&module).expect("invariant: fixture must build");
+        for (index, node) in sg.graph.node_weights_mut().enumerate() {
+            node.id = NodeId(format!("node-{index}"));
+        }
+
+        let err = compile_to_object_with_telemetry(&sg, TelemetryBuildMode::Trace)
+            .expect_err("traced compilation should require graph identity");
+
+        let message = err.to_string();
+        assert!(message.contains("Trace instrumentation requires graph identity"));
+        assert!(message.contains("missing function graph identity"));
     }
 
     #[test]

--- a/src/compiler/lowering.rs
+++ b/src/compiler/lowering.rs
@@ -2151,7 +2151,10 @@ mod tests {
         let obj_bytes = compile_to_object(&sg).expect("compilation should succeed");
 
         assert!(!object_contains(&obj_bytes, "duumbi_trace_init"));
+        assert!(!object_contains(&obj_bytes, "duumbi_trace_function_enter"));
+        assert!(!object_contains(&obj_bytes, "duumbi_trace_function_exit"));
         assert!(!object_contains(&obj_bytes, "duumbi_trace_block_enter"));
+        assert!(!object_contains(&obj_bytes, "duumbi_trace_block_exit"));
     }
 
     #[test]
@@ -2179,6 +2182,7 @@ mod tests {
         assert!(object_contains(&obj_bytes, "duumbi_trace_init"));
         assert!(object_contains(&obj_bytes, "duumbi_trace_function_enter"));
         assert!(object_contains(&obj_bytes, "duumbi_trace_block_enter"));
+        assert!(object_contains(&obj_bytes, "duumbi_trace_block_exit"));
         assert!(object_contains(&obj_bytes, "duumbi_trace_function_exit"));
     }
 

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -409,8 +409,10 @@ impl TraceMap {
     ///
     /// # Errors
     ///
-    /// Returns [`TelemetryError::TraceIdCollision`] if generated IDs collide
-    /// inside this graph.
+    /// Returns [`TelemetryError::MissingTraceGraphIdentity`] if this graph has
+    /// functions or blocks without stable graph identities. Returns
+    /// [`TelemetryError::TraceIdCollision`] if generated IDs collide inside
+    /// this graph.
     pub fn from_graph(graph: &SemanticGraph) -> Result<Self, TelemetryError> {
         Self::new(entries_for_graph(graph)?)
     }
@@ -419,8 +421,10 @@ impl TraceMap {
     ///
     /// # Errors
     ///
-    /// Returns [`TelemetryError::TraceIdCollision`] if generated IDs collide
-    /// inside the compiled program.
+    /// Returns [`TelemetryError::MissingTraceGraphIdentity`] if any program
+    /// module has functions or blocks without stable graph identities. Returns
+    /// [`TelemetryError::TraceIdCollision`] if generated IDs collide inside the
+    /// compiled program.
     pub fn from_program(program: &Program) -> Result<Self, TelemetryError> {
         let entries = program
             .modules

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -98,6 +98,22 @@ pub enum TelemetryError {
     /// Required telemetry evidence was not available.
     #[error("missing telemetry evidence: {0}")]
     MissingEvidence(String),
+    /// A traced build could not derive required graph identity metadata.
+    #[error(
+        "missing {kind} graph identity for module '{module}', function '{function}'{block_context}"
+    )]
+    MissingTraceGraphIdentity {
+        /// Missing trace-map entry kind.
+        kind: TraceMapKind,
+        /// Owning module name.
+        module: String,
+        /// Owning function name.
+        function: String,
+        /// Optional block label for block identity failures.
+        block: Option<String>,
+        /// Formatted optional block context for display.
+        block_context: String,
+    },
     /// A telemetry artifact could not be parsed.
     #[error("failed to parse telemetry artifact '{path}': {source}")]
     Parse {
@@ -396,7 +412,7 @@ impl TraceMap {
     /// Returns [`TelemetryError::TraceIdCollision`] if generated IDs collide
     /// inside this graph.
     pub fn from_graph(graph: &SemanticGraph) -> Result<Self, TelemetryError> {
-        Self::new(entries_for_graph(graph))
+        Self::new(entries_for_graph(graph)?)
     }
 
     /// Creates a combined trace map for all modules in a program.
@@ -409,7 +425,10 @@ impl TraceMap {
         let entries = program
             .modules
             .values()
-            .flat_map(entries_for_graph)
+            .map(entries_for_graph)
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .flatten()
             .collect();
         Self::new(entries)
     }
@@ -921,11 +940,11 @@ fn resolve_artifact_dir(
     Ok(workspace_root.join(configured))
 }
 
-fn entries_for_graph(graph: &SemanticGraph) -> Vec<TraceMapEntry> {
+fn entries_for_graph(graph: &SemanticGraph) -> Result<Vec<TraceMapEntry>, TelemetryError> {
     let mut entries = Vec::new();
 
     for function in &graph.functions {
-        let function_graph_id = function_trace_graph_id(graph, function);
+        let function_graph_id = function_trace_graph_id(graph, function)?;
         entries.push(TraceMapEntry {
             trace_id: trace_id(TraceMapKind::Function, &function_graph_id),
             kind: TraceMapKind::Function,
@@ -936,7 +955,7 @@ fn entries_for_graph(graph: &SemanticGraph) -> Vec<TraceMapEntry> {
         });
 
         for block in &function.blocks {
-            let block_graph_id = block_trace_graph_id(graph, function, block);
+            let block_graph_id = block_trace_graph_id(graph, function, block)?;
             entries.push(TraceMapEntry {
                 trace_id: trace_id(TraceMapKind::Block, &block_graph_id),
                 kind: TraceMapKind::Block,
@@ -948,32 +967,59 @@ fn entries_for_graph(graph: &SemanticGraph) -> Vec<TraceMapEntry> {
         }
     }
 
-    entries
+    Ok(entries)
 }
 
 /// Returns the graph identity used for a function trace entry.
-#[must_use]
-pub fn function_trace_graph_id(graph: &SemanticGraph, function: &FunctionInfo) -> String {
+///
+/// # Errors
+///
+/// Returns [`TelemetryError::MissingTraceGraphIdentity`] when no block node can
+/// be mapped back to a stable function graph identity.
+pub fn function_trace_graph_id(
+    graph: &SemanticGraph,
+    function: &FunctionInfo,
+) -> Result<String, TelemetryError> {
     function
         .blocks
         .iter()
         .find_map(|block| graph_id_from_first_node(graph, block, 2))
-        .unwrap_or_else(|| format!("duumbi:{}/{}", graph.module_name.0, function.name.0))
+        .ok_or_else(|| missing_trace_graph_identity(graph, function, None, TraceMapKind::Function))
 }
 
 /// Returns the graph identity used for a block trace entry.
-#[must_use]
+///
+/// # Errors
+///
+/// Returns [`TelemetryError::MissingTraceGraphIdentity`] when the block cannot
+/// be mapped back to a stable graph block identity.
 pub fn block_trace_graph_id(
     graph: &SemanticGraph,
     function: &FunctionInfo,
     block: &BlockInfo,
-) -> String {
-    graph_id_from_first_node(graph, block, 1).unwrap_or_else(|| {
-        format!(
-            "duumbi:{}/{}/{}",
-            graph.module_name.0, function.name.0, block.label.0
-        )
+) -> Result<String, TelemetryError> {
+    graph_id_from_first_node(graph, block, 1).ok_or_else(|| {
+        missing_trace_graph_identity(graph, function, Some(block), TraceMapKind::Block)
     })
+}
+
+fn missing_trace_graph_identity(
+    graph: &SemanticGraph,
+    function: &FunctionInfo,
+    block: Option<&BlockInfo>,
+    kind: TraceMapKind,
+) -> TelemetryError {
+    let block = block.map(|block| block.label.0.clone());
+    let block_context = block
+        .as_ref()
+        .map_or_else(String::new, |label| format!(", block '{label}'"));
+    TelemetryError::MissingTraceGraphIdentity {
+        kind,
+        module: graph.module_name.0.clone(),
+        function: function.name.0.clone(),
+        block,
+        block_context,
+    }
 }
 
 fn graph_id_from_first_node(
@@ -1149,6 +1195,46 @@ mod tests {
                 && entry.function == "main"
                 && entry.block.as_deref() == Some("entry")
         }));
+    }
+
+    #[test]
+    fn trace_map_from_graph_rejects_missing_function_identity() {
+        let mut graph = test_graph();
+        for (index, node) in graph.graph.node_weights_mut().enumerate() {
+            node.id = crate::types::NodeId(format!("node-{index}"));
+        }
+
+        let err = TraceMap::from_graph(&graph).expect_err("trace map should require graph IDs");
+
+        assert!(matches!(
+            err,
+            TelemetryError::MissingTraceGraphIdentity {
+                kind: TraceMapKind::Function,
+                ..
+            }
+        ));
+        assert!(err.to_string().contains("missing function graph identity"));
+    }
+
+    #[test]
+    fn trace_map_from_graph_rejects_missing_block_identity() {
+        let mut graph = test_graph();
+        graph.functions[0].blocks.push(crate::graph::BlockInfo {
+            label: crate::types::BlockLabel("empty".to_string()),
+            nodes: vec![],
+        });
+
+        let err = TraceMap::from_graph(&graph).expect_err("trace map should require block IDs");
+
+        assert!(matches!(
+            err,
+            TelemetryError::MissingTraceGraphIdentity {
+                kind: TraceMapKind::Block,
+                block: Some(_),
+                ..
+            }
+        ));
+        assert!(err.to_string().contains("block 'empty'"));
     }
 
     #[test]

--- a/tests/integration_telemetry.rs
+++ b/tests/integration_telemetry.rs
@@ -18,7 +18,7 @@ fn traced_option_none_unwrap_writes_crash_evidence_and_inspects() {
     assert!(stdout.contains("Block: duumbi:telemetry/main/entry"));
     assert!(stdout.contains("Exact node evidence: unavailable in v1"));
 
-    assert_trace_events_join_trace_map(&evidence);
+    assert_trace_events_join_trace_map(&evidence, &["function_enter", "block_enter"]);
 }
 
 #[test]
@@ -34,7 +34,15 @@ fn traced_call_then_panic_preserves_caller_context() {
     assert!(!stdout.contains("Function: duumbi:telemetry_call/helper"));
     assert!(!stdout.contains("Block: duumbi:telemetry_call/helper/entry"));
 
-    assert_trace_events_join_trace_map(&evidence);
+    assert_trace_events_join_trace_map(
+        &evidence,
+        &[
+            "function_enter",
+            "function_exit",
+            "block_enter",
+            "block_exit",
+        ],
+    );
 }
 
 #[test]
@@ -160,17 +168,17 @@ fn read_trace_events(telemetry_dir: &std::path::Path) -> Vec<TraceEvent> {
         .collect()
 }
 
-fn assert_trace_events_join_trace_map(evidence: &TraceFixtureEvidence) {
-    for (event, kind) in [
-        ("function_enter", TraceMapKind::Function),
-        ("function_exit", TraceMapKind::Function),
-        ("block_enter", TraceMapKind::Block),
-        ("block_exit", TraceMapKind::Block),
-    ] {
+fn assert_trace_events_join_trace_map(evidence: &TraceFixtureEvidence, required_events: &[&str]) {
+    for event in required_events {
+        let kind = match *event {
+            "function_enter" | "function_exit" => TraceMapKind::Function,
+            "block_enter" | "block_exit" => TraceMapKind::Block,
+            _ => panic!("unsupported trace event kind {event}"),
+        };
         let trace_id = evidence
             .trace_events
             .iter()
-            .find(|trace| trace.event == event)
+            .find(|trace| trace.event == *event)
             .unwrap_or_else(|| panic!("missing trace event kind {event}"))
             .trace_id
             .unwrap_or_else(|| panic!("trace event kind {event} did not include trace_id"));

--- a/tests/integration_telemetry.rs
+++ b/tests/integration_telemetry.rs
@@ -142,7 +142,7 @@ struct TraceFixtureEvidence {
 #[derive(Debug, Deserialize)]
 struct TraceEvent {
     event: String,
-    trace_id: u64,
+    trace_id: Option<u64>,
 }
 
 fn read_trace_map(telemetry_dir: &std::path::Path) -> TraceMap {
@@ -172,7 +172,8 @@ fn assert_trace_events_join_trace_map(evidence: &TraceFixtureEvidence) {
             .iter()
             .find(|trace| trace.event == event)
             .unwrap_or_else(|| panic!("missing trace event kind {event}"))
-            .trace_id;
+            .trace_id
+            .unwrap_or_else(|| panic!("trace event kind {event} did not include trace_id"));
 
         assert!(
             evidence

--- a/tests/integration_telemetry.rs
+++ b/tests/integration_telemetry.rs
@@ -3,29 +3,38 @@
 use std::fs;
 use std::process::Command;
 
+use duumbi::telemetry::{TraceMap, TraceMapKind};
+use serde::Deserialize;
+
 #[test]
 fn traced_option_none_unwrap_writes_crash_evidence_and_inspects() {
-    let stdout = traced_fixture_inspect_output(
+    let evidence = traced_fixture_evidence(
         "tests/fixtures/telemetry/option_none_unwrap.jsonld",
         "panic",
     );
 
+    let stdout = &evidence.inspect_stdout;
     assert!(stdout.contains("Function: duumbi:telemetry/main"));
     assert!(stdout.contains("Block: duumbi:telemetry/main/entry"));
     assert!(stdout.contains("Exact node evidence: unavailable in v1"));
+
+    assert_trace_events_join_trace_map(&evidence);
 }
 
 #[test]
 fn traced_call_then_panic_preserves_caller_context() {
-    let stdout = traced_fixture_inspect_output(
+    let evidence = traced_fixture_evidence(
         "tests/fixtures/telemetry/call_then_panic.jsonld",
         "call_then_panic",
     );
 
+    let stdout = &evidence.inspect_stdout;
     assert!(stdout.contains("Function: duumbi:telemetry_call/main"));
     assert!(stdout.contains("Block: duumbi:telemetry_call/main/entry"));
     assert!(!stdout.contains("Function: duumbi:telemetry_call/helper"));
     assert!(!stdout.contains("Block: duumbi:telemetry_call/helper/entry"));
+
+    assert_trace_events_join_trace_map(&evidence);
 }
 
 #[test]
@@ -58,7 +67,7 @@ fn telemetry_inspect_without_dir_reports_malformed_config() {
     );
 }
 
-fn traced_fixture_inspect_output(fixture: &str, binary_name: &str) -> String {
+fn traced_fixture_evidence(fixture: &str, binary_name: &str) -> TraceFixtureEvidence {
     let duumbi = env!("CARGO_BIN_EXE_duumbi");
     let tmp = tempfile::TempDir::new().expect("invariant: temp dir must be created");
     let telemetry_dir = tmp.path().join("telemetry");
@@ -96,6 +105,9 @@ fn traced_fixture_inspect_output(fixture: &str, binary_name: &str) -> String {
     assert!(telemetry_dir.join("traces.jsonl").exists());
     assert!(telemetry_dir.join("crash_dump.jsonl").exists());
 
+    let trace_map = read_trace_map(&telemetry_dir);
+    let trace_events = read_trace_events(&telemetry_dir);
+
     let inspect = Command::new(duumbi)
         .args([
             "telemetry",
@@ -112,5 +124,63 @@ fn traced_fixture_inspect_output(fixture: &str, binary_name: &str) -> String {
         "telemetry inspect failed: {}",
         String::from_utf8_lossy(&inspect.stderr)
     );
-    String::from_utf8(inspect.stdout).expect("invariant: inspect stdout must be UTF-8")
+    TraceFixtureEvidence {
+        inspect_stdout: String::from_utf8(inspect.stdout)
+            .expect("invariant: inspect stdout must be UTF-8"),
+        trace_map,
+        trace_events,
+    }
+}
+
+#[derive(Debug)]
+struct TraceFixtureEvidence {
+    inspect_stdout: String,
+    trace_map: TraceMap,
+    trace_events: Vec<TraceEvent>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TraceEvent {
+    event: String,
+    trace_id: u64,
+}
+
+fn read_trace_map(telemetry_dir: &std::path::Path) -> TraceMap {
+    let content = fs::read_to_string(telemetry_dir.join("trace_map.json"))
+        .expect("invariant: trace map must be readable");
+    serde_json::from_str(&content).expect("invariant: trace map must parse")
+}
+
+fn read_trace_events(telemetry_dir: &std::path::Path) -> Vec<TraceEvent> {
+    let content = fs::read_to_string(telemetry_dir.join("traces.jsonl"))
+        .expect("invariant: trace events must be readable");
+    content
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("invariant: trace event must parse"))
+        .collect()
+}
+
+fn assert_trace_events_join_trace_map(evidence: &TraceFixtureEvidence) {
+    for (event, kind) in [
+        ("function_enter", TraceMapKind::Function),
+        ("function_exit", TraceMapKind::Function),
+        ("block_enter", TraceMapKind::Block),
+        ("block_exit", TraceMapKind::Block),
+    ] {
+        let trace_id = evidence
+            .trace_events
+            .iter()
+            .find(|trace| trace.event == event)
+            .unwrap_or_else(|| panic!("missing trace event kind {event}"))
+            .trace_id;
+
+        assert!(
+            evidence
+                .trace_map
+                .entries
+                .iter()
+                .any(|entry| entry.kind == kind && entry.trace_id == trace_id),
+            "trace event {event} with id {trace_id} did not join to the trace map"
+        );
+    }
 }

--- a/tests/integration_telemetry.rs
+++ b/tests/integration_telemetry.rs
@@ -175,21 +175,29 @@ fn assert_trace_events_join_trace_map(evidence: &TraceFixtureEvidence, required_
             "block_enter" | "block_exit" => TraceMapKind::Block,
             _ => panic!("unsupported trace event kind {event}"),
         };
-        let trace_id = evidence
+        let matching_events: Vec<_> = evidence
             .trace_events
             .iter()
-            .find(|trace| trace.event == *event)
-            .unwrap_or_else(|| panic!("missing trace event kind {event}"))
-            .trace_id
-            .unwrap_or_else(|| panic!("trace event kind {event} did not include trace_id"));
-
+            .filter(|trace| trace.event == *event)
+            .collect();
         assert!(
-            evidence
-                .trace_map
-                .entries
-                .iter()
-                .any(|entry| entry.kind == kind && entry.trace_id == trace_id),
-            "trace event {event} with id {trace_id} did not join to the trace map"
+            !matching_events.is_empty(),
+            "missing trace event kind {event}"
         );
+
+        for trace in matching_events {
+            let trace_id = trace
+                .trace_id
+                .unwrap_or_else(|| panic!("trace event kind {event} did not include trace_id"));
+
+            assert!(
+                evidence
+                    .trace_map
+                    .entries
+                    .iter()
+                    .any(|entry| entry.kind == kind && entry.trace_id == trace_id),
+                "trace event {event} with id {trace_id} did not join to the trace map"
+            );
+        }
     }
 }


### PR DESCRIPTION
Related to #584.

Product spec: #628
Technical spec: #631

Workflow note: this implementation PR must leave the execution issue open until Stage 12 closure.

## Summary
- Require stable graph identity when generating trace map entries for traced builds.
- Make traced compiler lowering fail with an actionable graph-identity diagnostic instead of falling back to synthetic IDs.
- Preserve default untraced builds when graph identity metadata is absent.
- Harden trace-event integration evidence so function/block event IDs must join to `trace_map.json` entries.

## Ralph Cycle Evidence
- Cycle 1: source behavior change in src/telemetry/mod.rs and src/compiler/lowering.rs.
- Cycle 2: test/evidence hardening in src/compiler/lowering.rs and tests/integration_telemetry.rs.
- Cycle 2 CI fixups: narrowed assertions for panic trace records and panic-path normal-exit behavior.
- External LLM calls: 0.
- Estimated external cost: USD 0.
- Resource gate: not triggered; all work stayed inside the approved #584 technical spec and autonomous batch cap.

## Validation
- PASS: cargo test trace_graph_identity --lib
- PASS: cargo test trace_map_from_graph_rejects --lib
- PASS: cargo test traced_compile_rejects_missing_trace_graph_identity --lib
- PASS: cargo test trace_hooks --lib
- PASS: cargo test telemetry --lib
- PASS: cargo test --lib
- PASS: cargo test --test integration_phase1 phase1_build_help_lists_trace_flag
- PASS: cargo test --test integration_telemetry --no-run
- PASS: cargo fmt --check
- PASS: git diff --check
- PASS: cargo clippy --all-targets -- -D warnings
- PASS: PR CI check (ubuntu-latest)
- PASS: PR CI check (windows-latest)
- PASS: PR coverage
- BLOCKED locally: cargo test --test integration_telemetry and cargo test --all reach local linking and fail with `ld: unknown platform ... output.o`; clean origin/main reproduced the same failure, so this is local toolchain/object-format behavior rather than this PR.

## BDD Evidence Map
- Default compiled output does not reference trace hooks: compiler lowering unit test checks init, function enter/exit, and block enter/exit symbols are absent.
- Traced output references trace hooks: compiler lowering unit test checks init, function enter/exit, and block enter/exit symbols are present.
- Traced run emits function/block enter/exit events: integration telemetry test parses `traces.jsonl`; the call-then-panic fixture requires all four #584 function/block event kinds.
- Trace IDs join with graph metadata: integration telemetry test verifies each required event trace ID has a same-kind entry in `trace_map.json`.
- Panic path context: direct panic fixture verifies function/block entry events join the map and inspect maps active context.
- Stable graph-linked IDs and missing-identity failure: telemetry/lowering unit tests cover deterministic IDs, collision validation, missing function/block identity errors, and default-build unaffected behavior.
- External services: tests run locally through CLI/runtime artifacts with no provider credentials, Studio, network service, collector, or remote export.

## Stage 10 State
Ready for Stage 11 implementation review. The execution issue remains open; no merge, Done transition, or Stage 12 closure was performed.