### PR TITLE
Fix spec approval review evidence lookup

### DIFF
--- a/.github/workflows/stage-approval.yml
+++ b/.github/workflows/stage-approval.yml
@@ -447,11 +447,19 @@ jobs:
                 throw new Error(`${policy.kind} PR #${prNumber} must change only ${policy.expectedPath}; found ${changedPaths.join(', ') || 'no files'}.`);
               }
 
-              const checkRuns = await github.paginate(
-                github.rest.checks.listForRef,
-                { owner, repo, ref: pr.head.sha, per_page: 100 },
-                (response) => response.data.check_runs,
-              ).then((runs) => runs.flat().filter(Boolean));
+              const checkRuns = [];
+              for (let page = 1; ; page += 1) {
+                const response = await github.rest.checks.listForRef({
+                  owner,
+                  repo,
+                  ref: pr.head.sha,
+                  per_page: 100,
+                  page,
+                });
+                const pageRuns = response.data.check_runs || [];
+                checkRuns.push(...pageRuns);
+                if (pageRuns.length < 100) break;
+              }
               const badChecks = checkRuns.filter((check) =>
                 check.status !== 'completed' || !['success', 'neutral', 'skipped'].includes(check.conclusion)
               );


### PR DESCRIPTION
## Summary

Fixes spec approval readiness lookups used by Stage Approval and review-request workflows.

Changes:
- Replaces Stage Approval's paginated check-run lookup with explicit check-run page collection for PR head SHAs.
- Normalizes GitHub app bot review logins by stripping the REST `[bot]` suffix so `copilot-pull-request-reviewer[bot]` satisfies the configured `copilot-pull-request-reviewer` requirement.
- Applies the same reviewer normalization to product and technical spec review request workflows.

This is needed because Stage Approval run 26476041305 found zero checks despite GitHub returning four successful check runs for PR #634, and run 26476220269 did not count the Copilot REST review actor because REST exposes it as `copilot-pull-request-reviewer[bot]`.

## Change Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] CI/Build

## Validation

- [x] `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' .github/workflows/stage-approval.yml .github/workflows/spec-review-request.yml .github/workflows/technical-spec-review-request.yml`
- [x] `rg -n 'chatgpt-codex-connector|copilot-pull-request-reviewer.*and|and \`chatgpt' .agents .github docs specs README.md AGENTS.md -S` returned no matches
- [x] `git diff --cached --check`

## Docs Impact

- [x] No docs update needed
- [ ] Updated docs under `sites/docs/src/`
- [ ] Docs follow-up issue created

## Notes for Reviewers

Narrow follow-up to PR #635. It preserves the Copilot-only default and makes the existing gate count GitHub's actual REST actor shape for Copilot reviews.
