### PR TITLE
Require only Copilot for spec review gates

### DIFF
--- a/.agents/skills/duumbi-spec-draft/SKILL.md
+++ b/.agents/skills/duumbi-spec-draft/SKILL.md
@@ -111,10 +111,9 @@ For file-based specs:
 - open the PR as a draft while the first artifact is being assembled
 - mark the PR ready for review after the spec artifact is complete and local checks are complete
 - request or wait for the configured automated reviewers when available. In this
-  repository the default required reviewers are `copilot-pull-request-reviewer`
-  and `chatgpt-codex-connector` unless repository configuration states
-  otherwise. Do not treat a successful reviewer-request check as completed
-  review evidence.
+  repository the default required reviewer is `copilot-pull-request-reviewer`
+  unless repository configuration states otherwise. Do not treat a successful
+  reviewer-request check as completed review evidence.
 - inspect review feedback and check results, fix blocking findings inside the spec file, and repeat until the PR is review-clean
 - link the review-ready PR and spec path from the GitHub Issue
 - treat the PR as a spec-review artifact only; it must not close the execution issue when merged or closed

--- a/.agents/skills/duumbi-spec-review/SKILL.md
+++ b/.agents/skills/duumbi-spec-review/SKILL.md
@@ -41,9 +41,9 @@ Before approving through the AI gate, verify all of these facts:
 - the product spec PR is a spec-only PR and contains no implementation code
 - the product spec PR is open, non-draft, review-clean, and ready for approval merge
 - each configured automated reviewer has submitted actual, non-dismissed review
-  evidence; in this repository the default required reviewers are
-  `copilot-pull-request-reviewer` and `chatgpt-codex-connector` unless
-  repository configuration states otherwise
+  evidence; in this repository the default required reviewer is
+  `copilot-pull-request-reviewer` unless repository configuration states
+  otherwise
 - do not treat a successful reviewer-request check as completed review evidence
 - no latest automated or human review is `CHANGES_REQUESTED`
 - no review thread remains unresolved, including outdated threads after a fix

--- a/.agents/skills/duumbi-tech-spec-draft/SKILL.md
+++ b/.agents/skills/duumbi-tech-spec-draft/SKILL.md
@@ -130,10 +130,10 @@ specs/DUUMBI-<issue-number>/TECHNICAL.md
 Open a PR for the technical spec artifact and link it from the GitHub Issue. Use draft
 state while assembling the first artifact, then mark it ready for review, request
 or wait for configured automated reviewers. In this repository the default
-configured automated reviewers are `copilot-pull-request-reviewer` and
-`chatgpt-codex-connector` unless repository configuration states otherwise.
-Do not treat a successful "Request Copilot Review" check as completed review
-evidence; it only proves the request was sent. Address blocking review feedback
+configured automated reviewer is `copilot-pull-request-reviewer` unless
+repository configuration states otherwise. Do not treat a successful
+"Request Copilot Review" check as completed review evidence; it only proves the
+request was sent. Address blocking review feedback
 inside `TECHNICAL.md`, push the fix, and continue until checks are green and all
 review threads are resolved, including threads that became outdated after the
 fix. Only then route the issue to `Technical Spec Review`; Stage 9 Slack or AI

--- a/.agents/skills/duumbi-tech-spec-review/SKILL.md
+++ b/.agents/skills/duumbi-tech-spec-review/SKILL.md
@@ -43,9 +43,9 @@ Before approving through the AI gate, verify all of these facts:
 - the technical spec PR is a spec-only PR and contains no implementation code or test edits
 - the technical spec PR is open, non-draft, review-clean, and ready for approval merge
 - each configured automated reviewer has submitted actual, non-dismissed review
-  evidence; in this repository the default required reviewers are
-  `copilot-pull-request-reviewer` and `chatgpt-codex-connector` unless
-  repository configuration states otherwise
+  evidence; in this repository the default required reviewer is
+  `copilot-pull-request-reviewer` unless repository configuration states
+  otherwise
 - do not treat a successful review-request check, including `Request Copilot
   Review`, as completed review evidence
 - no latest automated or human review is `CHANGES_REQUESTED`

--- a/.github/workflows/spec-review-request.yml
+++ b/.github/workflows/spec-review-request.yml
@@ -56,7 +56,7 @@ jobs:
           INPUT_ISSUE_URL: ${{ inputs.issue_url || '' }}
           INPUT_ISSUE_NUMBER: ${{ inputs.issue_number || '' }}
           INPUT_STATUS: ${{ inputs.status || '' }}
-          DUUMBI_REQUIRED_SPEC_REVIEWERS: ${{ vars.DUUMBI_REQUIRED_SPEC_REVIEWERS || 'copilot-pull-request-reviewer,chatgpt-codex-connector' }}
+          DUUMBI_REQUIRED_SPEC_REVIEWERS: ${{ vars.DUUMBI_REQUIRED_SPEC_REVIEWERS || 'copilot-pull-request-reviewer' }}
         with:
           script: |
             const marker = "<!-- duumbi-spec-review-slack-notified -->";
@@ -149,7 +149,7 @@ jobs:
             };
 
             const requiredAutomatedReviewers = () =>
