### PR TITLE
[codex] Enrich inbox notes directly from workflow

### DIFF
--- a/.agents/skills/duumbi-inbox-enrichment/SKILL.md
+++ b/.agents/skills/duumbi-inbox-enrichment/SKILL.md
@@ -49,10 +49,12 @@ Use this skill for:
 - a bounded list of Inbox note paths
 - a scheduled sweep of notes that lack the standard Inbox contract, classification, or enrichment marker
 
-For scheduled sweeps, process a bounded batch. Default maximum: 5 notes per run.
-Scheduled dispatchers should inspect the Inbox before sending an agent handoff.
-If no candidate notes are present, they should record `not_needed` in workflow
-summary/metrics and skip Slack notification.
+For manual agent sweeps, process a bounded batch. Default maximum: 5 notes per
+run. The GitHub Actions scheduled workflow processes at most one note per run,
+commits the same Inbox note directly to `duumbi-vault/main`, and marks it with
+`duumbi/status/processed` plus `duumbi-inbox-enrichment:v1`. If no candidate
+notes are present, or if the selected note does not produce a vault commit, the
+workflow records `not_needed` in summary/metrics and skips Slack notification.
 
 ## Context To Inspect
 
@@ -126,6 +128,11 @@ If the note is raw, preserve the original text and append or rewrite only enough
 - Assumptions:
 - Recommendations:
 ```
+
+The automated workflow also adds a developer summary, a Mermaid UML-style
+overview, AI-agent instructions for later GitHub issue creation, and Obsidian
+tags for processed state, classification, business value, importance, and
+complexity.
 
 If the note already follows the contract, append or update only `## Enrichment result`.
 

--- a/.agents/skills/duumbi-inbox-enrichment/SKILL.md
+++ b/.agents/skills/duumbi-inbox-enrichment/SKILL.md
@@ -54,7 +54,8 @@ run. The GitHub Actions scheduled workflow processes at most one note per run,
 commits the same Inbox note directly to `duumbi-vault/main`, and marks it with
 `duumbi/status/processed` plus `duumbi-inbox-enrichment:v1`. If no candidate
 notes are present, or if the selected note does not produce a vault commit, the
-workflow records `not_needed` in summary/metrics and skips Slack notification.
+workflow records `no_candidate_note` or `no_vault_diff` in metrics and skips
+Slack notification.
 
 ## Context To Inspect
 

--- a/.github/workflows/inbox-enrichment-dispatch.yml
+++ b/.github/workflows/inbox-enrichment-dispatch.yml
@@ -10,11 +10,11 @@ on:
         required: false
         type: string
         default: ''
-      batch_size:
-        description: Maximum notes to enrich in one run
+      scan_limit:
+        description: Maximum Inbox notes to inspect while looking for one candidate
         required: false
         type: number
-        default: 5
+        default: 200
 
 permissions:
   contents: read
@@ -25,9 +25,14 @@ concurrency:
 
 jobs:
   dispatch:
-    name: Dispatch enrichment prompt
+    name: Enrich one Inbox note
     runs-on: ubuntu-latest
     steps:
+      - name: Check out source repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
       - name: Checkout DUUMBI vault
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         continue-on-error: true
@@ -35,227 +40,30 @@ jobs:
           repository: ${{ github.repository_owner }}/duumbi-vault
           path: duumbi-vault
           token: ${{ secrets.GH_PROJECT_PAT || github.token }}
-          persist-credentials: false
+          persist-credentials: true
 
-      - name: Build dispatch record
-        id: dispatch
+      - name: Enrich Inbox note
+        id: enrich
         uses: actions/github-script@v9
         env:
