### PR TITLE
docs: add DUUMBI Discord invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,5 +129,6 @@ Native Windows builds use the MSVC Rust target and do not require WSL2. The curr
 
 ## Community
 
+- Join the [DUUMBI Discord](https://discord.gg/FJ92HrZKu7) for community discussion, help, showcases, development coordination, and announcements.
 - Read the [Code of Conduct](CODE_OF_CONDUCT.md) before opening issues or pull requests.
 - Use the provided issue and PR templates.

--- a/sites/docs/src/introduction.md
+++ b/sites/docs/src/introduction.md
@@ -45,4 +45,5 @@ duumbi run
 - [Quick Start](getting-started/quickstart.md) — first program in 5 minutes
 - [CLI Reference](cli/overview.md) — all commands
 - [JSON-LD Format](jsonld/overview.md) — graph format reference
+- [Discord](https://discord.gg/FJ92HrZKu7) — community discussion, help, showcases, and announcements
 - [GitHub](https://github.com/hgahub/duumbi) — source code and issues


### PR DESCRIPTION
Related to #376.

Workflow note: This is the Stage 10 implementation evidence PR. The execution issue must remain open for Stage 11 review and Stage 12 closure. This PR must not close the execution issue.

## Summary

- Adds the verified official DUUMBI Discord invite to the GitHub README Community section.
- Adds the same invite to the docs Getting Help section.
- Keeps the implementation scope limited to public community discovery docs.

## Companion Website PR

- duumbi.dev source update: https://github.com/hgahub/duumbi-web/pull/2

## Ralph Cycle Evidence

### Cycle 1

Goal: publish the verified official Discord invite on DUUMBI public repository/docs entry points and prepare the website update.
Status: completed.
Files changed: `README.md`, `sites/docs/src/introduction.md`.
External LLM calls: 0. Estimated external LLM cost: USD 0.

Discord configuration evidence from maintainer-guided setup:

- Server: `Duumbi Dev`, configured by maintainer account `hgabor`.
- Public channels created or verified: `#general`, `#help`, `#showcase`, `#development`, `#announcements`.
- Roles created or verified: `Maintainer`, `Contributor`, `Community`.
- `#announcements` permissions: `@everyone` cannot send messages; `Maintainer` can send messages.
- Welcome/onboarding message pinned in `#general`, with docs, GitHub, getting-started, and Code of Conduct links.
- Channel topics configured for `#general`, `#help`, `#showcase`, `#development`, and `#announcements`.
- Safety setup configured: Verification Level `Low`, sensitive-content filtering for members without roles, Activity Alerts enabled with `#development` as the safety notifications channel.
- Stable invite verified in private/incognito browser: `https://discord.gg/FJ92HrZKu7`.

## BDD And E2E Evidence

- Reader joins from GitHub README: README now links to the verified invite.
- Docs reader finds help/community path: docs introduction now links to the verified invite.
- Website visitor joins from `duumbi.dev`: companion `duumbi-web` PR updates the existing navbar and footer Discord links to the verified invite.
- New member receives onboarding links: maintainer configured and pinned onboarding copy in `#general`; it includes docs, GitHub, getting started, and Code of Conduct.
- Direct-message welcome fallback: onboarding links are server-visible through the pinned `#general` message and channel topics.
- Member wants support: `#help` exists with support/troubleshooting topic.
- Member wants to share a demo: `#showcase` exists with showcase topic.
- Regular member joins: role evidence shows `Community`; `#announcements` evidence shows `@everyone` cannot send messages.
- Maintainer posts announcement: `Maintainer` role has send permission in `#announcements`.
- Recognized contributor helps: `Contributor` role exists without administrator permission.
- Spam/CoC moderation: Discord safety settings are enabled, and Activity Alerts route to `#development`.
- Product changes proposed in Discord: pinned onboarding copy states product decisions and implementation tracking must be recorded in GitHub Issues or DUUMBI intake before becoming official.

## Checks

- `git diff --check`: passed
- `rg -n "discord\\.gg|Discord" README.md sites/docs/src/introduction.md`: passed
- `mdbook build sites/docs`: not run; `mdbook` is not installed in the local environment

## Remaining Work

- Merge the companion `duumbi-web` PR after review so `duumbi.dev` deploys the official invite.
- Stage 11 review of this implementation evidence.
