### PR TITLE
Fix Copilot bot reviewer evidence matching

### DIFF
--- a/.github/workflows/spec-review-request.yml
+++ b/.github/workflows/spec-review-request.yml
@@ -233,16 +233,19 @@ jobs:
                 .map((reviewer) => reviewer.trim())
                 .filter(Boolean);
 
+            const normalizeReviewerLogin = (login) =>
+              String(login || "").trim().toLowerCase().replace(/\[bot\]$/, "");
+
             const validReviewEvidenceStates = new Set(["APPROVED", "COMMENTED", "CHANGES_REQUESTED"]);
 
             const missingRequiredReviewers = (latestReviews) => {
               const reviewActors = new Set(
                 latestReviews
                   .filter((review) => validReviewEvidenceStates.has(String(review.state || "").toUpperCase()))
-                  .map((review) => String(review.user?.login || "").toLowerCase())
+                  .map((review) => normalizeReviewerLogin(review.user?.login))
                   .filter(Boolean),
               );
-              return requiredAutomatedReviewers().filter((reviewer) => !reviewActors.has(reviewer.toLowerCase()));
+              return requiredAutomatedReviewers().filter((reviewer) => !reviewActors.has(normalizeReviewerLogin(reviewer)));
             };
 
             const findUnresolvedReviewThreads = async (pullNumber) => {

--- a/.github/workflows/stage-approval.yml
+++ b/.github/workflows/stage-approval.yml
@@ -384,16 +384,19 @@ jobs:
                 .map((reviewer) => reviewer.trim())
                 .filter(Boolean);
 
+            const normalizeReviewerLogin = (login) =>
+              String(login || '').trim().toLowerCase().replace(/\[bot\]$/, '');
+
             const validReviewEvidenceStates = new Set(['APPROVED', 'COMMENTED', 'CHANGES_REQUESTED']);
 
             const missingRequiredReviewers = (latestReviews) => {
               const reviewActors = new Set(
                 latestReviews
                   .filter((review) => validReviewEvidenceStates.has(String(review.state || '').toUpperCase()))
-                  .map((review) => String(review.user?.login || '').toLowerCase())
+                  .map((review) => normalizeReviewerLogin(review.user?.login))
                   .filter(Boolean),
               );
-              return requiredAutomatedReviewers().filter((reviewer) => !reviewActors.has(reviewer.toLowerCase()));
+              return requiredAutomatedReviewers().filter((reviewer) => !reviewActors.has(normalizeReviewerLogin(reviewer)));
             };
 
             const findUnresolvedReviewThreads = async (pullNumber) => {

--- a/.github/workflows/technical-spec-review-request.yml
+++ b/.github/workflows/technical-spec-review-request.yml
@@ -165,16 +165,19 @@ jobs:
                 .map((reviewer) => reviewer.trim())
                 .filter(Boolean);
 
+            const normalizeReviewerLogin = (login) =>
+              String(login || "").trim().toLowerCase().replace(/\[bot\]$/, "");
+
             const validReviewEvidenceStates = new Set(["APPROVED", "COMMENTED", "CHANGES_REQUESTED"]);
 
             const missingRequiredReviewers = (latestReviews) => {
               const reviewActors = new Set(
                 latestReviews
                   .filter((review) => validReviewEvidenceStates.has(String(review.state || "").toUpperCase()))
-                  .map((review) => String(review.user?.login || "").toLowerCase())
+                  .map((review) => normalizeReviewerLogin(review.user?.login))
                   .filter(Boolean),
               );
-              return requiredAutomatedReviewers().filter((reviewer) => !reviewActors.has(reviewer.toLowerCase()));
+              return requiredAutomatedReviewers().filter((reviewer) => !reviewActors.has(normalizeReviewerLogin(reviewer)));
             };
 
             const findUnresolvedReviewThreads = async (pullNumber) => {

--- a/scripts/github-actions/stage-approval-workflow.test.mjs
+++ b/scripts/github-actions/stage-approval-workflow.test.mjs
@@ -22,6 +22,8 @@ test("stage approval merges only reviewed spec PRs for Stage 7 and Stage 9 appro
   assert.match(workflow, /specs\/DUUMBI-\$\{issueNumber\}\/TECHNICAL\.md/);
   assert.match(workflow, /required automated review evidence from/);
   assert.match(workflow, /requiredAutomatedReviewers/);
+  assert.match(workflow, /normalizeReviewerLogin/);
+  assert.match(workflow, /replace\(\/\\\[bot\\\]\$\/, ''\)/);
   assert.match(workflow, /has unresolved review threads/);
   assert.match(workflow, /must change only \$\{policy\.expectedPath\}/);
   assert.match(workflow, /Related to #\$\{issueNumber\}/);
@@ -34,6 +36,8 @@ test("product spec Slack review requests wait for review-clean PRs", () => {
   assert.match(workflow, /PR is still draft/);
   assert.match(workflow, /required automated review evidence missing from/);
   assert.match(workflow, /requiredAutomatedReviewers/);
+  assert.match(workflow, /normalizeReviewerLogin/);
+  assert.match(workflow, /replace\(\/\\\[bot\\\]\$\/, ""\)/);
   assert.match(workflow, /unresolved review threads remain/);
   assert.match(workflow, /will be squash-merged on approval/);
   assert.match(workflow, /No product spec review notifications are ready to send/);
@@ -50,6 +54,8 @@ test("technical spec Slack review requests wait for review-clean PRs", () => {
   assert.match(workflow, /PR is still draft/);
   assert.match(workflow, /required automated review evidence missing from/);
   assert.match(workflow, /requiredAutomatedReviewers/);
+  assert.match(workflow, /normalizeReviewerLogin/);
+  assert.match(workflow, /replace\(\/\\\[bot\\\]\$\/, ""\)/);
   assert.match(workflow, /unresolved review threads remain/);
   assert.match(workflow, /will be squash-merged on approval/);
   assert.match(workflow, /No technical spec review notifications are ready to send/);

--- a/scripts/github-actions/stage-approval-workflow.test.mjs
+++ b/scripts/github-actions/stage-approval-workflow.test.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "../..");
 
 const readRepoFile = (path) => readFileSync(join(repoRoot, path), "utf8");
+const reviewerBotSuffixReplacement = /replace\(\s*\/\\\[bot\\\]\$\/\s*,\s*(["'])\1\s*\)/;
 
 test("stage approval merges only reviewed spec PRs for Stage 7 and Stage 9 approvals", () => {
   const workflow = readRepoFile(".github/workflows/stage-approval.yml");
@@ -23,7 +24,7 @@ test("stage approval merges only reviewed spec PRs for Stage 7 and Stage 9 appro
   assert.match(workflow, /required automated review evidence from/);
   assert.match(workflow, /requiredAutomatedReviewers/);
   assert.match(workflow, /normalizeReviewerLogin/);
-  assert.match(workflow, /replace\(\/\\\[bot\\\]\$\/, ''\)/);
+  assert.match(workflow, reviewerBotSuffixReplacement);
   assert.match(workflow, /has unresolved review threads/);
   assert.match(workflow, /must change only \$\{policy\.expectedPath\}/);
   assert.match(workflow, /Related to #\$\{issueNumber\}/);
@@ -37,7 +38,7 @@ test("product spec Slack review requests wait for review-clean PRs", () => {
   assert.match(workflow, /required automated review evidence missing from/);
   assert.match(workflow, /requiredAutomatedReviewers/);
   assert.match(workflow, /normalizeReviewerLogin/);
-  assert.match(workflow, /replace\(\/\\\[bot\\\]\$\/, ""\)/);
+  assert.match(workflow, reviewerBotSuffixReplacement);
   assert.match(workflow, /unresolved review threads remain/);
   assert.match(workflow, /will be squash-merged on approval/);
   assert.match(workflow, /No product spec review notifications are ready to send/);
@@ -55,7 +56,7 @@ test("technical spec Slack review requests wait for review-clean PRs", () => {
   assert.match(workflow, /required automated review evidence missing from/);
   assert.match(workflow, /requiredAutomatedReviewers/);
   assert.match(workflow, /normalizeReviewerLogin/);
-  assert.match(workflow, /replace\(\/\\\[bot\\\]\$\/, ""\)/);
+  assert.match(workflow, reviewerBotSuffixReplacement);
   assert.match(workflow, /unresolved review threads remain/);
   assert.match(workflow, /will be squash-merged on approval/);
   assert.match(workflow, /No technical spec review notifications are ready to send/);


### PR DESCRIPTION
## Summary

Fixes the Stage Approval failure from run https://github.com/hgahub/duumbi/actions/runs/26784586528.

Root cause:
- `DUUMBI_REQUIRED_SPEC_REVIEWERS` defaults to `copilot-pull-request-reviewer`.
- GitHub review submissions are returned with the bot login `copilot-pull-request-reviewer[bot]`.
- The workflow compared reviewer identities literally, so the real Copilot review on #644 was treated as missing evidence.

Changes:
- Normalize reviewer logins by lowercasing and stripping a trailing `[bot]` suffix before matching required reviewers.
- Apply the same normalization to Stage Approval, product spec review requests, and technical spec review requests.
- Add workflow regression assertions for the normalization path.

Checks:
- `node --test scripts/github-actions/stage-approval-workflow.test.mjs scripts/github-actions/duumbi-stage-handoff.test.mjs`
- `git diff --check`
- YAML parse check for `stage-approval.yml`, `spec-review-request.yml`, and `technical-spec-review-request.yml`

After this PR is merged, rerun the failed Stage Approval job/run for #370 or click the Slack approve path again. The existing Copilot review evidence on #644 should then be accepted.