-              String(process.env.DUUMBI_REQUIRED_SPEC_REVIEWERS || "copilot-pull-request-reviewer,chatgpt-codex-connector")
+              String(process.env.DUUMBI_REQUIRED_SPEC_REVIEWERS || "copilot-pull-request-reviewer")
                 .split(",")
                 .map((reviewer) => reviewer.trim())
                 .filter(Boolean);

--- a/.github/workflows/stage-approval.yml
+++ b/.github/workflows/stage-approval.yml
@@ -59,7 +59,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_REVIEW_CHANNEL_ID: ${{ secrets.SLACK_REVIEW_CHANNEL_ID }}
           INPUT_SLACK_RESPONSE_URL: ${{ github.event.client_payload.slack_response_url || '' }}
-          DUUMBI_REQUIRED_SPEC_REVIEWERS: ${{ vars.DUUMBI_REQUIRED_SPEC_REVIEWERS || 'copilot-pull-request-reviewer,chatgpt-codex-connector' }}
+          DUUMBI_REQUIRED_SPEC_REVIEWERS: ${{ vars.DUUMBI_REQUIRED_SPEC_REVIEWERS || 'copilot-pull-request-reviewer' }}
         with:
           script: |
             // ── Inputs ──────────────────────────────────────────────
@@ -336,7 +336,7 @@ jobs:
             };
 
             const requiredAutomatedReviewers = () =>
-              String(process.env.DUUMBI_REQUIRED_SPEC_REVIEWERS || 'copilot-pull-request-reviewer,chatgpt-codex-connector')
+              String(process.env.DUUMBI_REQUIRED_SPEC_REVIEWERS || 'copilot-pull-request-reviewer')
                 .split(',')
                 .map((reviewer) => reviewer.trim())
                 .filter(Boolean);

--- a/.github/workflows/technical-spec-review-request.yml
+++ b/.github/workflows/technical-spec-review-request.yml
@@ -56,7 +56,7 @@ jobs:
           INPUT_ISSUE_URL: ${{ inputs.issue_url || '' }}
           INPUT_ISSUE_NUMBER: ${{ inputs.issue_number || '' }}
           INPUT_STATUS: ${{ inputs.status || '' }}
-          DUUMBI_REQUIRED_SPEC_REVIEWERS: ${{ vars.DUUMBI_REQUIRED_SPEC_REVIEWERS || 'copilot-pull-request-reviewer,chatgpt-codex-connector' }}
+          DUUMBI_REQUIRED_SPEC_REVIEWERS: ${{ vars.DUUMBI_REQUIRED_SPEC_REVIEWERS || 'copilot-pull-request-reviewer' }}
         with:
           script: |
             const marker = "<!-- duumbi-tech-spec-review-slack-notified -->";
@@ -160,7 +160,7 @@ jobs:
             };
 
             const requiredAutomatedReviewers = () =>
-              String(process.env.DUUMBI_REQUIRED_SPEC_REVIEWERS || "copilot-pull-request-reviewer,chatgpt-codex-connector")
+              String(process.env.DUUMBI_REQUIRED_SPEC_REVIEWERS || "copilot-pull-request-reviewer")
                 .split(",")
                 .map((reviewer) => reviewer.trim())
                 .filter(Boolean);

--- a/docs/automation/agentic-development-orchestration.md
+++ b/docs/automation/agentic-development-orchestration.md
@@ -132,9 +132,8 @@ Stage 7 and Stage 9 AI gates may approve only when:
 - the PR is spec-only
 - the PR is open, non-draft, and ready for approval merge
 - actual non-dismissed configured automated review submissions exist. By
-  default this means `copilot-pull-request-reviewer` and
-  `chatgpt-codex-connector`; repositories can override the comma-separated list
-  with `DUUMBI_REQUIRED_SPEC_REVIEWERS`
+  default this means `copilot-pull-request-reviewer`; repositories can override
+  the comma-separated list with `DUUMBI_REQUIRED_SPEC_REVIEWERS`
 - reviewer-request workflow success does not count as review evidence
 - automated reviews and human reviews have no blocking `CHANGES_REQUESTED`
   decision


### PR DESCRIPTION
## Summary

Updates DUUMBI spec-review gate policy so the default required automated review evidence is only `copilot-pull-request-reviewer`.

This removes `chatgpt-codex-connector` from the default reviewer requirement in Stage 7/9 readiness workflows and aligns the local stage skills and automation documentation.

## Change Type

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [x] CI/Build

## Validation

- [x] `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' .github/workflows/stage-approval.yml .github/workflows/spec-review-request.yml .github/workflows/technical-spec-review-request.yml`
- [x] `rg -n 'chatgpt-codex-connector|copilot-pull-request-reviewer.*and|and \`chatgpt' .agents .github docs specs README.md AGENTS.md -S` returned no matches
- [x] `git diff --cached --check`

## Docs Impact

- [ ] No docs update needed
- [ ] Updated docs under `sites/docs/src/`
- [x] Updated automation docs under `docs/automation/`

## Notes for Reviewers

The override variable `DUUMBI_REQUIRED_SPEC_REVIEWERS` remains supported for repositories that need a comma-separated custom reviewer list. The default is now Copilot-only.