+          GH_PROJECT_PAT: ${{ secrets.GH_PROJECT_PAT }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          DEEPSEEK_MODEL: ${{ vars.DEEPSEEK_MODEL || 'deepseek-v4-pro' }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_REVIEW_CHANNEL_ID: ${{ secrets.SLACK_REVIEW_CHANNEL_ID }}
           DUUMBI_AGENT_DISPATCH_CHANNEL_ID: ${{ secrets.DUUMBI_AGENT_DISPATCH_CHANNEL_ID }}
           DUUMBI_METRICS_PATH: duumbi-workflow-metrics.json
         with:
           script: |
-            const fs = require("fs");
-            const path = require("path");
-            const inputs = context.payload.inputs || {};
-            const targetPath = String(inputs.target_path || "").trim();
-            const batchSize = Number(inputs.batch_size || 5);
-            const effectiveBatchSize = Number.isFinite(batchSize) && batchSize > 0 ? batchSize : 5;
-            const vaultRoot = path.resolve("duumbi-vault");
-            const inboxRoot = path.join(vaultRoot, "Duumbi", "00 Inbox (ToProcess)");
-            const warnings = [];
-            let workflowConclusion = "success";
-            let inspectedCount = 0;
-
-            const toVaultRelative = (absolutePath) => path.relative(vaultRoot, absolutePath).split(path.sep).join("/");
-            const isEnrichmentCandidate = (absolutePath) => {
-              const text = fs.readFileSync(absolutePath, "utf8");
-              const requiredSections = [
-                "## Source",
-                "## Raw input",
-                "## Interpreted intent",
-                "## Classification",
-                "## Clarifications",
-                "### Answered",
-                "### Open",
-                "## Relevant DUUMBI context",
-                "## Related GitHub context",
-                "## Initial routing recommendation",
-                "## Requested follow-up",
-                "## Enrichment result",
-              ];
-              return requiredSections.some((section) => !text.includes(section));
-            };
-            const collectCandidatePaths = (dir, limit) => {
-              const candidates = [];
-              const visit = (currentDir) => {
-                const entries = fs.readdirSync(currentDir, { withFileTypes: true })
-                  .sort((a, b) => a.name.localeCompare(b.name));
-                for (const entry of entries) {
-                  if (candidates.length >= limit) return;
-                  const fullPath = path.join(currentDir, entry.name);
-                  if (entry.isDirectory()) {
-                    visit(fullPath);
-                  } else if (entry.isFile() && entry.name.endsWith(".md")) {
-                    inspectedCount += 1;
-                    if (isEnrichmentCandidate(fullPath)) {
-                      candidates.push(toVaultRelative(fullPath));
-                    }
-                  }
-                }
-              };
-              visit(dir);
-              return candidates;
-            };
-
-            let candidatePaths = [];
-            if (!fs.existsSync(inboxRoot)) {
-              warnings.push("DUUMBI vault Inbox path is unavailable; enrichment dispatch failed closed.");
-              workflowConclusion = "failure";
-              core.setFailed(`Missing Inbox path: ${inboxRoot}`);
-            } else if (targetPath) {
-              const normalizedTarget = targetPath.replace(/^duumbi-vault\//, "").replace(/^\/+/, "");
-              const targetAbsolute = path.resolve(vaultRoot, normalizedTarget);
-              const relativeToInbox = path.relative(inboxRoot, targetAbsolute);
-              if (relativeToInbox.startsWith("..") || path.isAbsolute(relativeToInbox)) {
-                warnings.push("Target path is outside Duumbi/00 Inbox (ToProcess); no dispatch sent.");
-                workflowConclusion = "failure";
-                core.setFailed(`Target path is outside Inbox: ${targetPath}`);
-              } else if (!fs.existsSync(targetAbsolute) || !fs.statSync(targetAbsolute).isFile()) {
-                warnings.push("Target Inbox note does not exist; no dispatch sent.");
-                workflowConclusion = "failure";
-                core.setFailed(`Target Inbox note not found: ${targetPath}`);
-              } else {
-                inspectedCount = 1;
-                candidatePaths = isEnrichmentCandidate(targetAbsolute) ? [toVaultRelative(targetAbsolute)] : [];
-              }
-            } else {
-              candidatePaths = collectCandidatePaths(inboxRoot, effectiveBatchSize);
-            }
-
-            const shouldDispatch = candidatePaths.length > 0;
-            const dispatchDecision = workflowConclusion === "failure"
-              ? "dispatch_blocked"
-              : shouldDispatch
-                ? "dispatch_requested"
-                : "dispatch_not_needed";
-            const prompt = shouldDispatch ? [
-              "Run DUUMBI scheduled Inbox enrichment with duumbi-inbox-enrichment.",
-              "",
-              targetPath
-                ? `Target Inbox note: ${candidatePaths[0]}`
-                : "Target: bounded scheduled sweep of untagged or unnormalized notes under Duumbi/00 Inbox (ToProcess)/",
-              `Batch size: ${effectiveBatchSize}`,
-              "",
-              "Candidate notes:",
-              ...candidatePaths.map((candidatePath) => `- ${candidatePath}`),
-              "",
-              "Goal: Normalize manually edited Inbox notes into the DUUMBI Inbox contract, classify them, detect duplicates against active Inbox, Processed Inbox, Atlas, GitHub Issues, and GitHub Discussions, and leave them ready for Stage 4 triage.",
-              "",
-              "Do not create GitHub issues, specs, PRs, source changes, Atlas notes, or implementation work.",
-            ].join("\n") : "";
-
-            const token = process.env.SLACK_BOT_TOKEN;
-            const channel = process.env.DUUMBI_AGENT_DISPATCH_CHANNEL_ID || process.env.SLACK_REVIEW_CHANNEL_ID;
-            let slackNotification = shouldDispatch ? "not_configured" : "not_needed";
-            if (shouldDispatch && token && channel) {
-              const res = await fetch("https://slack.com/api/chat.postMessage", {
-                method: "POST",
-                headers: {
-                  Authorization: `Bearer ${token}`,
-                  "Content-Type": "application/json; charset=utf-8",
-                },
-                body: JSON.stringify({
-                  channel,
-                  text: [
-                    "*DUUMBI Inbox Enrichment Dispatch*",
-                    `*Repository:* ${context.repo.owner}/${context.repo.repo}`,
-                    `*Workflow run:* ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-                    "",
-                    "```",
-                    prompt,
-                    "```",
-                  ].join("\n"),
-                }),
-              });
-              const body = await res.json();
-              if (!res.ok || !body.ok) {
-                core.warning(`Slack notification failed: ${body.error || res.status}`);
-                slackNotification = "failed";
-              } else {
-                slackNotification = "posted";
-              }
-            } else if (shouldDispatch) {
-              core.warning("Slack dispatch channel is not configured; prompt is available in the workflow summary.");
-            }
-
-            const now = new Date().toISOString();
-            const metrics = {
-              schema_version: "duumbi.workflow_metrics.v1",
-              generated_at: now,
-              source: "github_actions",
-              repository: `${context.repo.owner}/${context.repo.repo}`,
-              workflow: {
-                name: context.workflow,
-                file: ".github/workflows/inbox-enrichment-dispatch.yml",
-                run_id: context.runId,
-                run_attempt: Number(process.env.GITHUB_RUN_ATTEMPT || 1),
-                event_name: context.eventName,
-                actor: context.actor,
-                ref: context.ref,
-                sha: context.sha,
-                conclusion: workflowConclusion,
-                started_at: now,
-                completed_at: now,
-                duration_ms: null,
-              },
-              correlation: {
-                issue_number: null,
-                pr_number: null,
-                stage: "inbox-enrichment",
-                decision: dispatchDecision,
-                project_status: null,
-              },
-              counts: {
-                issues_considered: inspectedCount,
-                issues_queued: candidatePaths.length,
-                slack_notifications_attempted: shouldDispatch && token && channel ? 1 : 0,
-                artifact_links_found: candidatePaths.length,
-                artifact_links_missing: null,
-              },
-              provider_usage: {
-                available: false,
-                reason: "agent_dispatch_only",
-                provider: null,
-                model: null,
-                request_count: null,
-                prompt_tokens: null,
-                completion_tokens: null,
-                total_tokens: null,
-                estimated_cost_usd: null,
-                latency_ms: null,
-                failure_count: null,
-              },
-              privacy: {
-                metadata_only: true,
-                raw_prompts_included: false,
-                raw_completions_included: false,
-                raw_slack_payloads_included: false,
-                secrets_included: false,
-              },
-              warnings: [
-                ...warnings,
-                ...(!shouldDispatch && workflowConclusion === "success" ? ["slack_notification_not_needed"] : []),
-                ...(shouldDispatch && slackNotification !== "posted" ? [`slack_notification_${slackNotification}`] : []),
-              ],
-            };
-            fs.writeFileSync(process.env.DUUMBI_METRICS_PATH, `${JSON.stringify(metrics, null, 2)}\n`);
-
-            const summary = core.summary
-              .addHeading("DUUMBI Inbox Enrichment Dispatch", 2)
-              .addTable([
-                [{ data: "Field", header: true }, { data: "Value", header: true }],
-                ["Target", targetPath || "scheduled sweep"],
-                ["Batch size", String(effectiveBatchSize)],
-                ["Inbox notes inspected", String(inspectedCount)],
-                ["Candidate notes", candidatePaths.length ? candidatePaths.join("<br>") : "none"],
-                ["Dispatch needed", String(shouldDispatch)],
-                ["Slack dispatch", slackNotification],
-              ]);
-            if (prompt) summary.addHeading("Agent Prompt", 3).addCodeBlock(prompt, "text");
-            await summary.write();
+            const enrichment = await import(`${process.env.GITHUB_WORKSPACE}/scripts/github-actions/inbox-enrichment-dispatch.mjs`);
+            await enrichment.runInboxEnrichment({
+              env: process.env,
+              context,
+              core,
+              summary: core.summary,
+              fetchImpl: fetch,
+              workspace: process.env.GITHUB_WORKSPACE,
+            });
 
       - name: Upload DUUMBI workflow metrics
         if: always()

--- a/docs/automation/agentic-development-orchestration.md
+++ b/docs/automation/agentic-development-orchestration.md
@@ -37,7 +37,7 @@ or source-repo contracts that support it.
 | Workflow | Trigger | Purpose |
 |---|---|---|
 | `slack-intake-dispatch.yml` | Slack shortcut repository dispatch, manual | Dispatches Stage 1 Slack intake without requiring the developer to name the skill. |
-| `inbox-enrichment-dispatch.yml` | 06:00 UTC and 18:00 UTC, manual | Checks `duumbi-vault` for unnormalized Inbox notes and dispatches `duumbi-inbox-enrichment` only when candidate notes exist. |
+| `inbox-enrichment-dispatch.yml` | 06:00 UTC and 18:00 UTC, manual | Uses DeepSeek to enrich one unprocessed Inbox note in `duumbi-vault/main`, then posts Slack only when a vault commit is created. |
 | `triage-queue-refill.yml` | every 4 hours, manual | Reads Project V2 `Needs Human Acceptance` count and uses a bounded DeepSeek Stage 4 triage refill when fewer than three issues are waiting. |
 | `clarification-routing.yml` | issue comment created, manual | Filters for explicit `@Clarification` comments on `needs-human-review` issues, uses DeepSeek for synthesis, posts a GitHub comment, and sends Slack. |
 | `spec-ai-gate.yml` | manual, repository dispatch | Records Stage 7/9 AI gate decisions and dispatches `stage-approval.yml` for clean approvals. |
@@ -65,12 +65,15 @@ closed.
 - `SLACK_REVIEW_CHANNEL_ID`: human review channel.
 - `DUUMBI_AGENT_DISPATCH_CHANNEL_ID`: optional agent dispatch channel; falls
   back to `SLACK_REVIEW_CHANNEL_ID`.
-- `GH_PROJECT_PAT`: PAT that can read and update GitHub Project V2.
-- `DEEPSEEK_API_KEY`: DeepSeek API key used by `triage-queue-refill.yml`
-  when the `Needs Human Acceptance` queue is below target, and by
-  `clarification-routing.yml` for explicit `@Clarification` synthesis.
-- `DEEPSEEK_MODEL`: optional repository variable for the refill model; defaults
-  to `deepseek-v4-pro`.
+- `GH_PROJECT_PAT`: PAT that can read and update GitHub Project V2 and write
+  enrichment commits to `duumbi-vault/main`.
+- `DEEPSEEK_API_KEY`: DeepSeek API key used by
+  `inbox-enrichment-dispatch.yml` for one-note Inbox preparation, by
+  `triage-queue-refill.yml` when the `Needs Human Acceptance` queue is below
+  target, and by `clarification-routing.yml` for explicit `@Clarification`
+  synthesis.
+- `DEEPSEEK_MODEL`: optional repository variable for DeepSeek-backed
+  automation; defaults to `deepseek-v4-pro`.
 - `DUUMBI_PROJECT_NUMBER`: repository variable for the Project V2 number used by
   `triage-queue-refill.yml`.
 - `DUUMBI_PROJECT_OWNER`: optional repository variable; defaults to repository
@@ -89,6 +92,27 @@ The workflow calls DeepSeek for a bounded JSON clarification synthesis, writes
 the synthesis as an issue comment, and sends a Slack notification when Slack
 secrets are configured. It does not update labels, Project V2 status, specs,
 PRs, or source code.
+
+## Inbox Enrichment Policy
+
+`inbox-enrichment-dispatch.yml` scans `Duumbi/00 Inbox (ToProcess)/` in
+`duumbi-vault`, selects at most one unprocessed Markdown note per run, and asks
+DeepSeek for a bounded English enrichment using active vault docs plus selected
+source-code context. It rewrites only that Inbox note, commits directly to
+`duumbi-vault/main` with `GH_PROJECT_PAT`, and never creates GitHub issues,
+specs, PRs, Atlas notes, or implementation changes.
+
+The enriched note must include the original raw input, interpreted intent,
+developer summary, Mermaid UML-style overview, classification, business value,
+importance, complexity, scope, risks, open questions, and instructions for a
+later AI agent that will create a GitHub issue. The workflow marks completion
+with `duumbi/status/processed` and the `duumbi-inbox-enrichment:v1` marker, so
+later scheduled runs ignore the note.
+
+Slack is commit-gated. If no candidate note exists, or if the selected note
+does not produce a vault diff, the workflow records metadata-only metrics and
+does not post Slack. If a note is committed and Slack secrets are configured,
+the workflow posts a short metadata-only completion notification.
 
 ## Stage 4 Refill LLM Policy
 

--- a/scripts/github-actions/inbox-enrichment-dispatch.mjs
+++ b/scripts/github-actions/inbox-enrichment-dispatch.mjs
@@ -1,0 +1,983 @@
+import { execFileSync } from "node:child_process";
+import fsModule from "node:fs";
+import pathModule from "node:path";
+
+import {
+  DEFAULT_DEEPSEEK_MODEL,
+  callDeepSeek,
+  estimateDeepSeekCostUsd,
+  normalizeText,
+  truncateText,
+} from "./triage-queue-refill.mjs";
+
+export const WORKFLOW_FILE = ".github/workflows/inbox-enrichment-dispatch.yml";
+export const ENRICHMENT_MARKER_PREFIX = "<!-- duumbi-inbox-enrichment:v1";
+export const DEFAULT_SCAN_LIMIT = 200;
+
+const REQUIRED_ENRICHMENT_SECTIONS = [
+  "## Source",
+  "## Raw input",
+  "## Interpreted intent",
+  "## Developer summary",
+  "## UML overview",
+  "## Classification",
+  "## Clarifications",
+  "### Answered",
+  "### Open",
+  "## Relevant DUUMBI context",
+  "## Related GitHub context",
+  "## Initial routing recommendation",
+  "## Requested follow-up",
+  "## AI agent instructions",
+  "## Obsidian tags",
+  "## Enrichment result",
+];
+
+const ACTIVE_VAULT_DOCS = [
+  "Duumbi/How to use.md",
+  "Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - PRD.md",
+  "Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - Glossary.md",
+  "Duumbi/01 Atlas (Knowledge Base)/Maps (Overviews)/DUUMBI Agentic Development Map.md",
+  "Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - Agentic Development Runbook.md",
+];
+
+const SOURCE_CONTEXT_FILES = [
+  "AGENTS.md",
+  "docs/architecture.md",
+  "docs/coding-conventions.md",
+  "Cargo.toml",
+  "src/types.rs",
+  "src/graph/mod.rs",
+  "src/compiler/mod.rs",
+  "src/agents/mod.rs",
+  "src/mcp/mod.rs",
+  "crates/duumbi-studio/src/lib.rs",
+];
+
+const CLASSIFICATIONS = new Set([
+  "idea",
+  "bug",
+  "feature",
+  "research",
+  "architecture",
+  "execution",
+  "knowledge",
+  "skill",
+  "unclear",
+]);
+
+const ESTIMATE_LEVELS = new Set(["low", "medium", "high", "critical"]);
+const RESULT_STATUSES = new Set([
+  "ready_for_triage",
+  "duplicate_candidate",
+  "needs_clarification",
+  "no_action_candidate",
+]);
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function parsePositiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function stripJsonFence(value) {
+  const text = normalizeText(value);
+  const fenceMatch = text.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  return fenceMatch ? fenceMatch[1].trim() : text;
+}
+
+function sanitizeTitle(value) {
+  const title = truncateText(value, 140).replace(/\s+/g, " ").trim();
+  return title || "Prepared DUUMBI Inbox Task";
+}
+
+function normalizeEnum(value, allowed, fallback) {
+  const normalized = normalizeText(value).toLowerCase().replace(/\s+/g, "_");
+  return allowed.has(normalized) ? normalized : fallback;
+}
+
+function normalizeStringArray(value, maxItems = 12, maxLength = 1200) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => truncateText(item, maxLength))
+    .filter(Boolean)
+    .slice(0, maxItems);
+}
+
+function markdownList(items, fallback = "- none") {
+  const values = normalizeStringArray(items);
+  return values.length ? values.map((item) => `- ${item}`).join("\n") : fallback;
+}
+
+function markdownBlockquote(value) {
+  const text = String(value ?? "").replace(/\r\n?/g, "\n").trimEnd();
+  if (!text) return "> none";
+  return text.split("\n").map((line) => `> ${line}`).join("\n");
+}
+
+function stripMarkdownFence(value) {
+  return normalizeText(value)
+    .replace(/^```(?:mermaid)?\s*/i, "")
+    .replace(/\s*```$/i, "")
+    .trim();
+}
+
+function defaultDiagram(title) {
+  const safeTitle = title.replace(/[\[\]{}<>]/g, "").slice(0, 60) || "Prepared task";
+  return [
+    "flowchart TD",
+    "  Raw[Raw inbox note] --> Enriched[Prepared task brief]",
+    `  Enriched --> Goal[${safeTitle}]`,
+    "  Goal --> Triage[Stage 4 triage]",
+    "  Triage --> Issue[Future GitHub issue]",
+  ].join("\n");
+}
+
+function tagName(value) {
+  return normalizeText(value).toLowerCase().replace(/[^a-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "") || "unclear";
+}
+
+export function buildObsidianTags(decision) {
+  return [
+    "duumbi/inbox/enriched",
+    "duumbi/status/processed",
+    `duumbi/classification/${tagName(decision.classification)}`,
+    `duumbi/value/${tagName(decision.business_value)}`,
+    `duumbi/importance/${tagName(decision.importance)}`,
+    `duumbi/complexity/${tagName(decision.complexity)}`,
+  ];
+}
+
+export function hasProcessedMarker(text) {
+  const normalized = String(text ?? "").toLowerCase();
+  return normalized.includes("duumbi-inbox-enrichment:v1")
+    || normalized.includes("duumbi/status/processed")
+    || normalized.includes("#duumbi/status/processed");
+}
+
+export function isEnrichmentCandidateText(text) {
+  const value = String(text ?? "");
+  if (!normalizeText(value) || hasProcessedMarker(value)) return false;
+  return REQUIRED_ENRICHMENT_SECTIONS.some((section) => !value.includes(section));
+}
+
+function toVaultRelative(path, vaultRoot, absolutePath) {
+  return path.relative(vaultRoot, absolutePath).split(path.sep).join("/");
+}
+
+function normalizeTargetPath(path, vaultRoot, inboxRoot, targetPath) {
+  const normalizedTarget = String(targetPath || "").trim().replace(/^duumbi-vault\//, "").replace(/^\/+/, "");
+  const targetAbsolute = path.resolve(vaultRoot, normalizedTarget);
+  const relativeToInbox = path.relative(inboxRoot, targetAbsolute);
+  if (relativeToInbox.startsWith("..") || path.isAbsolute(relativeToInbox)) {
+    throw new Error(`Target path is outside Duumbi/00 Inbox (ToProcess): ${targetPath}`);
+  }
+  return targetAbsolute;
+}
+
+export function collectCandidatePaths({
+  fs = fsModule,
+  path = pathModule,
+  vaultRoot,
+  inboxRoot,
+  targetPath = "",
+  scanLimit = DEFAULT_SCAN_LIMIT,
+}) {
+  if (!fs.existsSync(inboxRoot) || !fs.statSync(inboxRoot).isDirectory()) {
+    throw new Error(`Missing Inbox path: ${inboxRoot}`);
+  }
+
+  let inspectedCount = 0;
+  const candidatePaths = [];
+  const effectiveScanLimit = parsePositiveInteger(scanLimit, DEFAULT_SCAN_LIMIT);
+
+  const inspectFile = (absolutePath) => {
+    inspectedCount += 1;
+    const text = fs.readFileSync(absolutePath, "utf8");
+    if (isEnrichmentCandidateText(text)) {
+      candidatePaths.push(toVaultRelative(path, vaultRoot, absolutePath));
+    }
+  };
+
+  if (targetPath) {
+    const targetAbsolute = normalizeTargetPath(path, vaultRoot, inboxRoot, targetPath);
+    if (!fs.existsSync(targetAbsolute) || !fs.statSync(targetAbsolute).isFile()) {
+      throw new Error(`Target Inbox note not found: ${targetPath}`);
+    }
+    inspectFile(targetAbsolute);
+    return { candidatePaths: candidatePaths.slice(0, 1), inspectedCount };
+  }
+
+  const visit = (currentDir) => {
+    if (candidatePaths.length >= 1 || inspectedCount >= effectiveScanLimit) return;
+    const entries = fs.readdirSync(currentDir, { withFileTypes: true })
+      .sort((a, b) => a.name.localeCompare(b.name));
+    for (const entry of entries) {
+      if (candidatePaths.length >= 1 || inspectedCount >= effectiveScanLimit) return;
+      const fullPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        visit(fullPath);
+      } else if (entry.isFile() && entry.name.endsWith(".md")) {
+        inspectFile(fullPath);
+      }
+    }
+  };
+
+  visit(inboxRoot);
+  return { candidatePaths, inspectedCount };
+}
+
+function readRelativeFiles(fs, path, root, relativePaths, warnings, maxChars = 4000) {
+  return relativePaths.flatMap((relativePath) => {
+    const absolutePath = path.join(root, relativePath);
+    if (!fs.existsSync(absolutePath) || !fs.statSync(absolutePath).isFile()) {
+      warnings.push(`Context file is missing: ${relativePath}`);
+      return [];
+    }
+    return [{
+      path: relativePath,
+      text: truncateText(fs.readFileSync(absolutePath, "utf8"), maxChars),
+    }];
+  });
+}
+
+function readMarkdownNotes(fs, path, root, baseRoot, limit, maxChars, excluded = new Set()) {
+  if (!fs.existsSync(root) || !fs.statSync(root).isDirectory()) return [];
+  const notes = [];
+  const visit = (dir) => {
+    if (notes.length >= limit) return;
+    const entries = fs.readdirSync(dir, { withFileTypes: true })
+      .sort((a, b) => a.name.localeCompare(b.name));
+    for (const entry of entries) {
+      if (notes.length >= limit) return;
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        visit(fullPath);
+      } else if (entry.isFile() && entry.name.endsWith(".md")) {
+        const relativePath = toVaultRelative(path, baseRoot, fullPath);
+        if (!excluded.has(relativePath)) {
+          notes.push({
+            path: relativePath,
+            text: truncateText(fs.readFileSync(fullPath, "utf8"), maxChars),
+          });
+        }
+      }
+    }
+  };
+  visit(root);
+  return notes;
+}
+
+export function buildEnrichmentContext({
+  fs = fsModule,
+  path = pathModule,
+  workspace,
+  vaultRoot,
+  candidatePath,
+  warnings = [],
+}) {
+  const candidateAbsolute = path.join(vaultRoot, candidatePath);
+  const candidateText = fs.readFileSync(candidateAbsolute, "utf8");
+  const duumbiRoot = path.join(vaultRoot, "Duumbi");
+  const inboxRoot = path.join(duumbiRoot, "00 Inbox (ToProcess)");
+  const processedInboxRoot = path.join(duumbiRoot, "05 Archive", "Processed Inbox");
+  const atlasRoot = path.join(duumbiRoot, "01 Atlas (Knowledge Base)");
+  const excluded = new Set([candidatePath]);
+
+  return {
+    generated_at: nowIso(),
+    repository: "hgahub/duumbi",
+    vault_repository: "hgahub/duumbi-vault",
+    stage: "inbox-enrichment",
+    policy: {
+      max_notes_to_update: 1,
+      writes_allowed: ["same Inbox note in duumbi-vault/main"],
+      forbidden: [
+        "Do not create GitHub issues.",
+        "Do not create pull requests.",
+        "Do not move or archive Inbox notes.",
+        "Do not modify source code.",
+        "Do not start implementation.",
+      ],
+    },
+    candidate_note: {
+      path: candidatePath,
+      text: truncateText(candidateText, 9000),
+    },
+    active_vault_docs: readRelativeFiles(fs, path, vaultRoot, ACTIVE_VAULT_DOCS, warnings, 4500),
+    source_code_context: readRelativeFiles(fs, path, workspace, SOURCE_CONTEXT_FILES, warnings, 3500),
+    duplicate_context: {
+      active_inbox_notes: readMarkdownNotes(fs, path, inboxRoot, vaultRoot, 8, 2000, excluded),
+      processed_inbox_notes: readMarkdownNotes(fs, path, processedInboxRoot, vaultRoot, 8, 2000),
+      atlas_notes: readMarkdownNotes(fs, path, atlasRoot, vaultRoot, 8, 2200),
+    },
+  };
+}
+
+export function buildDeepSeekMessages(contextPayload) {
+  const schema = {
+    title: "short developer-readable title",
+    interpreted_intent: "what the user is asking for",
+    classification: "idea | bug | feature | research | architecture | execution | knowledge | skill | unclear",
+    business_value: "low | medium | high | critical",
+    importance: "low | medium | high | critical",
+    complexity: "low | medium | high | critical",
+    developer_summary: "clear implementation-oriented summary for humans",
+    uml_diagram_mermaid: "Mermaid diagram body only; no markdown fences",
+    clarifications_answered: ["facts already clear from the input/context"],
+    clarifications_open: ["questions a human may need to answer before implementation"],
+    relevant_duumbi_context: ["vault or source paths and why they matter"],
+    related_github_context: "known related GitHub state, or say triage should verify later",
+    initial_routing_recommendation: "GitHub issue | GitHub Discussion | Dot/Map/Work | skill update | no action | needs clarification | duplicate",
+    requested_follow_up: ["explicit requested next actions"],
+    ai_agent_instructions: ["instructions for later agents that will create a GitHub issue"],
+    scope_in: ["candidate scope"],
+    scope_out: ["non-goals"],
+    risks: ["risks or trade-offs"],
+    facts: ["factual observations"],
+    assumptions: ["assumptions to verify"],
+    recommendations: ["routing or implementation recommendations"],
+    status: "ready_for_triage | duplicate_candidate | needs_clarification | no_action_candidate",
+  };
+
+  return [
+    {
+      role: "system",
+      content: [
+        "You are the DUUMBI Inbox Enrichment Agent.",
+        "Return exactly one valid JSON object and no markdown outside JSON.",
+        "Write durable note content in English.",
+        "Prepare exactly one raw Inbox note for later Stage 4 triage.",
+        "Use the DUUMBI vault and source-code context to make the task understandable to a human developer.",
+        "Include a concise UML-style Mermaid diagram body. Prefer classDiagram or sequenceDiagram when appropriate; use flowchart TD only when a task-flow diagram is clearer.",
+        "Add practical AI-agent instructions for a later agent that will create a GitHub issue.",
+        "Clearly separate facts, assumptions, risks, and open questions.",
+        "Do not invent completed work, GitHub issue numbers, approvals, or implementation details that are not present in the supplied context.",
+        "Do not create GitHub issues, specs, PRs, source changes, Atlas notes, or implementation work.",
+        `Expected JSON schema example: ${JSON.stringify(schema)}`,
+      ].join("\n"),
+    },
+    {
+      role: "user",
+      content: JSON.stringify(contextPayload, null, 2),
+    },
+  ];
+}
+
+function buildJsonRepairMessages({ baseMessages, invalidContent, parseError }) {
+  return [
+    {
+      role: "system",
+      content: [
+        "Repair one DUUMBI Inbox enrichment response.",
+        "Return exactly one valid strict JSON object and no markdown outside JSON.",
+        "Do not include comments, trailing commas, prose outside JSON, or JSON5 syntax.",
+        `Previous parser error: ${truncateText(parseError?.message || parseError, 300)}`,
+      ].join("\n"),
+    },
+    ...baseMessages,
+    {
+      role: "user",
+      content: [
+        "Repair this malformed enrichment response into one valid JSON object:",
+        truncateText(invalidContent, 5000),
+      ].join("\n\n"),
+    },
+  ];
+}
+
+export function parseEnrichmentDecision(content) {
+  const text = stripJsonFence(content);
+  try {
+    const parsed = JSON.parse(text);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("Enrichment response must be a JSON object.");
+    }
+    return parsed;
+  } catch (firstError) {
+    const start = text.indexOf("{");
+    const end = text.lastIndexOf("}");
+    if (start >= 0 && end > start) {
+      try {
+        const parsed = JSON.parse(text.slice(start, end + 1));
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed;
+      } catch {
+        // Fall through to the original parser error.
+      }
+    }
+    throw new Error(`DeepSeek enrichment response was not valid JSON: ${firstError.message}`);
+  }
+}
+
+export function validateEnrichmentDecision(decision) {
+  const title = sanitizeTitle(decision?.title);
+  const classification = normalizeEnum(decision?.classification, CLASSIFICATIONS, "unclear");
+  const businessValue = normalizeEnum(decision?.business_value, ESTIMATE_LEVELS, "medium");
+  const importance = normalizeEnum(decision?.importance, ESTIMATE_LEVELS, "medium");
+  const complexity = normalizeEnum(decision?.complexity, ESTIMATE_LEVELS, "medium");
+  const status = normalizeEnum(decision?.status, RESULT_STATUSES, "ready_for_triage");
+  const developerSummary = truncateText(decision?.developer_summary, 4000);
+  const interpretedIntent = truncateText(decision?.interpreted_intent, 2500);
+
+  if (!developerSummary) {
+    throw new Error("DeepSeek enrichment response is missing developer_summary.");
+  }
+  if (!interpretedIntent) {
+    throw new Error("DeepSeek enrichment response is missing interpreted_intent.");
+  }
+
+  const normalized = {
+    title,
+    interpreted_intent: interpretedIntent,
+    classification,
+    business_value: businessValue,
+    importance,
+    complexity,
+    developer_summary: developerSummary,
+    uml_diagram_mermaid: stripMarkdownFence(decision?.uml_diagram_mermaid) || defaultDiagram(title),
+    clarifications_answered: normalizeStringArray(decision?.clarifications_answered),
+    clarifications_open: normalizeStringArray(decision?.clarifications_open),
+    relevant_duumbi_context: normalizeStringArray(decision?.relevant_duumbi_context),
+    related_github_context: truncateText(decision?.related_github_context, 2500)
+      || "Not inspected; Stage 4 triage should verify GitHub state later.",
+    initial_routing_recommendation: truncateText(decision?.initial_routing_recommendation, 1000)
+      || "GitHub issue",
+    requested_follow_up: normalizeStringArray(decision?.requested_follow_up),
+    ai_agent_instructions: normalizeStringArray(decision?.ai_agent_instructions, 16, 1400),
+    scope_in: normalizeStringArray(decision?.scope_in),
+    scope_out: normalizeStringArray(decision?.scope_out),
+    risks: normalizeStringArray(decision?.risks),
+    facts: normalizeStringArray(decision?.facts),
+    assumptions: normalizeStringArray(decision?.assumptions),
+    recommendations: normalizeStringArray(decision?.recommendations),
+    status,
+  };
+  normalized.obsidian_tags = buildObsidianTags(normalized);
+  return normalized;
+}
+
+export function buildEnrichedNote({ originalText, decision, candidatePath, generatedAt = nowIso() }) {
+  const statusLabel = decision.status.replace(/_/g, " ");
+  const hashtagLine = decision.obsidian_tags.map((tag) => `#${tag}`).join(" ");
+
+  return [
+    "---",
+    "tags:",
+    ...decision.obsidian_tags.map((tag) => `  - ${tag}`),
+    "duumbi_inbox_enrichment: processed",
+    `duumbi_inbox_enrichment_generated_at: ${generatedAt}`,
+    "---",
+    "",
+    `# ${decision.title}`,
+    "",
+    `${ENRICHMENT_MARKER_PREFIX} status=processed generated_at=${generatedAt} -->`,
+    "",
+    "## Source",
+    "- Surface: Manual Obsidian edit",
+    `- Vault path: ${candidatePath}`,
+    "- Submitted by: unknown unless explicit in the raw input",
+    "",
+    "## Raw input",
+    markdownBlockquote(originalText),
+    "",
+    "## Interpreted intent",
+    "",
+    decision.interpreted_intent,
+    "",
+    "## Developer summary",
+    "",
+    decision.developer_summary,
+    "",
+    "## UML overview",
+    "",
+    "```mermaid",
+    decision.uml_diagram_mermaid,
+    "```",
+    "",
+    "## Classification",
+    `- Type: ${decision.classification}`,
+    `- Business value: ${decision.business_value}`,
+    `- Importance: ${decision.importance}`,
+    `- Complexity: ${decision.complexity}`,
+    "",
+    "## Clarifications",
+    "### Answered",
+    markdownList(decision.clarifications_answered),
+    "",
+    "### Open",
+    markdownList(decision.clarifications_open),
+    "",
+    "## Relevant DUUMBI context",
+    markdownList(decision.relevant_duumbi_context),
+    "",
+    "## Related GitHub context",
+    "",
+    decision.related_github_context,
+    "",
+    "## Initial routing recommendation",
+    "",
+    decision.initial_routing_recommendation,
+    "",
+    "## Requested follow-up",
+    markdownList(decision.requested_follow_up),
+    "",
+    "## AI agent instructions",
+    markdownList(decision.ai_agent_instructions),
+    "",
+    "## Scope candidate",
+    "### In",
+    markdownList(decision.scope_in),
+    "",
+    "### Out",
+    markdownList(decision.scope_out),
+    "",
+    "## Risks and trade-offs",
+    markdownList(decision.risks),
+    "",
+    "## Obsidian tags",
+    "",
+    hashtagLine,
+    "",
+    "## Enrichment result",
+    `- Date: ${generatedAt}`,
+    `- Status: ${statusLabel}`,
+    "- Canonical duplicate: none verified",
+    "- Facts:",
+    markdownList(decision.facts, "  - none"),
+    "- Assumptions:",
+    markdownList(decision.assumptions, "  - none"),
+    "- Recommendations:",
+    markdownList(decision.recommendations, "  - none"),
+    "",
+  ].join("\n");
+}
+
+function providerUsageNotCalled(reason) {
+  return {
+    available: false,
+    reason,
+    provider: null,
+    model: null,
+    request_count: null,
+    prompt_tokens: null,
+    completion_tokens: null,
+    total_tokens: null,
+    estimated_cost_usd: null,
+    latency_ms: null,
+    failure_count: null,
+  };
+}
+
+function providerUsageFromDeepSeek(model, usage, latencyMs, requestCount = 1) {
+  return {
+    available: true,
+    reason: "deepseek_api_call",
+    provider: "deepseek",
+    model,
+    request_count: requestCount,
+    prompt_tokens: Number.isFinite(Number(usage.prompt_tokens)) ? Number(usage.prompt_tokens) : null,
+    completion_tokens: Number.isFinite(Number(usage.completion_tokens)) ? Number(usage.completion_tokens) : null,
+    total_tokens: Number.isFinite(Number(usage.total_tokens)) ? Number(usage.total_tokens) : null,
+    estimated_cost_usd: estimateDeepSeekCostUsd(model, usage),
+    latency_ms: Number.isFinite(latencyMs) ? latencyMs : null,
+    failure_count: 0,
+  };
+}
+
+function combineDeepSeekUsage(responses) {
+  const usage = {
+    prompt_tokens: 0,
+    completion_tokens: 0,
+    total_tokens: 0,
+  };
+  let latencyMs = 0;
+  let hasPrompt = false;
+  let hasCompletion = false;
+  let hasTotal = false;
+
+  for (const response of responses) {
+    const current = response?.usage || {};
+    const promptTokens = Number(current.prompt_tokens);
+    const completionTokens = Number(current.completion_tokens);
+    const totalTokens = Number(current.total_tokens);
+    if (Number.isFinite(promptTokens)) {
+      usage.prompt_tokens += promptTokens;
+      hasPrompt = true;
+    }
+    if (Number.isFinite(completionTokens)) {
+      usage.completion_tokens += completionTokens;
+      hasCompletion = true;
+    }
+    if (Number.isFinite(totalTokens)) {
+      usage.total_tokens += totalTokens;
+      hasTotal = true;
+    }
+    const currentLatency = Number(response?.latencyMs);
+    if (Number.isFinite(currentLatency)) latencyMs += currentLatency;
+  }
+
+  return {
+    usage: {
+      prompt_tokens: hasPrompt ? usage.prompt_tokens : null,
+      completion_tokens: hasCompletion ? usage.completion_tokens : null,
+      total_tokens: hasTotal ? usage.total_tokens : null,
+    },
+    latencyMs: latencyMs || null,
+  };
+}
+
+async function getParsedEnrichmentDecision({ fetchImpl, apiKey, model, messages, core, warnings }) {
+  const responses = [];
+  const firstResponse = await callDeepSeek({
+    fetchImpl,
+    apiKey,
+    model,
+    messages,
+    maxTokens: 5000,
+  });
+  responses.push(firstResponse);
+
+  try {
+    return {
+      parsedDecision: parseEnrichmentDecision(firstResponse.content),
+      responses,
+    };
+  } catch (error) {
+    const warning = `DeepSeek enrichment response was malformed; retrying strict JSON repair once: ${truncateText(error.message, 240)}`;
+    warnings.push(warning);
+    core?.warning?.(warning);
+    const repairResponse = await callDeepSeek({
+      fetchImpl,
+      apiKey,
+      model,
+      messages: buildJsonRepairMessages({
+        baseMessages: messages,
+        invalidContent: firstResponse.content,
+        parseError: error,
+      }),
+      maxTokens: 5000,
+    });
+    responses.push(repairResponse);
+    return {
+      parsedDecision: parseEnrichmentDecision(repairResponse.content),
+      responses,
+    };
+  }
+}
+
+function defaultGit(args, options) {
+  return execFileSync("git", args, {
+    cwd: options.cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+export function commitVaultChanges({
+  vaultRoot,
+  relativePaths,
+  git = defaultGit,
+  requireWriteToken = false,
+  env = process.env,
+}) {
+  const paths = relativePaths.filter(Boolean);
+  if (paths.length === 0) {
+    return { committed: false, commitSha: null };
+  }
+  if (requireWriteToken && !normalizeText(env.GH_PROJECT_PAT)) {
+    throw new Error("GH_PROJECT_PAT is required to commit directly to duumbi-vault/main.");
+  }
+
+  git(["config", "user.name", "duumbi-inbox-enrichment[bot]"], { cwd: vaultRoot });
+  git(["config", "user.email", "duumbi-inbox-enrichment[bot]@users.noreply.github.com"], { cwd: vaultRoot });
+  git(["add", "--", ...paths], { cwd: vaultRoot });
+  const status = git(["status", "--porcelain", "--", ...paths], { cwd: vaultRoot });
+  if (!normalizeText(status)) {
+    return { committed: false, commitSha: null };
+  }
+
+  git(["commit", "-m", "chore: enrich DUUMBI inbox note"], { cwd: vaultRoot });
+  const commitSha = normalizeText(git(["rev-parse", "HEAD"], { cwd: vaultRoot }));
+  git(["push", "origin", "HEAD:main"], { cwd: vaultRoot });
+  return { committed: true, commitSha };
+}
+
+async function postSlack({ fetchImpl, env, context, candidatePath, commitSha, workflowUrl, warnings }) {
+  const token = env.SLACK_BOT_TOKEN;
+  const channel = env.DUUMBI_AGENT_DISPATCH_CHANNEL_ID || env.SLACK_REVIEW_CHANNEL_ID;
+  if (!token || !channel) {
+    warnings.push("slack_notification_not_configured");
+    return "not_configured";
+  }
+
+  try {
+    const response = await fetchImpl("https://slack.com/api/chat.postMessage", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify({
+        channel,
+        text: [
+          "*DUUMBI Inbox Enrichment Complete*",
+          `*Repository:* ${context.repo.owner}/${context.repo.repo}`,
+          `*Vault note:* ${candidatePath}`,
+          `*Vault commit:* ${commitSha || "committed"}`,
+          `*Workflow run:* ${workflowUrl}`,
+        ].join("\n"),
+      }),
+    });
+    const text = await response.text();
+    const body = text ? JSON.parse(text) : {};
+    if (!response.ok || !body.ok) {
+      warnings.push(`slack_notification_failed:${body.error || response.status}`);
+      return "failed";
+    }
+    return "posted";
+  } catch (error) {
+    warnings.push(`slack_notification_failed:${truncateText(error.message || error, 160)}`);
+    return "failed";
+  }
+}
+
+function buildWorkflowMetrics({
+  context,
+  conclusion,
+  decision,
+  counts,
+  providerUsage,
+  warnings,
+  generatedAt = nowIso(),
+}) {
+  return {
+    schema_version: "duumbi.workflow_metrics.v1",
+    generated_at: generatedAt,
+    source: "github_actions",
+    repository: `${context.repo.owner}/${context.repo.repo}`,
+    workflow: {
+      name: context.workflow,
+      file: WORKFLOW_FILE,
+      run_id: context.runId,
+      run_attempt: Number(process.env.GITHUB_RUN_ATTEMPT || 1),
+      event_name: context.eventName,
+      actor: context.actor,
+      ref: context.ref,
+      sha: context.sha,
+      conclusion,
+      started_at: generatedAt,
+      completed_at: generatedAt,
+      duration_ms: null,
+    },
+    correlation: {
+      issue_number: null,
+      pr_number: null,
+      stage: "inbox-enrichment",
+      decision,
+      project_status: null,
+    },
+    counts,
+    provider_usage: providerUsage,
+    privacy: {
+      metadata_only: true,
+      raw_prompts_included: false,
+      raw_completions_included: false,
+      raw_slack_payloads_included: false,
+      secrets_included: false,
+    },
+    warnings,
+  };
+}
+
+function writeMetrics(fs, path, workspace, metricsPath, metrics) {
+  const outputPath = path.resolve(workspace, metricsPath || "duumbi-workflow-metrics.json");
+  fs.writeFileSync(outputPath, `${JSON.stringify(metrics, null, 2)}\n`);
+}
+
+async function writeSummary(summary, result) {
+  if (!summary) return;
+  const table = [
+    [{ data: "Field", header: true }, { data: "Value", header: true }],
+    ["Target", result.targetPath || "scheduled sweep"],
+    ["Scan limit", String(result.scanLimit)],
+    ["Inbox notes inspected", String(result.inspectedCount)],
+    ["Candidate note", result.candidatePath || "none"],
+    ["Updated note", result.updatedPath || "none"],
+    ["Vault commit", result.commitSha || "none"],
+    ["Slack dispatch", result.slackNotification || "not_needed"],
+  ];
+  await summary.addHeading("DUUMBI Inbox Enrichment", 2).addTable(table).write();
+}
+
+export async function runInboxEnrichment({
+  env = process.env,
+  context,
+  core = null,
+  summary = null,
+  fetchImpl = fetch,
+  fs = fsModule,
+  path = pathModule,
+  workspace = process.cwd(),
+  git = defaultGit,
+}) {
+  const generatedAt = nowIso();
+  const warnings = [];
+  const inputs = context?.payload?.inputs || {};
+  const targetPath = String(inputs.target_path || "").trim();
+  const scanLimit = parsePositiveInteger(inputs.scan_limit || inputs.batch_size, DEFAULT_SCAN_LIMIT);
+  const vaultRoot = path.resolve(workspace, "duumbi-vault");
+  const inboxRoot = path.join(vaultRoot, "Duumbi", "00 Inbox (ToProcess)");
+  const workflowUrl = `${context.serverUrl || "https://github.com"}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+  let providerUsage = providerUsageNotCalled("no_candidate_note");
+  const result = {
+    targetPath,
+    scanLimit,
+    inspectedCount: 0,
+    candidatePath: null,
+    updatedPath: null,
+    commitSha: null,
+    slackNotification: "not_needed",
+  };
+
+  try {
+    const { candidatePaths, inspectedCount } = collectCandidatePaths({
+      fs,
+      path,
+      vaultRoot,
+      inboxRoot,
+      targetPath,
+      scanLimit,
+    });
+    result.inspectedCount = inspectedCount;
+
+    if (candidatePaths.length === 0) {
+      const metrics = buildWorkflowMetrics({
+        context,
+        conclusion: "success",
+        decision: "no_candidate_note",
+        counts: {
+          issues_considered: inspectedCount,
+          issues_queued: 0,
+          slack_notifications_attempted: 0,
+          artifact_links_found: 0,
+          artifact_links_missing: null,
+        },
+        providerUsage,
+        warnings: ["slack_notification_not_needed", ...warnings],
+        generatedAt,
+      });
+      writeMetrics(fs, path, workspace, env.DUUMBI_METRICS_PATH, metrics);
+      await writeSummary(summary, result);
+      return { ...result, changed: false, decision: "no_candidate_note" };
+    }
+
+    const candidatePath = candidatePaths[0];
+    result.candidatePath = candidatePath;
+    const apiKey = env.DEEPSEEK_API_KEY;
+    if (!apiKey) {
+      throw new Error("DEEPSEEK_API_KEY is not configured; failing closed before Inbox enrichment.");
+    }
+
+    const contextPayload = buildEnrichmentContext({
+      fs,
+      path,
+      workspace,
+      vaultRoot,
+      candidatePath,
+      warnings,
+    });
+    const messages = buildDeepSeekMessages(contextPayload);
+    const { parsedDecision, responses } = await getParsedEnrichmentDecision({
+      fetchImpl,
+      apiKey,
+      model: env.DEEPSEEK_MODEL || DEFAULT_DEEPSEEK_MODEL,
+      messages,
+      core,
+      warnings,
+    });
+    const lastResponse = responses.at(-1);
+    const combinedUsage = combineDeepSeekUsage(responses);
+    providerUsage = providerUsageFromDeepSeek(
+      lastResponse.model,
+      combinedUsage.usage,
+      combinedUsage.latencyMs,
+      responses.length,
+    );
+    const decision = validateEnrichmentDecision(parsedDecision);
+    const candidateAbsolute = path.join(vaultRoot, candidatePath);
+    const originalText = fs.readFileSync(candidateAbsolute, "utf8");
+    const nextText = buildEnrichedNote({
+      originalText,
+      decision,
+      candidatePath,
+      generatedAt,
+    });
+    fs.writeFileSync(candidateAbsolute, nextText);
+    result.updatedPath = candidatePath;
+
+    const commitResult = commitVaultChanges({
+      vaultRoot,
+      relativePaths: [candidatePath],
+      git,
+      requireWriteToken: true,
+      env,
+    });
+    result.commitSha = commitResult.commitSha;
+
+    if (commitResult.committed) {
+      result.slackNotification = await postSlack({
+        fetchImpl,
+        env,
+        context,
+        candidatePath,
+        commitSha: commitResult.commitSha,
+        workflowUrl,
+        warnings,
+      });
+    }
+
+    const metrics = buildWorkflowMetrics({
+      context,
+      conclusion: "success",
+      decision: commitResult.committed ? "vault_note_enriched" : "no_vault_diff",
+      counts: {
+        issues_considered: result.inspectedCount,
+        issues_queued: commitResult.committed ? 1 : 0,
+        slack_notifications_attempted: commitResult.committed && result.slackNotification !== "not_configured" ? 1 : 0,
+        artifact_links_found: commitResult.committed ? 1 : 0,
+        artifact_links_missing: null,
+      },
+      providerUsage,
+      warnings,
+      generatedAt,
+    });
+    writeMetrics(fs, path, workspace, env.DUUMBI_METRICS_PATH, metrics);
+    await writeSummary(summary, result);
+    return { ...result, changed: commitResult.committed, decision: metrics.correlation.decision };
+  } catch (error) {
+    const message = error?.message || String(error);
+    warnings.push(`inbox_enrichment_failed:${truncateText(message, 240)}`);
+    const metrics = buildWorkflowMetrics({
+      context,
+      conclusion: "failure",
+      decision: "enrichment_failed",
+      counts: {
+        issues_considered: result.inspectedCount,
+        issues_queued: 0,
+        slack_notifications_attempted: 0,
+        artifact_links_found: 0,
+        artifact_links_missing: null,
+      },
+      providerUsage,
+      warnings,
+      generatedAt,
+    });
+    writeMetrics(fs, path, workspace, env.DUUMBI_METRICS_PATH, metrics);
+    await writeSummary(summary, result);
+    core?.setFailed?.(message);
+    return { ...result, changed: false, decision: "enrichment_failed", error: message };
+  }
+}

--- a/scripts/github-actions/inbox-enrichment-dispatch.mjs
+++ b/scripts/github-actions/inbox-enrichment-dispatch.mjs
@@ -277,6 +277,7 @@ export function buildEnrichmentContext({
   workspace,
   vaultRoot,
   candidatePath,
+  context = null,
   warnings = [],
 }) {
   const candidateAbsolute = path.join(vaultRoot, candidatePath);
@@ -289,8 +290,8 @@ export function buildEnrichmentContext({
 
   return {
     generated_at: nowIso(),
-    repository: "hgahub/duumbi",
-    vault_repository: "hgahub/duumbi-vault",
+    repository: `${context?.repo?.owner || "hgahub"}/${context?.repo?.repo || "duumbi"}`,
+    vault_repository: `${context?.repo?.owner || "hgahub"}/duumbi-vault`,
     stage: "inbox-enrichment",
     policy: {
       max_notes_to_update: 1,
@@ -745,6 +746,7 @@ async function postSlack({ fetchImpl, env, context, candidatePath, commitSha, wo
 }
 
 function buildWorkflowMetrics({
+  env = process.env,
   context,
   conclusion,
   decision,
@@ -762,7 +764,7 @@ function buildWorkflowMetrics({
       name: context.workflow,
       file: WORKFLOW_FILE,
       run_id: context.runId,
-      run_attempt: Number(process.env.GITHUB_RUN_ATTEMPT || 1),
+      run_attempt: Number(env.GITHUB_RUN_ATTEMPT || 1),
       event_name: context.eventName,
       actor: context.actor,
       ref: context.ref,
@@ -855,6 +857,7 @@ export async function runInboxEnrichment({
 
     if (candidatePaths.length === 0) {
       const metrics = buildWorkflowMetrics({
+        env,
         context,
         conclusion: "success",
         decision: "no_candidate_note",
@@ -880,6 +883,9 @@ export async function runInboxEnrichment({
     if (!apiKey) {
       throw new Error("DEEPSEEK_API_KEY is not configured; failing closed before Inbox enrichment.");
     }
+    if (!normalizeText(env.GH_PROJECT_PAT)) {
+      throw new Error("GH_PROJECT_PAT is required before Inbox enrichment can call DeepSeek and commit to duumbi-vault/main.");
+    }
 
     const contextPayload = buildEnrichmentContext({
       fs,
@@ -887,6 +893,7 @@ export async function runInboxEnrichment({
       workspace,
       vaultRoot,
       candidatePath,
+      context,
       warnings,
     });
     const messages = buildDeepSeekMessages(contextPayload);
@@ -940,6 +947,7 @@ export async function runInboxEnrichment({
     }
 
     const metrics = buildWorkflowMetrics({
+      env,
       context,
       conclusion: "success",
       decision: commitResult.committed ? "vault_note_enriched" : "no_vault_diff",
@@ -961,6 +969,7 @@ export async function runInboxEnrichment({
     const message = error?.message || String(error);
     warnings.push(`inbox_enrichment_failed:${truncateText(message, 240)}`);
     const metrics = buildWorkflowMetrics({
+      env,
       context,
       conclusion: "failure",
       decision: "enrichment_failed",

--- a/scripts/github-actions/inbox-enrichment-dispatch.test.mjs
+++ b/scripts/github-actions/inbox-enrichment-dispatch.test.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 
 import {
   ENRICHMENT_MARKER_PREFIX,
+  buildEnrichmentContext,
   buildObsidianTags,
   collectCandidatePaths,
   isEnrichmentCandidateText,
@@ -220,6 +221,21 @@ test("buildObsidianTags emits Obsidian-compatible classification tags", () => {
   ]);
 });
 
+test("buildEnrichmentContext derives repository names from context", () => {
+  const { workspace } = makeWorkspace();
+  const contextPayload = buildEnrichmentContext({
+    workspace,
+    vaultRoot: path.join(workspace, "duumbi-vault"),
+    candidatePath: "Duumbi/00 Inbox (ToProcess)/candidate.md",
+    context: {
+      repo: { owner: "example-owner", repo: "example-repo" },
+    },
+  });
+
+  assert.equal(contextPayload.repository, "example-owner/example-repo");
+  assert.equal(contextPayload.vault_repository, "example-owner/duumbi-vault");
+});
+
 test("runInboxEnrichment skips Slack and DeepSeek when all notes are processed", async () => {
   const { workspace } = makeWorkspace({ processed: true });
   const { fetchImpl, calls } = makeFetch();
@@ -252,6 +268,44 @@ test("runInboxEnrichment skips Slack and DeepSeek when all notes are processed",
   assert.equal(metrics.provider_usage.reason, "no_candidate_note");
 });
 
+test("runInboxEnrichment fails before DeepSeek when vault write token is missing", async () => {
+  const { workspace } = makeWorkspace();
+  const { fetchImpl, calls } = makeFetch();
+  const { git, calls: gitCalls } = makeGit();
+  const core = makeCore();
+
+  const result = await runInboxEnrichment({
+    env: {
+      DEEPSEEK_API_KEY: "deepseek",
+      SLACK_BOT_TOKEN: "slack",
+      SLACK_REVIEW_CHANNEL_ID: "C123",
+      DUUMBI_METRICS_PATH: "metrics.json",
+    },
+    context: makeContext(),
+    core,
+    summary: makeSummary(),
+    fetchImpl,
+    workspace,
+    git,
+  });
+
+  assert.equal(result.changed, false);
+  assert.equal(result.decision, "enrichment_failed");
+  assert.match(core.failed, /GH_PROJECT_PAT is required/);
+  assert.equal(calls.some((call) => call.url === "https://api.deepseek.com/chat/completions"), false);
+  assert.equal(gitCalls.length, 0);
+
+  const original = fs.readFileSync(
+    path.join(workspace, "duumbi-vault", "Duumbi", "00 Inbox (ToProcess)", "candidate.md"),
+    "utf8",
+  );
+  assert.match(original, /# Raw idea/);
+  const metrics = JSON.parse(fs.readFileSync(path.join(workspace, "metrics.json"), "utf8"));
+  assert.equal(metrics.correlation.decision, "enrichment_failed");
+  assert.equal(metrics.counts.slack_notifications_attempted, 0);
+  assert.equal(metrics.provider_usage.reason, "no_candidate_note");
+});
+
 test("runInboxEnrichment enriches one note, commits to vault, and posts Slack", async () => {
   const { workspace } = makeWorkspace({ secondRaw: true });
   const { fetchImpl, calls } = makeFetch();
@@ -266,6 +320,7 @@ test("runInboxEnrichment enriches one note, commits to vault, and posts Slack", 
       SLACK_BOT_TOKEN: "slack",
       SLACK_REVIEW_CHANNEL_ID: "C123",
       DUUMBI_METRICS_PATH: "metrics.json",
+      GITHUB_RUN_ATTEMPT: "7",
     },
     context: makeContext(),
     core,
@@ -301,6 +356,7 @@ test("runInboxEnrichment enriches one note, commits to vault, and posts Slack", 
 
   const metrics = JSON.parse(fs.readFileSync(path.join(workspace, "metrics.json"), "utf8"));
   assert.equal(metrics.correlation.decision, "vault_note_enriched");
+  assert.equal(metrics.workflow.run_attempt, 7);
   assert.equal(metrics.counts.slack_notifications_attempted, 1);
   assert.equal(metrics.provider_usage.provider, "deepseek");
 });

--- a/scripts/github-actions/inbox-enrichment-dispatch.test.mjs
+++ b/scripts/github-actions/inbox-enrichment-dispatch.test.mjs
@@ -1,0 +1,306 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  ENRICHMENT_MARKER_PREFIX,
+  buildObsidianTags,
+  collectCandidatePaths,
+  isEnrichmentCandidateText,
+  runInboxEnrichment,
+} from "./inbox-enrichment-dispatch.mjs";
+
+function response(body, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+function makeContext(inputs = {}) {
+  return {
+    workflow: "Inbox Enrichment Dispatch",
+    runId: 12345,
+    eventName: "workflow_dispatch",
+    actor: "tester",
+    ref: "refs/heads/main",
+    sha: "abc123",
+    serverUrl: "https://github.com",
+    repo: { owner: "hgahub", repo: "duumbi" },
+    payload: { inputs },
+  };
+}
+
+function makeCore() {
+  return {
+    failed: null,
+    warnings: [],
+    warning(message) {
+      this.warnings.push(message);
+    },
+    setFailed(message) {
+      this.failed = message;
+    },
+  };
+}
+
+function makeSummary() {
+  return {
+    rows: [],
+    addHeading() {
+      return this;
+    },
+    addTable(rows) {
+      this.rows = rows;
+      return this;
+    },
+    async write() {
+      return undefined;
+    },
+  };
+}
+
+function makeWorkspace({ processed = false, secondRaw = false } = {}) {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "duumbi-inbox-enrichment-"));
+  const vaultRoot = path.join(workspace, "duumbi-vault");
+  const inboxRoot = path.join(vaultRoot, "Duumbi", "00 Inbox (ToProcess)");
+  const processedRoot = path.join(vaultRoot, "Duumbi", "05 Archive", "Processed Inbox");
+  const atlasRoot = path.join(vaultRoot, "Duumbi", "01 Atlas (Knowledge Base)", "Works (Developed Materials)");
+  fs.mkdirSync(inboxRoot, { recursive: true });
+  fs.mkdirSync(processedRoot, { recursive: true });
+  fs.mkdirSync(atlasRoot, { recursive: true });
+
+  const candidateText = processed
+    ? [
+        "---",
+        "tags:",
+        "  - duumbi/status/processed",
+        "---",
+        "# Already processed",
+        `${ENRICHMENT_MARKER_PREFIX} status=processed -->`,
+      ].join("\n")
+    : "# Raw idea\n\nMake the provider setup easier for new users.\n";
+
+  fs.writeFileSync(path.join(inboxRoot, "candidate.md"), candidateText);
+  if (secondRaw) {
+    fs.writeFileSync(path.join(inboxRoot, "second.md"), "# Second raw idea\n\nAdd another thing.\n");
+  }
+  fs.writeFileSync(path.join(processedRoot, "old.md"), "# Old processed note\n\nProvider setup background.\n");
+  fs.writeFileSync(path.join(atlasRoot, "DUUMBI - PRD.md"), "# PRD\n\nDUUMBI is an AI-first semantic graph compiler.\n");
+  fs.writeFileSync(path.join(atlasRoot, "DUUMBI - Glossary.md"), "# Glossary\n\nGraph IR: central semantic graph.\n");
+
+  fs.mkdirSync(path.join(vaultRoot, "Duumbi", "01 Atlas (Knowledge Base)", "Maps (Overviews)"), { recursive: true });
+  fs.writeFileSync(
+    path.join(vaultRoot, "Duumbi", "01 Atlas (Knowledge Base)", "Maps (Overviews)", "DUUMBI Agentic Development Map.md"),
+    "# Agentic Development Map\n\nInbox leads to triage.",
+  );
+  fs.writeFileSync(
+    path.join(atlasRoot, "DUUMBI - Agentic Development Runbook.md"),
+    "# Runbook\n\nStage 4 creates GitHub issues after enrichment.",
+  );
+  fs.writeFileSync(path.join(vaultRoot, "Duumbi", "How to use.md"), "# How to use\n\nUse Inbox for raw capture.");
+
+  fs.mkdirSync(path.join(workspace, "docs"), { recursive: true });
+  fs.mkdirSync(path.join(workspace, "src", "graph"), { recursive: true });
+  fs.mkdirSync(path.join(workspace, "src", "compiler"), { recursive: true });
+  fs.mkdirSync(path.join(workspace, "src", "agents"), { recursive: true });
+  fs.mkdirSync(path.join(workspace, "src", "mcp"), { recursive: true });
+  fs.mkdirSync(path.join(workspace, "crates", "duumbi-studio", "src"), { recursive: true });
+  fs.writeFileSync(path.join(workspace, "AGENTS.md"), "# Agents\n\nKeep Query mode read-only.");
+  fs.writeFileSync(path.join(workspace, "docs", "architecture.md"), "# Architecture\n\nGraph IR is central.");
+  fs.writeFileSync(path.join(workspace, "docs", "coding-conventions.md"), "# Coding\n\nNo unwrap in library code.");
+  fs.writeFileSync(path.join(workspace, "Cargo.toml"), "[package]\nname = \"duumbi\"\n");
+  fs.writeFileSync(path.join(workspace, "src", "types.rs"), "pub enum DuumbiType { I64 }\n");
+  fs.writeFileSync(path.join(workspace, "src", "graph", "mod.rs"), "pub mod graph {}\n");
+  fs.writeFileSync(path.join(workspace, "src", "compiler", "mod.rs"), "pub mod compiler {}\n");
+  fs.writeFileSync(path.join(workspace, "src", "agents", "mod.rs"), "pub mod agents {}\n");
+  fs.writeFileSync(path.join(workspace, "src", "mcp", "mod.rs"), "pub mod mcp {}\n");
+  fs.writeFileSync(path.join(workspace, "crates", "duumbi-studio", "src", "lib.rs"), "pub mod app {}\n");
+
+  return { workspace, inboxRoot };
+}
+
+function makeFetch(decision = {}) {
+  const calls = [];
+  const fetchImpl = async (url, options = {}) => {
+    const body = options.body ? JSON.parse(options.body) : {};
+    calls.push({ url, method: options.method || "GET", body });
+
+    if (url === "https://api.deepseek.com/chat/completions") {
+      return response({
+        model: "deepseek-v4-pro",
+        choices: [{
+          message: {
+            content: JSON.stringify({
+              title: "Simplify provider setup",
+              interpreted_intent: "Prepare a task for making provider setup easier.",
+              classification: "feature",
+              business_value: "high",
+              importance: "high",
+              complexity: "medium",
+              developer_summary: "Create a clear issue candidate for improving the provider setup flow.",
+              uml_diagram_mermaid: [
+                "flowchart TD",
+                "  User[User] --> Setup[Provider setup]",
+                "  Setup --> Ready[Configured provider]",
+              ].join("\n"),
+              clarifications_answered: ["The request concerns provider setup UX."],
+              clarifications_open: ["Which provider should be the first manual test path?"],
+              relevant_duumbi_context: ["docs/architecture.md explains the graph-first architecture."],
+              related_github_context: "Not inspected; Stage 4 triage should verify GitHub state later.",
+              initial_routing_recommendation: "GitHub issue",
+              requested_follow_up: ["Create an issue during Stage 4 triage."],
+              ai_agent_instructions: ["Create one GitHub issue; do not start implementation."],
+              scope_in: ["Provider setup issue preparation."],
+              scope_out: ["No source code changes during enrichment."],
+              risks: ["The request may overlap with existing provider UX work."],
+              facts: ["The raw Inbox note requests easier provider setup."],
+              assumptions: ["The target user is a new DUUMBI user."],
+              recommendations: ["Route to Stage 4 triage as a feature candidate."],
+              status: "ready_for_triage",
+              ...decision,
+            }),
+          },
+        }],
+        usage: { prompt_tokens: 1200, completion_tokens: 420, total_tokens: 1620 },
+      });
+    }
+
+    if (url === "https://slack.com/api/chat.postMessage") {
+      return response({ ok: true, ts: "123.456" });
+    }
+
+    throw new Error(`Unexpected fetch: ${url}`);
+  };
+  return { fetchImpl, calls };
+}
+
+function makeGit() {
+  const calls = [];
+  const git = (args, options = {}) => {
+    calls.push({ args, cwd: options.cwd });
+    if (args[0] === "status") return " M Duumbi/00 Inbox (ToProcess)/candidate.md\n";
+    if (args[0] === "rev-parse") return "feedface1234567890\n";
+    return "";
+  };
+  return { git, calls };
+}
+
+test("candidate detection ignores processed marker and processed tag", () => {
+  assert.equal(isEnrichmentCandidateText("# Raw\n\nPlease build something."), true);
+  assert.equal(isEnrichmentCandidateText(`${ENRICHMENT_MARKER_PREFIX} status=processed -->`), false);
+  assert.equal(isEnrichmentCandidateText("---\ntags:\n  - duumbi/status/processed\n---\n# Done"), false);
+});
+
+test("collectCandidatePaths selects at most one unprocessed note", () => {
+  const { workspace, inboxRoot } = makeWorkspace({ secondRaw: true });
+  const result = collectCandidatePaths({
+    vaultRoot: path.join(workspace, "duumbi-vault"),
+    inboxRoot,
+  });
+  assert.deepEqual(result.candidatePaths, ["Duumbi/00 Inbox (ToProcess)/candidate.md"]);
+});
+
+test("buildObsidianTags emits Obsidian-compatible classification tags", () => {
+  assert.deepEqual(buildObsidianTags({
+    classification: "feature",
+    business_value: "high",
+    importance: "critical",
+    complexity: "medium",
+  }), [
+    "duumbi/inbox/enriched",
+    "duumbi/status/processed",
+    "duumbi/classification/feature",
+    "duumbi/value/high",
+    "duumbi/importance/critical",
+    "duumbi/complexity/medium",
+  ]);
+});
+
+test("runInboxEnrichment skips Slack and DeepSeek when all notes are processed", async () => {
+  const { workspace } = makeWorkspace({ processed: true });
+  const { fetchImpl, calls } = makeFetch();
+  const { git, calls: gitCalls } = makeGit();
+  const core = makeCore();
+
+  const result = await runInboxEnrichment({
+    env: {
+      DEEPSEEK_API_KEY: "deepseek",
+      GH_PROJECT_PAT: "pat",
+      SLACK_BOT_TOKEN: "slack",
+      SLACK_REVIEW_CHANNEL_ID: "C123",
+      DUUMBI_METRICS_PATH: "metrics.json",
+    },
+    context: makeContext(),
+    core,
+    summary: makeSummary(),
+    fetchImpl,
+    workspace,
+    git,
+  });
+
+  assert.equal(result.changed, false);
+  assert.equal(result.decision, "no_candidate_note");
+  assert.equal(calls.length, 0);
+  assert.equal(gitCalls.length, 0);
+  assert.equal(core.failed, null);
+  const metrics = JSON.parse(fs.readFileSync(path.join(workspace, "metrics.json"), "utf8"));
+  assert.equal(metrics.counts.slack_notifications_attempted, 0);
+  assert.equal(metrics.provider_usage.reason, "no_candidate_note");
+});
+
+test("runInboxEnrichment enriches one note, commits to vault, and posts Slack", async () => {
+  const { workspace } = makeWorkspace({ secondRaw: true });
+  const { fetchImpl, calls } = makeFetch();
+  const { git, calls: gitCalls } = makeGit();
+  const core = makeCore();
+
+  const result = await runInboxEnrichment({
+    env: {
+      DEEPSEEK_API_KEY: "deepseek",
+      DEEPSEEK_MODEL: "deepseek-v4-pro",
+      GH_PROJECT_PAT: "pat",
+      SLACK_BOT_TOKEN: "slack",
+      SLACK_REVIEW_CHANNEL_ID: "C123",
+      DUUMBI_METRICS_PATH: "metrics.json",
+    },
+    context: makeContext(),
+    core,
+    summary: makeSummary(),
+    fetchImpl,
+    workspace,
+    git,
+  });
+
+  assert.equal(result.changed, true);
+  assert.equal(result.updatedPath, "Duumbi/00 Inbox (ToProcess)/candidate.md");
+  assert.equal(result.commitSha, "feedface1234567890");
+  assert.equal(calls.filter((call) => call.url === "https://api.deepseek.com/chat/completions").length, 1);
+  assert.equal(calls.filter((call) => call.url === "https://slack.com/api/chat.postMessage").length, 1);
+  assert.ok(gitCalls.some((call) => call.args[0] === "commit"));
+  assert.ok(gitCalls.some((call) => call.args[0] === "push"));
+
+  const updated = fs.readFileSync(
+    path.join(workspace, "duumbi-vault", "Duumbi", "00 Inbox (ToProcess)", "candidate.md"),
+    "utf8",
+  );
+  const untouched = fs.readFileSync(
+    path.join(workspace, "duumbi-vault", "Duumbi", "00 Inbox (ToProcess)", "second.md"),
+    "utf8",
+  );
+  assert.match(updated, /duumbi-inbox-enrichment:v1/);
+  assert.match(updated, /duumbi\/status\/processed/);
+  assert.match(updated, /## Developer summary/);
+  assert.match(updated, /## UML overview/);
+  assert.match(updated, /```mermaid/);
+  assert.match(updated, /## AI agent instructions/);
+  assert.match(untouched, /# Second raw idea/);
+
+  const metrics = JSON.parse(fs.readFileSync(path.join(workspace, "metrics.json"), "utf8"));
+  assert.equal(metrics.correlation.decision, "vault_note_enriched");
+  assert.equal(metrics.counts.slack_notifications_attempted, 1);
+  assert.equal(metrics.provider_usage.provider, "deepseek");
+});

--- a/scripts/github-actions/triage-queue-refill.mjs
+++ b/scripts/github-actions/triage-queue-refill.mjs
@@ -709,6 +709,8 @@ export async function callDeepSeek({
   messages,
   timeoutMs = 120_000,
   emptyContentRetries = 2,
+  maxTokens = 2500,
+  temperature = 0.2,
 }) {
   const started = Date.now();
   const maxAttempts = Math.max(1, 1 + Number(emptyContentRetries || 0));
@@ -743,8 +745,8 @@ export async function callDeepSeek({
           model,
           messages: retryMessages,
           response_format: { type: "json_object" },
-          temperature: 0.2,
-          max_tokens: 2500,
+          temperature,
+          max_tokens: maxTokens,
         }),
         signal: controller.signal,
       });


### PR DESCRIPTION
## Summary

- Replace the Inbox Enrichment Dispatch handoff with a direct one-note enrichment workflow that uses DeepSeek, rewrites the selected Inbox note, commits to `duumbi-vault/main`, and posts Slack only after a vault commit is created.
- Add a tested `scripts/github-actions/inbox-enrichment-dispatch.mjs` module that selects at most one unprocessed note, builds bounded vault/source context, validates JSON-mode model output, emits Obsidian tags and a Mermaid UML overview, commits via git, and records metadata-only metrics.
- Update the automation docs and local `duumbi-inbox-enrichment` skill contract to describe the new direct-write and commit-gated Slack behavior.

## Validation

- `node --check scripts/github-actions/inbox-enrichment-dispatch.mjs`
- `node --check scripts/github-actions/inbox-enrichment-dispatch.test.mjs`
- `node --check scripts/github-actions/triage-queue-refill.mjs`
- `node --test scripts/github-actions/inbox-enrichment-dispatch.test.mjs scripts/github-actions/triage-queue-refill.test.mjs`

## Notes

A broader `node --test scripts/github-actions/*.test.mjs` run still reports 3 pre-existing/unrelated assertion failures in the stage approval workflow text tests; this PR does not touch those workflows.