### PR TITLE
Fix spec review project routing automation

### DIFF
--- a/.github/workflows/spec-review-request.yml
+++ b/.github/workflows/spec-review-request.yml
@@ -48,6 +48,7 @@ jobs:
       issues_queued_count: ${{ steps.request.outputs.issues_queued_count }}
       artifact_links_found: ${{ steps.request.outputs.artifact_links_found }}
       artifact_links_missing: ${{ steps.request.outputs.artifact_links_missing }}
+      project_status_updates: ${{ steps.request.outputs.project_status_updates }}
     steps:
       - name: Validate request and build Slack payload
         id: request
@@ -56,6 +57,7 @@ jobs:
           INPUT_ISSUE_URL: ${{ inputs.issue_url || '' }}
           INPUT_ISSUE_NUMBER: ${{ inputs.issue_number || '' }}
           INPUT_STATUS: ${{ inputs.status || '' }}
+          GH_PROJECT_PAT: ${{ secrets.GH_PROJECT_PAT }}
           DUUMBI_REQUIRED_SPEC_REVIEWERS: ${{ vars.DUUMBI_REQUIRED_SPEC_REVIEWERS || 'copilot-pull-request-reviewer' }}
         with:
           script: |
@@ -78,6 +80,83 @@ jobs:
               .map((label) => typeof label === "string" ? label : label.name)
               .filter(Boolean);
             const issueUrlFor = (number) => `https://github.com/${context.repo.owner}/${context.repo.repo}/issues/${number}`;
