### PR TITLE
Notify Slack when issues are ready for build

### DIFF
--- a/.github/workflows/ready-for-build-handoff.yml
+++ b/.github/workflows/ready-for-build-handoff.yml
@@ -33,6 +33,9 @@ jobs:
           GH_PROJECT_PAT: ${{ secrets.GH_PROJECT_PAT }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_REVIEW_CHANNEL_ID: ${{ secrets.SLACK_REVIEW_CHANNEL_ID }}
+          DUUMBI_PROJECT_NUMBER: ${{ vars.DUUMBI_PROJECT_NUMBER }}
+          DUUMBI_PROJECT_OWNER: ${{ vars.DUUMBI_PROJECT_OWNER || github.repository_owner }}
+          DUUMBI_PROJECT_OWNER_TYPE: ${{ vars.DUUMBI_PROJECT_OWNER_TYPE || 'user' }}
           DUUMBI_METRICS_PATH: duumbi-workflow-metrics.json
         with:
           script: |
@@ -60,6 +63,15 @@ jobs:
             function extractGithubUrls(text) {
               return [...new Set((String(text || "").match(/https:\/\/github\.com\/[^\s)>"]+/g) || [])
                 .map((url) => url.replace(/[.,;:]+$/, "")))];
+            }
+
+            function extractLabeledUrl(text, labelPattern) {
+              const lines = String(text || "").split("\n");
+              const line = lines.find((candidate) => {
+                const match = candidate.match(/^\*\*([^:*]+):\*\*\s*(.+)$/);
+                return match && labelPattern.test(match[1]);
+              });
+              return extractGithubUrls(line || "")[0] || "";
             }
 
             function extractNextPrompt(text, issue) {
@@ -122,6 +134,83 @@ jobs:
               return null;
             }
 
+            async function listReadyProjectIssues() {
+              const projectPat = process.env.GH_PROJECT_PAT;
+              const projectNumber = Number(process.env.DUUMBI_PROJECT_NUMBER || 0);
+              const projectOwner = process.env.DUUMBI_PROJECT_OWNER || owner;
+              const ownerType = String(process.env.DUUMBI_PROJECT_OWNER_TYPE || "user").toLowerCase();
+              if (!projectPat || !projectNumber) {
+                warnings.push("project_ready_scan_not_configured");
+                return [];
+              }
+              const rootField = ownerType === "organization" ? "organization" : "user";
+              const query = `
+                query($owner:String!,$number:Int!,$cursor:String) {
+                  ${rootField}(login:$owner) {
+                    projectV2(number:$number) {
+                      items(first:100, after:$cursor) {
+                        nodes {
+                          content {
+                            ... on Issue {
+                              number
+                              title
+                              url
+                              state
+                              repository { nameWithOwner }
+                              labels(first:30) { nodes { name } }
+                            }
+                          }
+                          fieldValues(first:20) {
+                            nodes {
+                              ... on ProjectV2ItemFieldSingleSelectValue {
+                                name
+                                field { ... on ProjectV2SingleSelectField { name } }
+                              }
+                            }
+                          }
+                        }
+                        pageInfo { hasNextPage endCursor }
+                      }
+                    }
+                  }
+                }`;
+              const ready = [];
+              let cursor = null;
+              do {
+                const response = await fetch("https://api.github.com/graphql", {
+                  method: "POST",
+                  headers: {
+                    Authorization: `bearer ${projectPat}`,
+                    "Content-Type": "application/json",
+                  },
+                  body: JSON.stringify({ query, variables: { owner: projectOwner, number: projectNumber, cursor } }),
+                });
+                const body = await response.json();
+                if (body.errors) {
+                  warnings.push("project_ready_scan_failed");
+                  core.warning(`Project Ready for Build scan failed: ${body.errors.map((e) => e.message).join("; ")}`);
+                  return ready;
+                }
+                const page = body.data?.[rootField]?.projectV2?.items;
+                for (const item of page?.nodes || []) {
+                  const issue = item.content;
+                  if (!issue || issue.repository?.nameWithOwner !== `${owner}/${repo}` || issue.state !== "OPEN") continue;
+                  const status = (item.fieldValues?.nodes || []).find((value) =>
+                    value?.field?.name === "Status" && value?.name === "Ready for Build",
+                  );
+                  if (!status) continue;
+                  ready.push({
+                    number: issue.number,
+                    title: issue.title,
+                    html_url: issue.url,
+                    labels: (issue.labels?.nodes || []).map((label) => ({ name: label.name })),
+                  });
+                }
+                cursor = page?.pageInfo?.hasNextPage ? page.pageInfo.endCursor : null;
+              } while (cursor);
+              return ready;
+            }
+
             async function getIssue(issueNumber) {
               const { data } = await github.rest.issues.get({
                 owner,
@@ -146,20 +235,18 @@ jobs:
                 return [...candidates.values()];
               }
 
-              const issues = await github.paginate(github.rest.issues.listForRepo, {
+              const labeledIssues = await github.paginate(github.rest.issues.listForRepo, {
                 owner,
                 repo,
                 state: "open",
+                labels: "tech-spec-approved",
                 per_page: 100,
               });
-              for (const issue of issues.filter((item) => !item.pull_request)) {
-                const labels = labelsFor(issue);
-                if (labels.includes("tech-spec-approved")) {
-                  candidates.set(issue.number, issue);
-                  continue;
-                }
-                const status = await getProjectStatus(issue.number);
-                if (status === "Ready for Build") candidates.set(issue.number, issue);
+              for (const issue of labeledIssues.filter((item) => !item.pull_request)) {
+                candidates.set(issue.number, issue);
+              }
+              for (const issue of await listReadyProjectIssues()) {
+                candidates.set(issue.number, issue);
               }
               return [...candidates.values()];
             }
@@ -191,9 +278,16 @@ jobs:
               const stage9 = [...comments].reverse().find((comment) =>
                 /Stage 9 (Technical Spec Review Decision|AI Gate Decision)/i.test(comment.body || ""),
               );
-              const urls = extractGithubUrls(stage9?.body || "");
-              const technicalSpec = urls.find((url) => /\/pull\/\d+/.test(url)) || "";
-              const productSpec = urls.find((url) => url !== technicalSpec && /\/pull\/\d+/.test(url)) || "";
+              const stage9Body = stage9?.body || "";
+              const urls = extractGithubUrls(stage9Body);
+              const technicalSpec =
+                extractLabeledUrl(stage9Body, /^(Technical spec|Spec PR)$/i) ||
+                urls.find((url) => /\/pull\/\d+/.test(url)) ||
+                "";
+              const productSpec =
+                extractLabeledUrl(stage9Body, /^Product spec$/i) ||
+                urls.find((url) => url !== technicalSpec && /\/pull\/\d+/.test(url)) ||
+                "";
               const prompt = extractNextPrompt(stage9?.body || "", issue);
               const signal = [
                 labels.includes("tech-spec-approved") ? "`tech-spec-approved` label" : null,
@@ -243,10 +337,17 @@ jobs:
             const candidates = await collectCandidates();
             const results = [];
             for (const issue of candidates) {
-              results.push(await notifyIssue(issue));
+              try {
+                results.push(await notifyIssue(issue));
+              } catch (error) {
+                warnings.push(`notify_failed_issue_${issue.number}`);
+                core.warning(`Ready for Build handoff failed for #${issue.number}: ${error.message}`);
+                results.push({ issue: issue.number, outcome: "failed", error: error.message });
+              }
             }
 
             const posted = results.filter((result) => result.outcome === "posted").length;
+            const failed = results.filter((result) => result.outcome === "failed").length;
             const now = new Date().toISOString();
             fs.writeFileSync(process.env.DUUMBI_METRICS_PATH, `${JSON.stringify({
               schema_version: "duumbi.workflow_metrics.v1",
@@ -311,9 +412,14 @@ jobs:
                 [{ data: "Field", header: true }, { data: "Value", header: true }],
                 ["Issues considered", String(candidates.length)],
                 ["Slack notifications posted", String(posted)],
+                ["Failures", String(failed)],
                 ["Results", JSON.stringify(results)],
               ])
               .write();
+
+            if (failed > 0) {
+              core.setFailed(`${failed} Ready for Build Slack handoff(s) failed.`);
+            }
 
       - name: Upload DUUMBI workflow metrics
         if: always()

--- a/.github/workflows/ready-for-build-handoff.yml
+++ b/.github/workflows/ready-for-build-handoff.yml
@@ -1,0 +1,325 @@
+name: Ready For Build Handoff
+
+on:
+  issues:
+    types: [labeled]
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Optional issue number to notify if it is Ready for Build
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ready-for-build-handoff-${{ github.event.issue.number || github.event.inputs.issue_number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  notify:
+    name: Notify Stage 10 handoff
+    if: github.event_name != 'issues' || github.event.label.name == 'tech-spec-approved'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Ready for Build handoff
+        uses: actions/github-script@v9
+        env:
+          GH_PROJECT_PAT: ${{ secrets.GH_PROJECT_PAT }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_REVIEW_CHANNEL_ID: ${{ secrets.SLACK_REVIEW_CHANNEL_ID }}
+          DUUMBI_METRICS_PATH: duumbi-workflow-metrics.json
+        with:
+          script: |
+            const fs = require("fs");
+            const { owner, repo } = context.repo;
+            const eventName = context.eventName;
+            const slackToken = process.env.SLACK_BOT_TOKEN;
+            const slackChannel = process.env.SLACK_REVIEW_CHANNEL_ID;
+            const markerFor = (issueNumber) => `<!-- duumbi-ready-for-build-slack-notified:v1 issue=${issueNumber} -->`;
+            const warnings = [];
+
+            function labelsFor(issue) {
+              return (issue.labels || [])
+                .map((label) => typeof label === "string" ? label : label.name)
+                .filter(Boolean);
+            }
+
+            function slackEscape(value) {
+              return String(value || "")
+                .replace(/&/g, "&amp;")
+                .replace(/</g, "&lt;")
+                .replace(/>/g, "&gt;");
+            }
+
+            function extractGithubUrls(text) {
+              return [...new Set((String(text || "").match(/https:\/\/github\.com\/[^\s)>"]+/g) || [])
+                .map((url) => url.replace(/[.,;:]+$/, "")))];
+            }
+
+            function extractNextPrompt(text, issue) {
+              const match = String(text || "").match(/## Next Codex Prompt\s*```text\n([\s\S]*?)```/i);
+              if (match?.[1]?.trim()) return match[1].trim();
+              return [
+                "Run DUUMBI Stage 10 Implementation Coordination with duumbi-implementation.",
+                "",
+                `Target issue: ${issue.html_url}`,
+                "Mode: coordinate Stage 10 branch, PR, blocker, or evidence state",
+                "",
+                "Goal: Verify Ready for Build context, manage branch and PR readiness, consolidate Ralph-cycle evidence when relevant, choose the next routed action, and delegate implementation edits only through bounded Ralph cycles.",
+                "",
+                "Do not exceed the approved product or technical specs, skip resource gates, perform Stage 12 closure, merge PRs, or mark the issue done.",
+              ].join("\n");
+            }
+
+            async function getProjectStatus(issueNumber) {
+              const projectPat = process.env.GH_PROJECT_PAT;
+              if (!projectPat) return null;
+              const query = `
+                query($owner:String!,$repo:String!,$number:Int!) {
+                  repository(owner:$owner,name:$repo) {
+                    issue(number:$number) {
+                      projectItems(first:20) {
+                        nodes {
+                          fieldValues(first:20) {
+                            nodes {
+                              ... on ProjectV2ItemFieldSingleSelectValue {
+                                name
+                                field { ... on ProjectV2SingleSelectField { name } }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }`;
+              const response = await fetch("https://api.github.com/graphql", {
+                method: "POST",
+                headers: {
+                  Authorization: `bearer ${projectPat}`,
+                  "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ query, variables: { owner, repo, number: Number(issueNumber) } }),
+              });
+              const body = await response.json();
+              if (body.errors) {
+                warnings.push(`project_status_query_failed_issue_${issueNumber}`);
+                core.warning(`Project status query failed for #${issueNumber}: ${body.errors.map((e) => e.message).join("; ")}`);
+                return null;
+              }
+              const items = body.data?.repository?.issue?.projectItems?.nodes || [];
+              for (const item of items) {
+                for (const value of item.fieldValues?.nodes || []) {
+                  if (value?.field?.name === "Status" && value?.name) return value.name;
+                }
+              }
+              return null;
+            }
+
+            async function getIssue(issueNumber) {
+              const { data } = await github.rest.issues.get({
+                owner,
+                repo,
+                issue_number: Number(issueNumber),
+              });
+              return data;
+            }
+
+            async function collectCandidates() {
+              const candidates = new Map();
+
+              if (eventName === "issues") {
+                const issue = context.payload.issue;
+                if (context.payload.label?.name === "tech-spec-approved") candidates.set(issue.number, issue);
+                return [...candidates.values()];
+              }
+
+              const inputIssue = String(context.payload.inputs?.issue_number || "").trim();
+              if (inputIssue) {
+                candidates.set(Number(inputIssue), await getIssue(inputIssue));
+                return [...candidates.values()];
+              }
+
+              const issues = await github.paginate(github.rest.issues.listForRepo, {
+                owner,
+                repo,
+                state: "open",
+                per_page: 100,
+              });
+              for (const issue of issues.filter((item) => !item.pull_request)) {
+                const labels = labelsFor(issue);
+                if (labels.includes("tech-spec-approved")) {
+                  candidates.set(issue.number, issue);
+                  continue;
+                }
+                const status = await getProjectStatus(issue.number);
+                if (status === "Ready for Build") candidates.set(issue.number, issue);
+              }
+              return [...candidates.values()];
+            }
+
+            async function loadComments(issueNumber) {
+              return github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: issueNumber,
+                per_page: 100,
+              });
+            }
+
+            async function notifyIssue(issue) {
+              const labels = labelsFor(issue);
+              const projectStatus = await getProjectStatus(issue.number);
+              const isReady = labels.includes("tech-spec-approved") || projectStatus === "Ready for Build";
+              if (!isReady) return { issue: issue.number, outcome: "not_ready" };
+
+              const comments = await loadComments(issue.number);
+              const marker = markerFor(issue.number);
+              if (comments.some((comment) => (comment.body || "").includes(marker))) {
+                return { issue: issue.number, outcome: "already_notified" };
+              }
+
+              if (!slackToken) throw new Error("SLACK_BOT_TOKEN is not configured.");
+              if (!slackChannel) throw new Error("SLACK_REVIEW_CHANNEL_ID is not configured.");
+
+              const stage9 = [...comments].reverse().find((comment) =>
+                /Stage 9 (Technical Spec Review Decision|AI Gate Decision)/i.test(comment.body || ""),
+              );
+              const urls = extractGithubUrls(stage9?.body || "");
+              const technicalSpec = urls.find((url) => /\/pull\/\d+/.test(url)) || "";
+              const productSpec = urls.find((url) => url !== technicalSpec && /\/pull\/\d+/.test(url)) || "";
+              const prompt = extractNextPrompt(stage9?.body || "", issue);
+              const signal = [
+                labels.includes("tech-spec-approved") ? "`tech-spec-approved` label" : null,
+                projectStatus === "Ready for Build" ? "`Ready for Build` Project status" : null,
+              ].filter(Boolean).join(" and ");
+
+              const text = [
+                "*DUUMBI Stage 10 handoff: Ready for Build*",
+                `*Issue:* <${issue.html_url}|#${issue.number} ${slackEscape(issue.title)}>`,
+                `*Signal:* ${signal || "Ready for Build"}`,
+                technicalSpec ? `*Technical spec:* ${technicalSpec}` : null,
+                productSpec ? `*Product spec:* ${productSpec}` : null,
+                "",
+                "*Next Codex prompt:*",
+                "```",
+                prompt,
+                "```",
+              ].filter((line) => line !== null).join("\n");
+
+              const response = await fetch("https://slack.com/api/chat.postMessage", {
+                method: "POST",
+                headers: {
+                  Authorization: `Bearer ${slackToken}`,
+                  "Content-Type": "application/json; charset=utf-8",
+                },
+                body: JSON.stringify({ channel: slackChannel, text }),
+              });
+              const body = await response.json();
+              if (!response.ok || !body.ok) throw new Error(`Slack chat.postMessage failed: ${body.error || response.status}`);
+
+              const markerBody = [
+                marker,
+                "Ready for Build Slack handoff posted.",
+                "",
+                `Slack timestamp: ${body.ts || "<unavailable>"}`,
+                `Signal: ${signal || "Ready for Build"}`,
+              ].join("\n");
+              const { data: comment } = await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body: markerBody,
+              });
+              return { issue: issue.number, outcome: "posted", comment_url: comment.html_url };
+            }
+
+            const candidates = await collectCandidates();
+            const results = [];
+            for (const issue of candidates) {
+              results.push(await notifyIssue(issue));
+            }
+
+            const posted = results.filter((result) => result.outcome === "posted").length;
+            const now = new Date().toISOString();
+            fs.writeFileSync(process.env.DUUMBI_METRICS_PATH, `${JSON.stringify({
+              schema_version: "duumbi.workflow_metrics.v1",
+              generated_at: now,
+              source: "github_actions",
+              repository: `${owner}/${repo}`,
+              workflow: {
+                name: context.workflow,
+                file: ".github/workflows/ready-for-build-handoff.yml",
+                run_id: context.runId,
+                run_attempt: Number(process.env.GITHUB_RUN_ATTEMPT || 1),
+                event_name: eventName,
+                actor: context.actor,
+                ref: context.ref,
+                sha: context.sha,
+                conclusion: "success",
+                started_at: now,
+                completed_at: now,
+                duration_ms: null,
+              },
+              correlation: {
+                issue_number: candidates.length === 1 ? candidates[0].number : null,
+                pr_number: null,
+                stage: "10-handoff",
+                decision: null,
+                project_status: "Ready for Build",
+              },
+              counts: {
+                issues_considered: candidates.length,
+                issues_queued: posted,
+                slack_notifications_attempted: posted,
+                artifact_links_found: null,
+                artifact_links_missing: null,
+              },
+              provider_usage: {
+                available: false,
+                reason: "notification_only",
+                provider: null,
+                model: null,
+                request_count: null,
+                prompt_tokens: null,
+                completion_tokens: null,
+                total_tokens: null,
+                estimated_cost_usd: null,
+                latency_ms: null,
+                failure_count: null,
+              },
+              privacy: {
+                metadata_only: true,
+                raw_prompts_included: false,
+                raw_completions_included: false,
+                raw_slack_payloads_included: false,
+                secrets_included: false,
+              },
+              warnings,
+              results,
+            }, null, 2)}\n`);
+
+            await core.summary
+              .addHeading("Ready for Build Handoff", 2)
+              .addTable([
+                [{ data: "Field", header: true }, { data: "Value", header: true }],
+                ["Issues considered", String(candidates.length)],
+                ["Slack notifications posted", String(posted)],
+                ["Results", JSON.stringify(results)],
+              ])
+              .write();
+
+      - name: Upload DUUMBI workflow metrics
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: duumbi-workflow-metrics-ready-for-build-handoff-${{ github.run_id }}-${{ github.run_attempt }}
+          path: duumbi-workflow-metrics.json
+          if-no-files-found: warn

--- a/.github/workflows/ready-for-build-handoff.yml
+++ b/.github/workflows/ready-for-build-handoff.yml
@@ -18,7 +18,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: ready-for-build-handoff-${{ github.event.issue.number || github.event.inputs.issue_number || github.run_id }}
+  group: ready-for-build-handoff
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/ready-for-build-handoff.yml
+++ b/.github/workflows/ready-for-build-handoff.yml
@@ -35,7 +35,7 @@ jobs:
           SLACK_REVIEW_CHANNEL_ID: ${{ secrets.SLACK_REVIEW_CHANNEL_ID }}
           DUUMBI_PROJECT_NUMBER: ${{ vars.DUUMBI_PROJECT_NUMBER }}
           DUUMBI_PROJECT_OWNER: ${{ vars.DUUMBI_PROJECT_OWNER || github.repository_owner }}
-          DUUMBI_PROJECT_OWNER_TYPE: ${{ vars.DUUMBI_PROJECT_OWNER_TYPE || 'user' }}
+          DUUMBI_PROJECT_OWNER_TYPE: ${{ vars.DUUMBI_PROJECT_OWNER_TYPE }}
           DUUMBI_METRICS_PATH: duumbi-workflow-metrics.json
         with:
           script: |
@@ -89,6 +89,13 @@ jobs:
               ].join("\n");
             }
 
+            function inferProjectOwnerType() {
+              const configured = String(process.env.DUUMBI_PROJECT_OWNER_TYPE || "").trim().toLowerCase();
+              if (configured === "organization" || configured === "user") return configured;
+              const ownerKind = context.payload.repository?.owner?.type;
+              return ownerKind === "Organization" ? "organization" : "user";
+            }
+
             async function getProjectStatus(issueNumber) {
               const projectPat = process.env.GH_PROJECT_PAT;
               if (!projectPat) return null;
@@ -138,7 +145,7 @@ jobs:
               const projectPat = process.env.GH_PROJECT_PAT;
               const projectNumber = Number(process.env.DUUMBI_PROJECT_NUMBER || 0);
               const projectOwner = process.env.DUUMBI_PROJECT_OWNER || owner;
-              const ownerType = String(process.env.DUUMBI_PROJECT_OWNER_TYPE || "user").toLowerCase();
+              const ownerType = inferProjectOwnerType();
               if (!projectPat || !projectNumber) {
                 warnings.push("project_ready_scan_not_configured");
                 return [];
@@ -286,7 +293,6 @@ jobs:
                 "";
               const productSpec =
                 extractLabeledUrl(stage9Body, /^Product spec$/i) ||
-                urls.find((url) => url !== technicalSpec && /\/pull\/\d+/.test(url)) ||
                 "";
               const prompt = extractNextPrompt(stage9?.body || "", issue);
               const signal = [
@@ -348,6 +354,8 @@ jobs:
 
             const posted = results.filter((result) => result.outcome === "posted").length;
             const failed = results.filter((result) => result.outcome === "failed").length;
+            const notificationAttempts = posted + failed;
+            const workflowConclusion = failed > 0 ? "failure" : "success";
             const now = new Date().toISOString();
             fs.writeFileSync(process.env.DUUMBI_METRICS_PATH, `${JSON.stringify({
               schema_version: "duumbi.workflow_metrics.v1",
@@ -363,7 +371,7 @@ jobs:
                 actor: context.actor,
                 ref: context.ref,
                 sha: context.sha,
-                conclusion: "success",
+                conclusion: workflowConclusion,
                 started_at: now,
                 completed_at: now,
                 duration_ms: null,
@@ -378,7 +386,7 @@ jobs:
               counts: {
                 issues_considered: candidates.length,
                 issues_queued: posted,
-                slack_notifications_attempted: posted,
+                slack_notifications_attempted: notificationAttempts,
                 artifact_links_found: null,
                 artifact_links_missing: null,
               },

--- a/docs/automation/agentic-development-orchestration.md
+++ b/docs/automation/agentic-development-orchestration.md
@@ -41,6 +41,7 @@ or source-repo contracts that support it.
 | `triage-queue-refill.yml` | every 4 hours, manual | Reads Project V2 `Needs Human Acceptance` count and uses a bounded DeepSeek Stage 4 triage refill when fewer than three issues are waiting. |
 | `clarification-routing.yml` | issue comment created, manual | Filters for explicit `@Clarification` comments on `needs-human-review` issues, uses DeepSeek for synthesis, posts a GitHub comment, and sends Slack. |
 | `spec-ai-gate.yml` | manual, repository dispatch | Records Stage 7/9 AI gate decisions and dispatches `stage-approval.yml` for clean approvals. |
+| `ready-for-build-handoff.yml` | `tech-spec-approved` label, every 15 minutes, manual | Sends the Stage 10 Slack handoff when an issue becomes Ready for Build, with an idempotent issue marker so the notification can be retried independently from `stage-approval.yml`. |
 | `stage10-authorization-request.yml` | label, hourly, manual, repository dispatch | Sends Stage 10 resource authorization Slack notifications and records resource decisions. |
 | `stage11-review-request.yml` | label, hourly, manual | Sends implementation review handoff notifications and records the Stage 11 notification marker. |
 | `stage11-merge-decision.yml` | manual, repository dispatch | Processes explicit human merge authorization, fails closed on missing evidence, and squash-merges only when Stage 11 evidence, CI, and Copilot review are clean. |
@@ -161,6 +162,16 @@ reviewers, fix and resolve review feedback, route to `Technical Spec Review`,
 then run Stage 9 through the configured AI or human gate. Only a satisfied
 Stage 9 gate may merge the technical spec PR, move the issue to `Ready for
 Build`, and send the Stage 10 prompt.
+
+`ready-for-build-handoff.yml` is the fallback and retry path for the Stage 10
+Slack handoff. It posts when `tech-spec-approved` is added and also scans for
+open issues that are already labeled `tech-spec-approved` or whose Project V2
+Status is `Ready for Build`. It records
+`<!-- duumbi-ready-for-build-slack-notified:v1 issue=N -->` on the issue after a
+successful Slack post, so reruns and scheduled scans do not duplicate the same
+handoff. This keeps Slack delivery independent from `stage-approval.yml` merge
+or validation failures while preserving GitHub Issues and Project V2 as the
+source of truth.
 
 Stage 11 merge remains human-authorized. The merge workflow requires explicit
 human decision, Stage 11 review artifact, green checks, clean Copilot review,


### PR DESCRIPTION
## Summary

- Add a dedicated Ready For Build Handoff workflow that posts the Stage 10 prompt through GitHub Actions Slack secrets when `tech-spec-approved` is added.
- Add scheduled/manual retry coverage for issues already labeled `tech-spec-approved` or in Project V2 `Ready for Build`.
- Document the workflow and idempotent issue marker.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ready-for-build-handoff.yml"); puts "yaml ok"'`
- embedded workflow script syntax checked with `node --input-type=module --check`
- `git diff --check`

Related to #376.