+
+            const updateProjectStatus = async (issueNumber, targetStatus) => {
+              const projectPat = process.env.GH_PROJECT_PAT;
+              if (!projectPat) {
+                core.info("GH_PROJECT_PAT not set — skipping Project V2 status update.");
+                return false;
+              }
+
+              const gql = async (query, variables) => {
+                const response = await fetch("https://api.github.com/graphql", {
+                  method: "POST",
+                  headers: {
+                    Authorization: `bearer ${projectPat}`,
+                    "Content-Type": "application/json",
+                  },
+                  body: JSON.stringify({ query, variables }),
+                });
+                const json = await response.json();
+                if (json.errors) throw new Error(json.errors.map((error) => error.message).join("; "));
+                return json.data;
+              };
+
+              const itemsData = await gql(`
+                query($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    issue(number: $number) {
+                      projectItems(first: 10) {
+                        nodes { id project { id title } }
+                      }
+                    }
+                  }
+                }`,
+                { owner: context.repo.owner, repo: context.repo.repo, number: issueNumber },
+              );
+
+              const items = itemsData.repository?.issue?.projectItems?.nodes || [];
+              let updated = false;
+              for (const item of items) {
+                const fieldsData = await gql(`
+                  query($pid: ID!) {
+                    node(id: $pid) {
+                      ... on ProjectV2 {
+                        fields(first: 30) {
+                          nodes {
+                            ... on ProjectV2SingleSelectField { id name options { id name } }
+                          }
+                        }
+                      }
+                    }
+                  }`,
+                  { pid: item.project.id },
+                );
+
+                const statusField = fieldsData.node?.fields?.nodes?.find((field) => field.name === "Status");
+                if (!statusField) continue;
+
+                const option = statusField.options.find((candidate) => candidate.name === targetStatus);
+                if (!option) {
+                  core.warning(`Status option "${targetStatus}" not found in "${item.project.title}".`);
+                  continue;
+                }
+
+                await gql(`
+                  mutation($pid: ID!, $iid: ID!, $fid: ID!, $oid: String!) {
+                    updateProjectV2ItemFieldValue(input: {
+                      projectId: $pid, itemId: $iid, fieldId: $fid,
+                      value: { singleSelectOptionId: $oid }
+                    }) { projectV2Item { id } }
+                  }`,
+                  { pid: item.project.id, iid: item.id, fid: statusField.id, oid: option.id },
+                );
+
+                updated = true;
+                core.info(`Project "${item.project.title}" → ${targetStatus}`);
+              }
+              return updated;
+            };
 
             const hasNotificationMarker = async (issueNumber) => {
               const comments = await github.paginate(github.rest.issues.listComments, {
@@ -438,6 +517,7 @@ jobs:
               core.setOutput("issues_queued_count", "0");
               core.setOutput("artifact_links_found", "0");
               core.setOutput("artifact_links_missing", "0");
+              core.setOutput("project_status_updates", "0");
               core.setOutput("should_notify", "false");
               return;
             }
@@ -446,6 +526,7 @@ jobs:
             const notifiedIssues = [];
             let artifactLinksFound = 0;
             let artifactLinksMissing = 0;
+            let projectStatusUpdates = 0;
             for (const issue of issuesToNotify) {
               const specArtifact = await findSpecArtifact(issue.number);
               if (specArtifact.startsWith("<missing:")) {
@@ -460,6 +541,13 @@ jobs:
                 core.info(`Skipping issue #${issue.number}: product spec PR not ready for approval (${readiness.summary}).`);
                 continue;
               }
+              try {
+                if (await updateProjectStatus(issue.number, "Spec Review")) {
+                  projectStatusUpdates += 1;
+                }
+              } catch (error) {
+                core.warning(`Project V2 status update failed for #${issue.number}: ${error.message}`);
+              }
               slackMessages.push(buildSlackMessage(issue, triggeredBy, specArtifact, readiness));
               notifiedIssues.push(issue);
             }
@@ -470,6 +558,7 @@ jobs:
               core.setOutput("issues_queued_count", "0");
               core.setOutput("artifact_links_found", String(artifactLinksFound));
               core.setOutput("artifact_links_missing", String(artifactLinksMissing));
+              core.setOutput("project_status_updates", String(projectStatusUpdates));
               core.setOutput("should_notify", "false");
               return;
             }
@@ -479,6 +568,7 @@ jobs:
             core.setOutput("issues_queued_count", String(notifiedIssues.length));
             core.setOutput("artifact_links_found", String(artifactLinksFound));
             core.setOutput("artifact_links_missing", String(artifactLinksMissing));
+            core.setOutput("project_status_updates", String(projectStatusUpdates));
             core.setOutput("should_notify", "true");
 
       - name: Post Slack notifications
@@ -579,6 +669,7 @@ jobs:
           ISSUES_QUEUED_COUNT: ${{ needs.notify.outputs.issues_queued_count || '0' }}
           ARTIFACT_LINKS_FOUND: ${{ needs.notify.outputs.artifact_links_found || '0' }}
           ARTIFACT_LINKS_MISSING: ${{ needs.notify.outputs.artifact_links_missing || '0' }}
+          PROJECT_STATUS_UPDATES: ${{ needs.notify.outputs.project_status_updates || '0' }}
           DUUMBI_METRICS_PATH: duumbi-workflow-metrics.json
         with:
           script: |
@@ -668,6 +759,7 @@ jobs:
                 slack_notifications_attempted: process.env.SHOULD_NOTIFY === "true" ? issueNumbers.length : 0,
                 artifact_links_found: asNumber(process.env.ARTIFACT_LINKS_FOUND),
                 artifact_links_missing: asNumber(process.env.ARTIFACT_LINKS_MISSING),
+                project_status_updates: asNumber(process.env.PROJECT_STATUS_UPDATES),
               },
               provider_usage: {
                 available: false,
@@ -703,6 +795,7 @@ jobs:
                 ["Issues queued", String(metrics.counts.issues_queued ?? "unavailable")],
                 ["Artifact links found", String(metrics.counts.artifact_links_found ?? "unavailable")],
                 ["Artifact links missing", String(metrics.counts.artifact_links_missing ?? "unavailable")],
+                ["Project status updates", String(metrics.counts.project_status_updates ?? "unavailable")],
                 ["Provider usage", "unavailable: no_provider_step"],
               ])
               .write();

--- a/.github/workflows/stage-approval.yml
+++ b/.github/workflows/stage-approval.yml
@@ -1,6 +1,8 @@
 name: Stage Approval
 
 on:
+  pull_request:
+    types: [closed]
   workflow_dispatch:
     inputs:
       stage:
@@ -44,12 +46,13 @@ permissions:
   statuses: read
 
 concurrency:
-  group: stage-approval-${{ github.event.inputs.issue_number || github.event.client_payload.issue_number || 'dispatch' }}
+  group: stage-approval-${{ github.event.inputs.pr_number || github.event.client_payload.pr_number || github.event.pull_request.number || github.event.inputs.issue_number || github.event.client_payload.issue_number || 'dispatch' }}
   cancel-in-progress: false
 
 jobs:
   execute:
     name: Execute approval
+    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Execute decision
@@ -65,6 +68,15 @@ jobs:
             // ── Inputs ──────────────────────────────────────────────
             const raw = context.eventName === 'repository_dispatch'
               ? context.payload.client_payload
+              : context.eventName === 'pull_request'
+              ? {
+                  stage: '',
+                  issue_number: 0,
+                  decision: 'approve',
+                  rationale: '',
+                  pr_number: Number(context.payload.pull_request?.number || context.payload.number || 0),
+                  reviewer: `GitHub PR merge (${context.actor})`,
+                }
               : {
                   stage: String(context.payload.inputs.stage),
                   issue_number: Number(context.payload.inputs.issue_number),
@@ -74,13 +86,44 @@ jobs:
                   reviewer: String(context.payload.inputs.reviewer || context.actor),
                 };
 
-            const stage = String(raw.stage);
-            const issueNumber = Number(raw.issue_number);
+            let stage = String(raw.stage);
+            let issueNumber = Number(raw.issue_number);
             const decision = String(raw.decision);
-            const rationale = raw.rationale || `Recorded via Stage Approval workflow (decision: ${decision}).`;
+            let rationale = raw.rationale || `Recorded via Stage Approval workflow (decision: ${decision}).`;
             let prNumber = Number(raw.pr_number || 0);
-            const reviewer = raw.reviewer || context.actor;
+            let reviewer = raw.reviewer || context.actor;
             const { owner, repo } = context.repo;
+
+            if (context.eventName === 'pull_request') {
+              const pr = context.payload.pull_request;
+              if (!pr?.merged) {
+                core.info('Ignoring closed PR because it was not merged.');
+                return;
+              }
+              prNumber = Number(pr.number || context.payload.number || prNumber);
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner, repo, pull_number: prNumber, per_page: 100,
+              });
+              if (files.length !== 1 || files[0].status === 'removed') {
+                core.info(`Ignoring merged PR #${prNumber}: not a single-file spec artifact.`);
+                return;
+              }
+              const productMatch = files[0].filename.match(/^specs\/DUUMBI-(\d+)\/PRODUCT\.md$/);
+              const technicalMatch = files[0].filename.match(/^specs\/DUUMBI-(\d+)\/TECHNICAL\.md$/);
+              if (productMatch) {
+                stage = '7';
+                issueNumber = Number(productMatch[1]);
+              } else if (technicalMatch) {
+                stage = '9';
+                issueNumber = Number(technicalMatch[1]);
+              } else {
+                core.info(`Ignoring merged PR #${prNumber}: ${files[0].filename} is not a DUUMBI spec artifact.`);
+                return;
+              }
+              reviewer = `GitHub PR merge (${context.actor})`;
+              rationale = `Spec-only PR #${prNumber} was merged by ${context.actor}; treating the merged review-clean artifact as Stage ${stage} approval evidence.`;
+            }
+
             const issueUrl = `https://github.com/${owner}/${repo}/issues/${issueNumber}`;
             const today = new Date().toISOString().split('T')[0];
             let specPrMerge = null;
@@ -573,6 +616,7 @@ jobs:
 
             // ── Post or reuse decision comment ──────────────────────
             let posted = [...comments].reverse().find(matchingDecisionComment);
+            const reusedDecisionComment = Boolean(posted);
             if (posted) {
               core.info(`Decision comment already exists: ${posted.html_url}`);
             } else {
@@ -761,7 +805,7 @@ jobs:
             // Post to review channel
             const slackToken = process.env.SLACK_BOT_TOKEN;
             const slackChannel = process.env.SLACK_REVIEW_CHANNEL_ID;
-            if (slackToken && slackChannel) {
+            if (slackToken && slackChannel && !(context.eventName === 'pull_request' && reusedDecisionComment)) {
               try {
                 const res = await fetch('https://slack.com/api/chat.postMessage', {
                   method: 'POST',
@@ -776,6 +820,8 @@ jobs:
               } catch (err) {
                 core.warning(`Slack notification failed: ${err.message}`);
               }
+            } else if (context.eventName === 'pull_request' && reusedDecisionComment) {
+              core.info('Skipping duplicate Slack summary for already-recorded pull_request approval.');
             }
 
             // ── Workflow summary ─────────────────────────────────────

--- a/scripts/github-actions/stage-approval-workflow.test.mjs
+++ b/scripts/github-actions/stage-approval-workflow.test.mjs
@@ -11,6 +11,11 @@ const readRepoFile = (path) => readFileSync(join(repoRoot, path), "utf8");
 test("stage approval merges only reviewed spec PRs for Stage 7 and Stage 9 approvals", () => {
   const workflow = readRepoFile(".github/workflows/stage-approval.yml");
 
+  assert.match(workflow, /pull_request:\s*\n\s+types:\s+\[closed\]/);
+  assert.match(workflow, /github\.event\.pull_request\.merged == true/);
+  assert.match(workflow, /Spec-only PR #\$\{prNumber\} was merged by/);
+  assert.ok(workflow.includes("files[0].filename.match(/^specs\\/DUUMBI-(\\d+)\\/PRODUCT\\.md$/)"));
+  assert.ok(workflow.includes("files[0].filename.match(/^specs\\/DUUMBI-(\\d+)\\/TECHNICAL\\.md$/)"));
   assert.match(workflow, /contents:\s+write/);
   assert.match(workflow, /pulls\.merge/);
   assert.match(workflow, /specs\/DUUMBI-\$\{issueNumber\}\/PRODUCT\.md/);
@@ -33,6 +38,9 @@ test("product spec Slack review requests wait for review-clean PRs", () => {
   assert.match(workflow, /will be squash-merged on approval/);
   assert.match(workflow, /No product spec review notifications are ready to send/);
   assert.match(workflow, /\.then\(\(runs\) => runs\.flat\(\)\.filter\(Boolean\)\)/);
+  assert.match(workflow, /GH_PROJECT_PAT: \$\{\{ secrets\.GH_PROJECT_PAT \}\}/);
+  assert.match(workflow, /updateProjectStatus\(issue\.number, "Spec Review"\)/);
+  assert.match(workflow, /Project status updates/);
 });
 
 test("technical spec Slack review requests wait for review-clean PRs", () => {


### PR DESCRIPTION
## Summary

Fixes the Stage 6/7 routing gap observed on #370.

Cause:
- Adding the `spec-review` label triggered the product-spec review request path, but that workflow only prepared Slack review notifications. It did not update the GitHub Project V2 `Status` field to `Spec Review`, so the issue could retain a stale status such as `In Progress`.
- `stage-approval.yml` only handled manual workflow dispatch and Slack `repository_dispatch`. If a reviewed spec-only PR was approved and merged directly through GitHub, no Stage 7 transition ran.

Changes:
- `spec-review-request.yml` now updates Project V2 `Status` to `Spec Review` via `GH_PROJECT_PAT` after the linked product spec PR is verified review-clean and before Slack notification handoff.
- `stage-approval.yml` now listens for merged DUUMBI spec-only PRs and derives Stage 7 or Stage 9 approval from a merged `specs/DUUMBI-*/PRODUCT.md` or `TECHNICAL.md` artifact.
- Manual merged product-spec PRs now get the same Stage 7 behavior: decision comment, next Codex prompt, labels, Project Status `Technical Spec Needed`, and Slack summary when configured.
- Added regression assertions for the new workflow paths.

Checks:
- `node --test scripts/github-actions/stage-approval-workflow.test.mjs scripts/github-actions/duumbi-stage-handoff.test.mjs`
- `git diff --check`
- YAML parse check for `.github/workflows/stage-approval.yml` and `.github/workflows/spec-review-request.yml`

Operational note:
- This PR does not modify #644, preserving that PR as spec-only for #370.
- After this fix is merged, re-run `Spec Review Request` for issue #370 or let its scheduled sweep repair the Project Status to `Spec Review`. A later merge of #644 will then route #370 to `Technical Spec Needed` and emit the Stage 8 prompt and Slack summary through the updated Stage Approval path.