### PR TITLE
Codify DUUMBI AI review policy

### DIFF
--- a/.agents/skills/duumbi-delivery-autopilot/SKILL.md
+++ b/.agents/skills/duumbi-delivery-autopilot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: duumbi-delivery-autopilot
-description: "Run DUUMBI delivery autopilot from one Spec Needed issue: draft product and technical specs, use configured automated reviews plus Codex AI gates for Stage 7 and Stage 9, merge spec-only PRs when gates are clean, then enter Stage 10 Ralph-cycle implementation without bypassing resource gates."
+description: "Run DUUMBI delivery autopilot from one Spec Needed issue: draft product and technical specs, use required automated reviews plus Codex AI gates for Stage 7 and Stage 9, merge spec-only PRs when gates are clean, then enter Stage 10 Ralph-cycle implementation without bypassing resource gates."
 ---
 
 You are the DUUMBI Delivery Autopilot Coordinator.
@@ -13,12 +13,12 @@ This skill covers:
 
 - verifying one issue is accepted and in `Spec Needed`
 - running Stage 6 product spec draft through `duumbi-spec-draft`
-- waiting for or verifying actual non-dismissed configured automated reviewer submissions on
+- running Codex self-review and waiting for or verifying actual non-dismissed required automated reviewer submissions on
   the product spec PR
 - running Stage 7 product spec review through `duumbi-spec-review` in AI-gate mode
 - merging the product spec-only PR only after a clean Stage 7 AI gate
 - running Stage 8 technical spec draft through `duumbi-tech-spec-draft`
-- waiting for or verifying actual non-dismissed configured automated reviewer submissions on
+- running Codex self-review and waiting for or verifying actual non-dismissed required automated reviewer submissions on
   the technical spec PR
 - running Stage 9 technical spec review through `duumbi-tech-spec-review` in AI-gate mode
 - merging the technical spec-only PR only after a clean Stage 9 AI gate
@@ -28,7 +28,7 @@ This skill covers:
 This skill does not:
 
 - accept Stage 5 work
-- bypass configured automated review or CI/check evidence
+- bypass Codex self-review, required automated review, or CI/check evidence
 - approve specs when AI gate requirements are missing
 - broaden product or technical scope
 - exceed Ralph-cycle resource gates
@@ -49,9 +49,18 @@ If any starting gate is missing, stop and report the missing gate.
 
 Stage 7 and Stage 9 may be approved by AI only when all gate requirements in `duumbi-spec-review` or `duumbi-tech-spec-review` are satisfied.
 
+Review service policy:
+
+- Codex self-review is mandatory before each AI gate.
+- Copilot is the default required automated reviewer for file-based spec gates.
+- CodeRabbit is advisory when present.
+- Greptile is manual-only and quota-limited. Delivery autopilot must not invoke
+  Greptile unless the developer explicitly requested it; spec-only PRs should
+  normally complete without Greptile.
+
 Fail closed when:
 
-- configured automated review evidence is absent, request-only, or unresolved
+- required automated review evidence is absent, request-only, or unresolved
 - checks are failing, pending, or missing without a documented not-applicable reason
 - blocking findings exist
 - unresolved product, architecture, security, migration, cost, scope, or verification questions remain
@@ -63,19 +72,19 @@ Durable decision comments must use:
 - `## Stage 7 AI Gate Decision`
 - `## Stage 9 AI Gate Decision`
 
-Each AI gate decision must link the issue, spec PR, configured automated review evidence, checks, findings, and next state.
+Each AI gate decision must link the issue, spec PR, required automated review evidence, checks, findings, and next state.
 
 ## Operating Flow
 
 1. Verify the target issue, Stage 5 decision, labels, Project status, and source links.
 2. Run Stage 6 with `duumbi-spec-draft`.
-3. Verify the product spec PR exists, is spec-only, and has configured automated review requested.
-4. Wait for actual non-dismissed configured automated reviewer submissions and checks when they are not complete. A successful review-request check is not review evidence. If waiting is not possible in the current environment, stop with the next prompt.
+3. Verify the product spec PR exists, is spec-only, and has Codex self-review and required automated review requested.
+4. Wait for actual non-dismissed required automated reviewer submissions and checks when they are not complete. A successful review-request check is not review evidence. If waiting is not possible in the current environment, stop with the next prompt.
 5. Run Stage 7 in AI-gate mode. If clean, record the AI gate decision and route through the deterministic spec AI gate or Stage Approval workflow. If not clean, stop with findings.
 6. Merge the product spec-only PR after the Stage 7 AI gate approval is recorded.
 7. Run Stage 8 with `duumbi-tech-spec-draft`.
-8. Verify the technical spec PR exists, is spec-only, and has configured automated review requested.
-9. Wait for actual non-dismissed configured automated reviewer submissions and checks when they are not complete. Resolve all review threads, including outdated threads after fixes. If waiting is not possible, stop with the next prompt.
+8. Verify the technical spec PR exists, is spec-only, and has Codex self-review and required automated review requested.
+9. Wait for actual non-dismissed required automated reviewer submissions and checks when they are not complete. Resolve all review threads, including outdated threads after fixes. If waiting is not possible, stop with the next prompt.
 10. Run Stage 9 in AI-gate mode. If clean, record the AI gate decision and route through the deterministic spec AI gate or Stage Approval workflow. If not clean, stop with findings.
 11. Merge the technical spec-only PR after the Stage 9 AI gate approval is recorded.
 12. Run Stage 10 coordination with `duumbi-implementation`.
@@ -88,7 +97,7 @@ Before merging a spec-only PR:
 
 - verify the PR is not an implementation PR
 - verify the execution issue is referenced only with non-closing language
-- verify CI/check state and configured automated review evidence are acceptable for the AI gate
+- verify CI/check state and required automated review evidence are acceptable for the AI gate
 - verify the Stage 7 or Stage 9 AI gate decision comment exists
 - use squash merge by default
 
@@ -118,7 +127,7 @@ Delivery autopilot complete:
 **Spec PR merges:** <merged PRs or none>
 **Stage 10 state:** <Ready for Build | In Progress | Cycle Authorization | In Review | Blocked | not reached>
 **Ralph cycles processed:** <count or none>
-**Checks and automated review evidence:** <summary>
+**Checks and required automated review evidence:** <summary>
 **Open blockers:** <none or list>
 **Next prompt:** <copy-ready prompt if stopped>
 ```

--- a/.agents/skills/duumbi-implementation/SKILL.md
+++ b/.agents/skills/duumbi-implementation/SKILL.md
@@ -40,6 +40,20 @@ Stage 9 owns technical spec approval. `duumbi-ralph-cycle` owns per-cycle implem
 - The source repo `AGENTS.md` controls local implementation conventions.
 - Do not claim GitHub status, approval state, branch state, PR state, source facts, or check results unless verified.
 
+## AI Review Service Policy
+
+- Before moving an implementation PR to `In Review`, require Codex self-review
+  of the consolidated diff and evidence.
+- Copilot is the default automated PR reviewer to inspect for implementation
+  readiness; a reviewer-request workflow alone is not review evidence.
+- CodeRabbit comments are advisory when present unless branch protection makes
+  them required.
+- Greptile is manual-only and quota-limited. Do not invoke it from Stage 10
+  unless the developer explicitly asks for a deep review. If the implementation
+  PR meets high-risk criteria from `docs/automation/code-review-policy.md`,
+  record that Greptile is recommended or requested, but do not create a review
+  loop.
+
 ## Language Rules
 
 - User-facing replies follow the language the user initiated.
@@ -167,6 +181,9 @@ When consolidating PR evidence, include:
 - affected files or modules
 - Ralph cycle resource approvals and evidence reports
 - commands/checks and results
+- AI review plan: Codex self-review status, Copilot review state, CodeRabbit
+  advisory state when present, and Greptile status (`not needed`, `recommended
+  for human decision`, `manually requested`, or `completed`)
 - screenshots/logs when relevant
 - remaining risks and open questions
 - readiness state: `ready for human review` or `blocked`
@@ -205,6 +222,7 @@ For `Move To In Review`:
 
 - require an implementation PR with evidence
 - require product and technical completion criteria to be addressed
+- require Codex self-review and an explicit AI review plan in the PR evidence
 - trigger or report the deterministic Stage 11 handoff path through
   `.github/workflows/implementation-review-request.yml`; use the existing
   `needs-review` label only when it is already available, and do not create it

--- a/.agents/skills/duumbi-ralph-cycle/SKILL.md
+++ b/.agents/skills/duumbi-ralph-cycle/SKILL.md
@@ -41,6 +41,17 @@ Stage 9 owns technical spec approval. `duumbi-implementation` owns Stage 10 coor
 - The source repo `AGENTS.md` controls local implementation conventions.
 - Do not claim GitHub status, approval state, branch state, PR state, source facts, resource use, or check results unless verified.
 
+## AI Review Hygiene
+
+- Ralph cycles produce implementation evidence; they do not request external AI
+  code reviews by default.
+- Run Codex self-review of the cycle diff before reporting `ready for PR
+  review`.
+- Do not invoke Greptile from a Ralph cycle unless the developer explicitly
+  requested a manual deep review. If the current diff appears high-risk under
+  `docs/automation/code-review-policy.md`, mention that in the evidence report
+  for Stage 10/11 routing instead of triggering Greptile automatically.
+
 ## Language Rules
 
 - User-facing replies follow the language the user initiated.

--- a/.agents/skills/duumbi-review-artifact/SKILL.md
+++ b/.agents/skills/duumbi-review-artifact/SKILL.md
@@ -39,6 +39,18 @@ Stage 10 owns implementation changes after review findings. Human reviewers own 
 - The review artifact must map claims to source evidence.
 - Do not claim CI status, review status, changed-file coverage, or completion criteria unless verified.
 
+## AI Review Service Policy
+
+- Stage 11 always includes Codex self-review as part of the review artifact.
+- Inspect Copilot review state as the default automated PR review evidence.
+  A reviewer-request workflow alone is not enough.
+- Treat CodeRabbit as advisory unless branch protection explicitly requires it.
+- Greptile is manual-only and quota-limited. Do not invoke it by default. If a
+  PR meets high-risk criteria from `docs/automation/code-review-policy.md`,
+  record whether Greptile was `not requested`, `recommended for human decision`,
+  `manually requested`, or `completed`. Only treat Greptile findings as gate
+  inputs after an actual configured or manually requested review exists.
+
 ## Language Rules
 
 - User-facing replies follow the language the user initiated.
@@ -62,6 +74,8 @@ Before reviewing:
 
 - GitHub issue title, body, comments, labels, Project status, and linked artifacts
 - implementation PR title, body, commits, changed files, review threads, and check/CI status
+- PR AI review plan from the body or Stage 10 evidence, including Codex
+  self-review, Copilot, CodeRabbit when present, and Greptile status
 - approved product spec and product-spec `Checks`
 - approved product spec BDD scenarios
 - approved technical spec, BDD-to-test mapping, live E2E plan, and completion criteria
@@ -90,6 +104,10 @@ Verify:
 - product-spec BDD scenarios are covered by mapped evidence
 - live E2E evidence exists for the canonical interface when required by the technical spec
 - technical-spec completion criteria are satisfied
+- Codex self-review was performed and has no unresolved blocking finding
+- Copilot review is clean, handled, or explicitly unavailable with rationale
+- Greptile was not needed, recommended but not run, or manually requested and
+  handled according to the policy
 - Ralph cycle resource approvals exist for any cycles that exceeded the resource gate, and evidence exists for all cycles
 - no unapproved scope expansion, broad refactor, or unrelated cleanup is present
 - risks and open questions are documented
@@ -125,6 +143,12 @@ Write or return:
 
 ## Ralph Cycle Evidence
 - Cycle <N>: <resource approval when required/evidence link and summary>
+
+## AI Review Evidence
+- Codex self-review:
+- Copilot review:
+- CodeRabbit review:
+- Greptile review:
 
 ## Changed Files Review
 - <file/module>: <expected by spec | resource-approved or permitted cycle | unexpected> - <note>

--- a/.agents/skills/duumbi-spec-draft/SKILL.md
+++ b/.agents/skills/duumbi-spec-draft/SKILL.md
@@ -19,7 +19,7 @@ This skill covers:
 - adding English Gherkin-style BDD scenarios that express observable behavior
 - writing the product spec as a GitHub issue comment for small issues
 - creating `specs/DUUMBI-<issue-number>/PRODUCT.md` in the relevant source repository and opening a review-ready PR for larger, architectural, cross-module, or durable specs
-- marking the file-based spec PR ready for review, requesting configured automated review, waiting for actual reviewer submissions, addressing blocking review feedback, resolving review threads, and reaching green checks before Slack approval is requested
+- marking the file-based spec PR ready for review, running Codex self-review, requesting required automated review, waiting for actual reviewer submissions, addressing blocking review feedback, resolving review threads, and reaching green checks before Slack approval is requested
 - linking the spec artifact back to the GitHub Issue
 - moving the issue to `Spec Review`, or to `Needs Clarification` when blocked
 - keeping the execution issue open by avoiding GitHub auto-close keywords in spec-only PR titles, bodies, and commit messages
@@ -42,6 +42,18 @@ Stage 7 owns product spec review and approval. Stage 8 owns technical specificat
 - Product spec artifacts hold the accepted product behavior candidate for review.
 - File-based specs live in the relevant source repository, not in this Obsidian vault.
 - Obsidian Atlas provides durable context but should not mirror live GitHub state.
+
+## AI Review Service Policy
+
+- Run Codex self-review before marking a file-based product spec PR ready for
+  review and before moving the issue to `Spec Review`.
+- Copilot is the default required automated reviewer for file-based product spec
+  PRs in this repository, recorded as `copilot-pull-request-reviewer` unless
+  repository configuration states otherwise.
+- Greptile is manual-only and quota-limited. Do not invoke it for normal
+  product spec PRs, docs-only changes, or every push. Use it only when the
+  developer explicitly requests a manual deep review.
+- Do not treat a successful reviewer-request workflow as review evidence.
 
 ## Language Rules
 
@@ -110,10 +122,11 @@ For file-based specs:
 - create or update only the spec file and minimal supporting metadata if required by the source repo
 - open the PR as a draft while the first artifact is being assembled
 - mark the PR ready for review after the spec artifact is complete and local checks are complete
-- request or wait for the configured automated reviewers when available. In this
-  repository the default required reviewer is `copilot-pull-request-reviewer`
-  unless repository configuration states otherwise. Do not treat a successful
-  reviewer-request check as completed review evidence.
+- run Codex self-review, then request or wait for the required automated
+  reviewers when available. In this repository the default required reviewer is
+  `copilot-pull-request-reviewer` unless repository configuration states
+  otherwise. Do not include Greptile in this default gate and do not treat a
+  successful reviewer-request check as completed review evidence.
 - inspect review feedback and check results, fix blocking findings inside the spec file, and repeat until the PR is review-clean
 - link the review-ready PR and spec path from the GitHub Issue
 - treat the PR as a spec-review artifact only; it must not close the execution issue when merged or closed
@@ -181,7 +194,11 @@ After a successful spec artifact exists:
 - add existing `spec-review` label when available
 - do not mark the product spec approved
 - do not close the execution issue; it must remain open until Stage 12 closure verifies merged implementation evidence
-- for file-based specs, add `spec-review` only after the PR is no longer draft, checks are green, actual non-dismissed configured automated reviewer submissions exist, and every review thread is resolved, including outdated threads after fixes; the Stage 7 Slack approval will merge the spec PR if approved
+- for file-based specs, add `spec-review` only after the PR is no longer draft,
+  checks are green, Codex self-review has no blocking finding, actual
+  non-dismissed required automated reviewer submissions exist, and every review
+  thread is resolved, including outdated threads after fixes; the Stage 7 Slack
+  approval will merge the spec PR if approved
 
 When blocked:
 
@@ -216,7 +233,7 @@ Product spec draft complete:
 - Do not bury blocking questions in a draft spec.
 - Do not create technical specs, implementation code, PRs for implementation, or Ralph cycles.
 - Do not approve your own product spec.
-- Do not request Slack approval for a file-based product spec while its PR is still draft, missing checks, missing actual non-dismissed configured automated review evidence, or has any unresolved review thread.
+- Do not request Slack approval for a file-based product spec while its PR is still draft, missing checks, missing Codex self-review, missing actual non-dismissed required automated review evidence, or has any unresolved review thread.
 - Do not use GitHub auto-close keywords in spec-only PRs; only Stage 12 closure may close the execution issue.
 - Keep the spec traceable to source links and decisions.
 - Stop and ask the user if a requested write exceeds Stage 6.

--- a/.agents/skills/duumbi-spec-review/SKILL.md
+++ b/.agents/skills/duumbi-spec-review/SKILL.md
@@ -40,10 +40,12 @@ Before approving through the AI gate, verify all of these facts:
 
 - the product spec PR is a spec-only PR and contains no implementation code
 - the product spec PR is open, non-draft, review-clean, and ready for approval merge
-- each configured automated reviewer has submitted actual, non-dismissed review
+- Codex self-review has no blocking finding
+- each required automated reviewer has submitted actual, non-dismissed review
   evidence; in this repository the default required reviewer is
   `copilot-pull-request-reviewer` unless repository configuration states
-  otherwise
+  otherwise. Greptile is manual-only and must not be treated as required unless
+  a human explicitly configured or requested it for this PR.
 - do not treat a successful reviewer-request check as completed review evidence
 - no latest automated or human review is `CHANGES_REQUESTED`
 - no review thread remains unresolved, including outdated threads after a fix
@@ -62,6 +64,17 @@ If any requirement is missing, fail closed: record a review report, route to `Sp
 - The durable Stage 7 decision record is a structured GitHub issue comment.
 - For file-based specs, also comment on the PR when available so review context stays with the spec diff.
 - Obsidian Atlas provides context, but should not mirror live review state.
+
+## AI Review Service Policy
+
+- Stage 7 always performs Codex product-spec review against the checklist below.
+- File-based product spec PR approval also requires required automated review
+  evidence, Copilot by default.
+- CodeRabbit and Greptile comments are advisory unless branch protection or an
+  explicit human instruction says otherwise.
+- Do not invoke Greptile from Stage 7 by default. Product spec review should use
+  Codex checklist plus Copilot evidence; Greptile is reserved for rare manual
+  escalation.
 
 ## Language Rules
 
@@ -86,7 +99,7 @@ When the prompt contains an explicit **Approve** decision (e.g. `Human decision:
 1. `gh issue view <N> --json number,title,labels,body` — verify `spec-review` label is present
 2. `gh issue view <N> --comments --json comments` — find the Stage 6 Product Spec Draft artifact link
 3. Construct and post the Stage 7 Decision Comment on the issue
-4. If the artifact is a PR, verify it is open, non-draft, changes only `specs/DUUMBI-<N>/PRODUCT.md`, has green checks, actual non-dismissed configured automated reviewer submissions, no blocking review decisions, and no unresolved review threads, including outdated unresolved threads
+4. If the artifact is a PR, verify it is open, non-draft, changes only `specs/DUUMBI-<N>/PRODUCT.md`, has green checks, Codex self-review with no blocking finding, actual non-dismissed required automated reviewer submissions, no blocking review decisions, and no unresolved review threads, including outdated unresolved threads
 5. If the artifact is a PR, squash-merge it with non-closing issue references such as `Related to #<N>`; do not close the execution issue
 6. Post a short pointer comment on the PR (if identifiable)
 7. Update labels: remove `needs-spec` and `spec-review`, add `product-spec-approved` and `needs-tech-spec`
@@ -207,7 +220,7 @@ For file-based specs, also comment on the PR with the same decision or a short p
 For `Approve`:
 
 - require explicit human approval or a fully satisfied AI gate
-- for file-based specs, require an open non-draft spec-only PR with green checks, actual non-dismissed configured automated reviewer submissions, no blocking review decisions, and no unresolved review threads
+- for file-based specs, require an open non-draft spec-only PR with green checks, Codex self-review with no blocking finding, actual non-dismissed required automated reviewer submissions, no blocking review decisions, and no unresolved review threads
 - for file-based specs, squash-merge the product spec PR before moving the issue to `Technical Spec Needed`
 - write the decision comment
 - set Project Status to `Technical Spec Needed` when available

--- a/.agents/skills/duumbi-tech-spec-draft/SKILL.md
+++ b/.agents/skills/duumbi-tech-spec-draft/SKILL.md
@@ -20,7 +20,7 @@ This skill covers:
 - defining at least one live LLM-backed E2E path through the canonical interface when the work touches LLM behavior
 - defining the Ralph Cycle resource policy, approval thresholds, and autonomous batch cap
 - opening a PR for the technical spec artifact
-- marking the technical spec PR ready for review, requesting configured automated review, waiting for actual reviewer submissions, addressing blocking review feedback, resolving review threads, and reaching green checks before Slack approval is requested
+- marking the technical spec PR ready for review, running Codex self-review, requesting required automated review, waiting for actual reviewer submissions, addressing blocking review feedback, resolving review threads, and reaching green checks before Slack approval is requested
 - linking the technical spec review-ready PR back to the GitHub Issue
 - moving the issue to `Technical Spec Review`, or to `Needs Clarification` when blocked
 - when the initiating prompt explicitly asks to continue through `Ready for Build`, handing off to `duumbi-tech-spec-review` after Stage 8 is review-clean so Stage 9 can process an explicit human or AI-gate approval, merge the spec PR, and advance the issue
@@ -45,6 +45,19 @@ Stage 9 owns technical spec review, approval, spec PR merge, and `Ready for Buil
 - Technical specs define how AI implementation agents should safely make the product spec true.
 - Technical specs live in the relevant source repository, not in this Obsidian vault.
 - Obsidian Atlas provides durable context, but should not mirror live GitHub state.
+
+## AI Review Service Policy
+
+- Run Codex self-review before marking a technical spec PR ready for review and
+  before moving the issue to `Technical Spec Review`.
+- Copilot is the default required automated reviewer for file-based technical
+  spec PRs in this repository, recorded as `copilot-pull-request-reviewer`
+  unless repository configuration states otherwise.
+- Greptile is manual-only and quota-limited. Do not invoke it for normal
+  technical spec PRs, docs-only changes, or every push. Use it only when the
+  developer explicitly requests a manual deep review for high-risk architecture
+  or implementation-plan concerns.
+- Do not treat a successful reviewer-request workflow as review evidence.
 
 ## Language Rules
 
@@ -128,12 +141,13 @@ specs/DUUMBI-<issue-number>/TECHNICAL.md
 ```
 
 Open a PR for the technical spec artifact and link it from the GitHub Issue. Use draft
-state while assembling the first artifact, then mark it ready for review, request
-or wait for configured automated reviewers. In this repository the default
-configured automated reviewer is `copilot-pull-request-reviewer` unless
-repository configuration states otherwise. Do not treat a successful
-"Request Copilot Review" check as completed review evidence; it only proves the
-request was sent. Address blocking review feedback
+state while assembling the first artifact, then mark it ready for review, run
+Codex self-review, and request or wait for required automated reviewers. In this
+repository the default required automated reviewer is
+`copilot-pull-request-reviewer` unless repository configuration states
+otherwise. Do not include Greptile in this default gate and do not treat a
+successful "Request Copilot Review" check as completed review evidence; it only
+proves the request was sent. Address blocking review feedback
 inside `TECHNICAL.md`, push the fix, and continue until checks are green and all
 review threads are resolved, including threads that became outdated after the
 fix. Only then route the issue to `Technical Spec Review`; Stage 9 Slack or AI
@@ -150,7 +164,8 @@ are verified:
   references
 - CI/checks and status contexts are complete and passing, or explicitly
   not applicable for a docs-only diff
-- each configured automated reviewer has submitted actual, non-dismissed review
+- Codex self-review has no blocking finding
+- each required automated reviewer has submitted actual, non-dismissed review
   evidence; review-request workflow success is not enough
 - no latest review is `CHANGES_REQUESTED`
 - no review thread remains unresolved, including outdated threads after a push
@@ -310,7 +325,7 @@ Technical spec draft complete:
 - Do not modify implementation code, tests, migrations, generated outputs, or runtime assets.
 - Do not run Ralph cycles or implementation commands.
 - Do not approve your own technical spec.
-- Do not request Slack approval for a technical spec while its PR is still draft, missing checks, missing actual non-dismissed configured automated review evidence, or has any unresolved review thread.
+- Do not request Slack approval for a technical spec while its PR is still draft, missing checks, missing Codex self-review, missing actual non-dismissed required automated review evidence, or has any unresolved review thread.
 - Do not use GitHub auto-close keywords in spec-only PRs; only Stage 12 closure may close the execution issue.
 - Keep the technical spec traceable to the approved product spec and source evidence.
 - Stop and ask the user if a requested write exceeds Stage 8.

--- a/.agents/skills/duumbi-tech-spec-review/SKILL.md
+++ b/.agents/skills/duumbi-tech-spec-review/SKILL.md
@@ -42,10 +42,12 @@ Before approving through the AI gate, verify all of these facts:
 
 - the technical spec PR is a spec-only PR and contains no implementation code or test edits
 - the technical spec PR is open, non-draft, review-clean, and ready for approval merge
-- each configured automated reviewer has submitted actual, non-dismissed review
+- Codex self-review has no blocking finding
+- each required automated reviewer has submitted actual, non-dismissed review
   evidence; in this repository the default required reviewer is
   `copilot-pull-request-reviewer` unless repository configuration states
-  otherwise
+  otherwise. Greptile is manual-only and must not be treated as required unless
+  a human explicitly configured or requested it for this PR.
 - do not treat a successful review-request check, including `Request Copilot
   Review`, as completed review evidence
 - no latest automated or human review is `CHANGES_REQUESTED`
@@ -66,6 +68,17 @@ If any requirement is missing, fail closed: record a review report, route to `Te
 - The durable Stage 9 decision record is a structured GitHub issue comment.
 - For file-based technical specs, also comment on the PR when available so review context stays with the spec diff.
 - Obsidian Atlas provides context, but should not mirror live review state.
+
+## AI Review Service Policy
+
+- Stage 9 always performs Codex implementability review against the checklist
+  below.
+- File-based technical spec PR approval also requires required automated review
+  evidence, Copilot by default.
+- CodeRabbit and Greptile comments are advisory unless branch protection or an
+  explicit human instruction says otherwise.
+- Do not invoke Greptile from Stage 9 by default. Use it only for rare manual
+  escalation on high-risk architecture or implementation-plan questions.
 
 ## Language Rules
 
@@ -90,7 +103,7 @@ When the prompt contains an explicit **Approve** decision (e.g. `Human decision:
 
 1. `gh issue view <N> --json number,title,labels,body` — verify `technical-spec-review` label is present
 2. `gh issue view <N> --comments --json comments` — find the Stage 8 Technical Spec Draft artifact link and product spec link from existing comments (search for "Stage 8 Technical Spec Draft" and "Stage 6 Product Spec Draft")
-3. Verify the technical spec PR is open, non-draft, changes only `specs/DUUMBI-<N>/TECHNICAL.md`, has green checks, actual non-dismissed configured automated reviewer submissions, no blocking review decisions, and no unresolved review threads, including outdated unresolved threads
+3. Verify the technical spec PR is open, non-draft, changes only `specs/DUUMBI-<N>/TECHNICAL.md`, has green checks, Codex self-review with no blocking finding, actual non-dismissed required automated reviewer submissions, no blocking review decisions, and no unresolved review threads, including outdated unresolved threads
 4. Squash-merge the technical spec PR with non-closing issue references such as `Related to #<N>`; do not close the execution issue
 5. Construct and post the Stage 9 Decision Comment on the issue (use the Decision Comment template below)
 6. Post a short pointer comment on the tech spec PR
@@ -240,7 +253,7 @@ For file-based technical specs, also comment on the PR with the same decision or
 For `Approve`:
 
 - require explicit human approval or a fully satisfied AI gate
-- require an open non-draft spec-only PR with green checks, actual non-dismissed configured automated reviewer submissions, no blocking review decisions, and no unresolved review threads
+- require an open non-draft spec-only PR with green checks, Codex self-review with no blocking finding, actual non-dismissed required automated reviewer submissions, no blocking review decisions, and no unresolved review threads
 - fail closed if the only automated-review evidence is a successful reviewer
   request workflow; the reviewer must have submitted a review or equivalent
   configured evidence

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,13 @@ Describe what changed and why.
 - [ ] `cargo test --all`
 - [ ] `cargo audit`
 
+## AI Review Plan
+
+- [ ] Codex self-review completed and blocking findings are fixed or listed
+- [ ] Copilot review requested/received or explicitly not applicable
+- [ ] Greptile not used, or manually requested because this PR meets the high-risk criteria in `docs/automation/code-review-policy.md`
+- [ ] Review threads are resolved after verifying fixes
+
 ## Docs Impact
 
 - [ ] No docs update needed

--- a/.github/copilot-review-instructions.md
+++ b/.github/copilot-review-instructions.md
@@ -1,6 +1,10 @@
 # Copilot Review Instructions for DUUMBI
 
 Review pull requests with emphasis on correctness, safety, and docs consistency.
+DUUMBI uses Copilot as the default automated PR reviewer. Codex self-review
+provides stage-aware evidence, and Greptile is manual-only for scarce high-risk
+deep reviews. Do not assume Greptile evidence is required unless a human asked
+for it.
 
 ## High-priority checks
 
@@ -33,3 +37,5 @@ When PR changes CLI behavior, JSON-LD schema/types/ops, module/dependency behavi
 - Prioritize findings: bugs, risks, regressions, and missing tests first.
 - Be specific: include impacted files and exact behavior concerns.
 - Keep suggestions actionable and minimal.
+- Mark wording, style, and optional maintainability suggestions as non-blocking
+  unless they create correctness, security, data-loss, or spec-compliance risk.

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,4 +1,4 @@
-name: Copilot Review (All PRs)
+name: Copilot Review (Default PR Gate)
 
 on:
   pull_request:
@@ -16,6 +16,9 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
+            // Copilot is DUUMBI's default low-cost automated reviewer.
+            // Greptile is configured separately as manual-only for scarce,
+            // high-risk deep reviews; this workflow must not invoke it.
             try {
               await github.rest.pulls.requestReviewers({
                 owner: context.repo.owner,

--- a/.github/workflows/spec-ai-gate.yml
+++ b/.github/workflows/spec-ai-gate.yml
@@ -31,7 +31,7 @@ on:
         type: string
         default: ''
       automated_review_evidence:
-        description: Link or summary of configured automated review evidence
+        description: Link or summary of required automated review evidence
         required: false
         type: string
         default: ''
@@ -102,7 +102,7 @@ jobs:
               `**Spec PR:** ${prUrl}`,
               `**Automated review evidence:** ${automatedReviewEvidence || "verified by invoking agent; no link provided"}`,
               `**Rationale:** ${rationale}`,
-              `**Gate policy:** fail-closed if configured automated review, checks, scope, or blocking findings are missing`,
+              `**Gate policy:** fail-closed if required automated review, checks, scope, or blocking findings are missing. Greptile is manual-only and not part of the default spec gate.`,
               `**Next state:** ${nextState}`,
             ].join("\n");
 

--- a/.github/workflows/spec-review-request.yml
+++ b/.github/workflows/spec-review-request.yml
@@ -227,6 +227,8 @@ jobs:
               return [...latest.values()];
             };
 
+            // Low-cost required review gate. Keep quota-limited manual reviewers
+            // such as Greptile out of DUUMBI_REQUIRED_SPEC_REVIEWERS.
             const requiredAutomatedReviewers = () =>
               String(process.env.DUUMBI_REQUIRED_SPEC_REVIEWERS || "copilot-pull-request-reviewer")
                 .split(",")
@@ -351,7 +353,7 @@ jobs:
                 return {
                   ready: false,
                   prNumber,
-                  summary: `required automated review evidence missing from ${missingReviewers.join(", ")}; review-request checks do not count`,
+                  summary: `required automated review evidence missing from ${missingReviewers.join(", ")}; review-request checks do not count; Greptile is manual-only and not part of the default spec gate`,
                 };
               }
               if (blockingReviews.length > 0) return { ready: false, prNumber, summary: "blocking review decision remains" };

--- a/.github/workflows/stage-approval.yml
+++ b/.github/workflows/stage-approval.yml
@@ -296,7 +296,7 @@ jobs:
                   `Target issue: ${issueUrl}`,
                   `Expected artifact: specs/DUUMBI-${issueNumber}/PRODUCT.md, unless the skill determines that an issue-comment spec is sufficient.`,
                   '',
-                  'Goal: Verify Stage 5 acceptance, inspect active DUUMBI context and relevant source context, draft the product spec in English with BDD Scenarios, open a spec PR if file-based, mark it ready for review, wait for actual configured automated reviewer submissions, address blocking review feedback until checks and automated reviews are clean, resolve review threads after verifying the fixes, link it from the issue, and move the issue to Spec Review only after it is ready for approval merge.',
+                  'Goal: Verify Stage 5 acceptance, inspect active DUUMBI context and relevant source context, draft the product spec in English with BDD Scenarios, open a spec PR if file-based, mark it ready for review, run Codex self-review, wait for actual required automated reviewer submissions (Copilot by default), address blocking review feedback until checks and required automated reviews are clean, resolve review threads after verifying the fixes, link it from the issue, and move the issue to Spec Review only after it is ready for approval merge. Do not invoke Greptile unless the developer explicitly requests a manual deep review.',
                   '',
                   `Spec-only PR rule: use non-closing issue references such as "Related to #${issueNumber}" or "Spec for #${issueNumber}". Include a workflow note that this PR must leave the execution issue open.`,
                   '',
@@ -312,7 +312,7 @@ jobs:
                   `Product spec artifact: ${knownProductSpec}`,
                   `Expected artifact: specs/DUUMBI-${issueNumber}/TECHNICAL.md`,
                   '',
-                  'Goal: Verify product spec approval, inspect repo AGENTS.md and affected source areas, draft an agent-facing technical spec with BDD-to-test mapping, live E2E plan, and Ralph Cycle resource policy, open a technical spec PR, mark it ready for review, wait for actual configured automated reviewer submissions, address blocking review feedback until checks and automated reviews are clean, resolve review threads after verifying the fixes, link it from the issue, move the issue to Technical Spec Review only after it is ready for approval merge, then record Stage 9 approval through the configured AI or human gate, merge the spec PR, move the issue to Ready for Build, and send the Stage 10 prompt.',
+                  'Goal: Verify product spec approval, inspect repo AGENTS.md and affected source areas, draft an agent-facing technical spec with BDD-to-test mapping, live E2E plan, and Ralph Cycle resource policy, open a technical spec PR, mark it ready for review, run Codex self-review, wait for actual required automated reviewer submissions (Copilot by default), address blocking review feedback until checks and required automated reviews are clean, resolve review threads after verifying the fixes, link it from the issue, move the issue to Technical Spec Review only after it is ready for approval merge, then record Stage 9 approval through the configured AI or human gate, merge the spec PR, move the issue to Ready for Build, and send the Stage 10 prompt. Do not invoke Greptile unless the developer explicitly requests a manual deep review.',
                   '',
                   `Spec-only PR rule: use non-closing issue references such as "Related to #${issueNumber}" or "Technical spec for #${issueNumber}". Include a workflow note that this PR must leave the execution issue open.`,
                   '',
@@ -378,6 +378,8 @@ jobs:
               return [...latest.values()];
             };
 
+            // Low-cost required review gate. Keep quota-limited manual reviewers
+            // such as Greptile out of DUUMBI_REQUIRED_SPEC_REVIEWERS.
             const requiredAutomatedReviewers = () =>
               String(process.env.DUUMBI_REQUIRED_SPEC_REVIEWERS || 'copilot-pull-request-reviewer')
                 .split(',')
@@ -531,7 +533,7 @@ jobs:
               const blockingReviews = latestReviews.filter((review) => review.state === 'CHANGES_REQUESTED');
               const missingReviewers = missingRequiredReviewers(latestReviews);
               if (missingReviewers.length > 0) {
-                throw new Error(`${policy.kind} PR #${prNumber} is missing required automated review evidence from: ${missingReviewers.join(', ')}. A review-request check is not enough; approval waits for actual reviewer submissions and fixes.`);
+                throw new Error(`${policy.kind} PR #${prNumber} is missing required automated review evidence from: ${missingReviewers.join(', ')}. A review-request check is not enough; approval waits for actual reviewer submissions and fixes. Greptile is manual-only and must not be used to satisfy this default gate unless a human explicitly configured it.`);
               }
               if (blockingReviews.length > 0) {
                 throw new Error(`${policy.kind} PR #${prNumber} has blocking review decisions: ${blockingReviews.map((review) => `${review.user?.login || 'unknown'}:${review.state}`).join(', ')}`);

--- a/.github/workflows/technical-spec-review-request.yml
+++ b/.github/workflows/technical-spec-review-request.yml
@@ -159,6 +159,8 @@ jobs:
               return [...latest.values()];
             };
 
+            // Low-cost required review gate. Keep quota-limited manual reviewers
+            // such as Greptile out of DUUMBI_REQUIRED_SPEC_REVIEWERS.
             const requiredAutomatedReviewers = () =>
               String(process.env.DUUMBI_REQUIRED_SPEC_REVIEWERS || "copilot-pull-request-reviewer")
                 .split(",")
@@ -283,7 +285,7 @@ jobs:
                 return {
                   ready: false,
                   prNumber,
-                  summary: `required automated review evidence missing from ${missingReviewers.join(", ")}; review-request checks do not count`,
+                  summary: `required automated review evidence missing from ${missingReviewers.join(", ")}; review-request checks do not count; Greptile is manual-only and not part of the default spec gate`,
                 };
               }
               if (blockingReviews.length > 0) return { ready: false, prNumber, summary: "blocking review decision remains" };

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,35 @@
+{
+  "strictness": 2,
+  "commentTypes": ["logic", "syntax"],
+  "triggerOnUpdates": false,
+  "skipReview": "AUTOMATIC",
+  "statusCheck": false,
+  "updateExistingSummaryComment": true,
+  "ignorePatterns": "target/**\n**/target/**\nnode_modules/**\ndist/**\ncoverage/**\n.duumbi/cache/**\nspecs/**\ndocs/**\n**/*.md\n**/*.svg\n**/*.png\n**/*.drawio",
+  "instructions": "DUUMBI uses Greptile as a manual, quota-limited reviewer only. Prioritize correctness, security, Rust compile/runtime behavior, graph invariants, async/concurrency safety, provider/auth handling, registry integrity, MCP/intent boundaries, and tests. Do not request wording-only, style-only, or documentation-only changes. Treat P0/P1 findings as blocking. Treat P2 maintainability findings as non-blocking unless they can cause incorrect behavior, security risk, data loss, crashes, or violated specs.",
+  "rules": [
+    {
+      "id": "rust-error-handling",
+      "rule": "Rust library code must not use unwrap. Prefer thiserror for module errors, anyhow only at application boundaries, and contextual error propagation with ?. Use expect only for documented invariants.",
+      "scope": ["src/**", "crates/**", "runtime/**", "tests/**"],
+      "severity": "high"
+    },
+    {
+      "id": "graph-ir-invariants",
+      "rule": "Treat the semantic graph IR as the source of truth. Flag changes that can desynchronize parser, graph, validator, lowering, runtime, or registry assumptions.",
+      "scope": ["src/parser/**", "src/graph/**", "src/compiler/**", "src/runtime/**", "runtime/**"],
+      "severity": "high"
+    },
+    {
+      "id": "async-provider-safety",
+      "rule": "Flag blocking work in async contexts, unsafe provider credential handling, missing timeout/retry behavior, unbounded external calls, and unreviewed live-provider side effects.",
+      "scope": ["src/agents/**", "src/mcp/**", "src/intent/**", "src/registry/**", "crates/**"],
+      "severity": "high"
+    },
+    {
+      "id": "spec-boundary",
+      "rule": "For implementation PRs, flag behavior that exceeds the linked product or technical spec, bypasses Ralph-cycle resource gates, or weakens required verification evidence.",
+      "severity": "medium"
+    }
+  ]
+}

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,20 @@
+{
+  "files": [
+    {
+      "path": "AGENTS.md",
+      "description": "Repository-local agent and coding contract for DUUMBI."
+    },
+    {
+      "path": "docs/architecture.md",
+      "description": "DUUMBI architecture overview and subsystem boundaries."
+    },
+    {
+      "path": "docs/coding-conventions.md",
+      "description": "Repository coding and review conventions."
+    },
+    {
+      "path": "docs/automation/code-review-policy.md",
+      "description": "DUUMBI policy for Codex self-review, Copilot, CodeRabbit, and Greptile usage."
+    }
+  ]
+}

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,35 @@
+# DUUMBI Greptile Review Rules
+
+Greptile is manual-only for this repository. It should be used as a scarce,
+high-signal reviewer for complex implementation PRs, not as a default reviewer
+for every PR or commit.
+
+## Review Focus
+
+- Prioritize correctness, security, data loss, crashes, Rust compile/runtime
+  behavior, graph invariants, async/concurrency safety, provider/auth handling,
+  registry integrity, MCP/intent boundaries, and missing tests.
+- Treat style, naming, wording, documentation polish, and optional refactors as
+  non-blocking unless they create concrete behavior or maintenance risk.
+- Prefer one concise blocking finding over several speculative comments.
+- Do not ask for broad refactors unless the current change is unsafe or violates
+  an approved spec.
+
+## DUUMBI Boundaries
+
+- The semantic graph IR is the central source of truth.
+- Cranelift types must remain contained inside `src/compiler/`.
+- AI agents should receive read-only graph snapshots and propose explicit
+  mutation plans.
+- Query mode is read-only by default; mutation belongs in Agent or Intent mode.
+- Stage 10 implementation must stay inside approved product and technical specs
+  and Ralph-cycle resource gates.
+
+## PR Type Expectations
+
+- Specs, docs, and routine config PRs should not receive Greptile review unless
+  a developer explicitly asks for it.
+- Implementation PRs with complex Rust, security-sensitive behavior,
+  provider/auth changes, async/concurrency behavior, compiler/runtime changes,
+  or cross-module refactors are the main Greptile use case.
+- If a finding is a nit, label it as non-blocking in the review text.

--- a/docs/automation/agentic-development-orchestration.md
+++ b/docs/automation/agentic-development-orchestration.md
@@ -27,9 +27,9 @@ or source-repo contracts that support it.
 - `duumbi-obsidian-capture` and `duumbi-codex-intake` now search active Inbox,
   Processed Inbox, Atlas, and GitHub before creating duplicate notes.
 - `duumbi-spec-review` and `duumbi-tech-spec-review` now support bounded AI
-  gates while still failing closed on missing configured automated review
+  gates while still failing closed on missing required automated review
   submissions, checks, scope, unresolved findings, or unmerged spec PR
-  readiness.
+  readiness. Copilot is the default required reviewer; Greptile is manual-only.
 - `duumbi-closure` runs after a verified merge or equivalent completion
   evidence to close the loop across GitHub, source surfaces, Inbox notes, and
   durable knowledge sync decisions.
@@ -155,13 +155,27 @@ Reference pricing pages:
 
 ## Gate Policy
 
+Review service selection is governed by
+`docs/automation/code-review-policy.md`:
+
+- Codex self-review is mandatory before agents mark work ready, approve an AI
+  gate, or recommend implementation merge readiness.
+- Copilot is the default automated PR reviewer and the default required
+  evidence source for file-based Stage 7 and Stage 9 gates.
+- CodeRabbit is advisory when present; it is not a DUUMBI gate unless branch
+  protection explicitly requires it.
+- Greptile is manual-only, quota-limited, and reserved for stable high-risk
+  implementation PRs or explicitly requested deep review. Do not include
+  Greptile in `DUUMBI_REQUIRED_SPEC_REVIEWERS`.
+
 Stage 7 and Stage 9 AI gates may approve only when:
 
 - the PR is spec-only
 - the PR is open, non-draft, and ready for approval merge
-- actual non-dismissed configured automated review submissions exist. By
+- actual non-dismissed required automated review submissions exist. By
   default this means `copilot-pull-request-reviewer`; repositories can override
-  the comma-separated list with `DUUMBI_REQUIRED_SPEC_REVIEWERS`
+  the comma-separated low-cost reviewer list with
+  `DUUMBI_REQUIRED_SPEC_REVIEWERS`
 - reviewer-request workflow success does not count as review evidence
 - automated reviews and human reviews have no blocking `CHANGES_REQUESTED`
   decision
@@ -175,8 +189,8 @@ Stage 7 and Stage 9 AI gates may approve only when:
 Stage 7 and Stage 9 human Slack approvals are merge finalizers for file-based
 specs. The review request workflows send Slack approval cards only after the
 linked PRODUCT.md or TECHNICAL.md PR is review-clean. Review-clean means the
-PR has actual non-dismissed configured automated reviewer submissions, green checks, no
-blocking review decisions, and no unresolved review threads. Approval then
+PR has actual non-dismissed required automated reviewer submissions, green
+checks, no blocking review decisions, and no unresolved review threads. Approval then
 revalidates the exact PR, squash-merges the spec artifact with non-closing issue
 references, records the stage decision, and advances the issue to the next
 workflow state. If the PR is draft, dirty, not spec-only, missing required
@@ -184,7 +198,7 @@ reviewer submissions, or has unresolved review threads, the workflow fails
 closed or defers notification.
 
 The Stage 7 approval prompt is intentionally a Stage 8-to-Ready handoff. It
-instructs Codex to draft the technical spec, wait for configured automated
+instructs Codex to draft the technical spec, wait for required automated
 reviewers, fix and resolve review feedback, route to `Technical Spec Review`,
 then run Stage 9 through the configured AI or human gate. Only a satisfied
 Stage 9 gate may merge the technical spec PR, move the issue to `Ready for
@@ -201,7 +215,8 @@ or validation failures while preserving GitHub Issues and Project V2 as the
 source of truth.
 
 Stage 11 merge remains human-authorized. The merge workflow requires explicit
-human decision, Stage 11 review artifact, green checks, clean Copilot review,
+human decision, Stage 11 review artifact, green checks, clean or handled
+Copilot review,
 and an open non-draft implementation PR. It uses squash merge by default and
 emits the Stage 12 closure prompt after merge.
 

--- a/docs/automation/code-review-policy.md
+++ b/docs/automation/code-review-policy.md
@@ -1,0 +1,95 @@
+# DUUMBI AI Code Review Policy
+
+This policy defines which AI review services DUUMBI agents should use and when.
+It exists to keep review evidence useful without wasting quota or triggering
+unbounded review loops.
+
+## Review Service Roles
+
+| Service | Default role | Use when | Do not use when |
+|---|---|---|---|
+| Codex self-review | Mandatory agent-side review before a PR is marked ready, before a stage gate is approved, and before Stage 11 recommends merge readiness | The agent has task context, can inspect the diff, run checks, map evidence to specs, and classify blocking vs non-blocking findings | As the only evidence for file-based spec approval or implementation merge readiness |
+| Copilot review | Default automated PR review gate | Any source-controlled PR, including specs, technical specs, docs, config, and implementation | As proof that the agent ran tests or verified spec coverage |
+| CodeRabbit | Optional advisory review when already configured and active on a PR | Implementation PRs where line-level maintainability, test coverage, or broad code-quality comments are useful | As a required DUUMBI gate unless branch protection explicitly requires it |
+| Greptile | Manual, quota-limited deep code review | Stable implementation PRs with complex Rust, security-sensitive behavior, cross-module architecture changes, async/concurrency risk, compiler/runtime behavior, provider/auth changes, or broad refactors | Spec-only, docs-only, routine config-only, small low-risk PRs, or every push/update |
+
+`DUUMBI_REQUIRED_SPEC_REVIEWERS` must remain the low-cost required automated
+reviewer set for spec-only gates. In this repository the default is
+`copilot-pull-request-reviewer`. Do not add Greptile to that variable; Greptile
+is a manual escalation path.
+
+## Review-Clean Definition
+
+A PR is review-clean only when all required items for its row are satisfied:
+
+- checks are green, neutral, skipped, or explicitly not applicable
+- Codex self-review found no blocking issue, or the blocking issue is fixed
+- the latest required automated reviewer submissions have no
+  `CHANGES_REQUESTED`
+- unresolved review threads are resolved after verifying the fix
+- non-blocking findings are either fixed or explicitly accepted as remaining
+  risk in the PR, issue, or Stage 11 artifact
+
+Successful reviewer-request workflows do not count as review submissions.
+
+## Stage And PR-Type Matrix
+
+| Stage or PR type | Required review | Optional escalation | Notes |
+|---|---|---|---|
+| Stage 6 product spec PR | Codex product/spec self-review plus Copilot review evidence | Greptile only if a human explicitly requests product-risk review, which should be rare | Product specs are not code implementation reviews. Prefer Codex checklist and Copilot as default evidence. |
+| Stage 7 product spec approval or AI gate | Codex Stage 7 review plus Copilot evidence on file-based specs | Human review when AI gate is blocked | Approval must stay spec-only and non-closing. |
+| Stage 8 technical spec PR | Codex technical self-review plus Copilot review evidence | Greptile only for high-risk architecture or implementation-plan review after human request | Technical specs should prepare implementation, not trigger code-review quota by default. |
+| Stage 9 technical spec approval or AI gate | Codex Stage 9 implementability review plus Copilot evidence | Human review when AI gate is blocked | Approval must fail closed on unresolved implementation, scope, security, migration, or verification questions. |
+| Stage 10 implementation PR readiness | Codex self-review after implementation evidence is consolidated plus Copilot review | CodeRabbit advisory if active; Greptile for high-risk Rust/code criteria below | Stage 10 does not merge. It prepares evidence and routes to Stage 11. |
+| Stage 11 implementation review | Codex review artifact, green checks, clean or handled Copilot review, and resolved threads | Greptile only when the PR meets high-risk criteria and the developer asks for it | Human reviewer makes the final PR decision in GitHub. |
+| Docs-only PR | Codex self-review plus applicable docs checks; Copilot review may be present | None by default | Do not use Greptile. |
+| Config-only or GitHub Actions-only PR | Codex self-review plus syntax/security-permission inspection and applicable checks; Copilot review may be present | Greptile only for security-sensitive workflow/permission changes after human request | Prefer static validation and focused human attention over general AI review churn. |
+
+## Greptile Manual Escalation Criteria
+
+Use Greptile only after the PR is stable enough that a deep review is likely to
+be final. A PR qualifies for Greptile consideration when it touches source code
+and at least one of these is true:
+
+- Rust changes span more than five meaningful files or more than roughly 400
+  non-generated lines
+- compiler lowering, graph invariants, parser semantics, runtime C code,
+  provider/auth/credentials, registry, MCP, or intent execution behavior changes
+- async, concurrency, cancellation, rollback, repair, self-healing, or external
+  provider behavior changes
+- new dependencies, security-sensitive behavior, migrations, irreversible
+  operations, or broad refactors are introduced
+- Codex self-review or Copilot finds a non-obvious blocking issue that would
+  benefit from a second independent reviewer
+
+When Greptile is used:
+
+1. Run Codex self-review and relevant checks first.
+2. Request Greptile once, with a focused comment such as
+   `@greptileai review this PR for Rust correctness, graph invariants, and async safety`.
+3. Address P0/P1 and genuinely blocking P2 findings.
+4. Do not re-run Greptile after every fix. Use Codex self-review to verify fixes
+   unless the developer explicitly authorizes one follow-up Greptile run.
+5. Record in the PR or Stage 11 artifact whether Greptile was not used, used
+   once, or re-run with explicit authorization.
+
+## Blocking Policy
+
+Blocking findings are correctness bugs, spec violations, security issues,
+data loss, crashes, failing checks, unresolved required review decisions, or
+missing evidence required by the approved specs.
+
+Non-blocking findings include style, wording, minor maintainability, optional
+test suggestions, and reviewer preferences that do not change behavior or risk.
+Agents may fix non-blocking findings when cheap, but they must not create an
+unbounded review loop to satisfy nits.
+
+## Related Configuration
+
+- `.github/workflows/copilot-review.yml` requests Copilot as the default PR
+  reviewer.
+- `.github/workflows/spec-review-request.yml`,
+  `.github/workflows/technical-spec-review-request.yml`, and
+  `.github/workflows/stage-approval.yml` enforce review-clean spec gates.
+- `.greptile/config.json` sets Greptile to manual-only with
+  `skipReview: "AUTOMATIC"` and `triggerOnUpdates: false`.

--- a/scripts/github-actions/duumbi-stage-handoff.mjs
+++ b/scripts/github-actions/duumbi-stage-handoff.mjs
@@ -435,6 +435,11 @@ export function buildStage11Prompt(input) {
     "Ralph Cycle evidence against the approved specs; produce a structured review",
     "artifact and recommendation for a human merge decision.",
     "",
+    "Review policy: run Codex self-review as part of the artifact, inspect Copilot",
+    "review state, treat CodeRabbit as advisory when present, and do not invoke",
+    "Greptile unless the PR is a stable high-risk implementation change and the",
+    "developer explicitly requested a manual deep review.",
+    "",
     "Do not merge PRs, close issues, move work to Done, perform Stage 12 closure, or",
     "modify implementation code, specs, generated artifacts, or runtime assets.",
   ].join("\n");

--- a/scripts/github-actions/duumbi-stage-handoff.test.mjs
+++ b/scripts/github-actions/duumbi-stage-handoff.test.mjs
@@ -165,6 +165,7 @@ test("Stage 11 prompt and Slack message include issue, PR, specs, checks, and ev
   const prompt = buildStage11Prompt(input);
   assert.match(prompt, /duumbi-review-artifact/);
   assert.match(prompt, /Implementation PR: https:\/\/github\.com\/hgahub\/duumbi\/pull\/619/);
+  assert.match(prompt, /Greptile unless the PR is a stable high-risk implementation change/);
   assert.match(prompt, /Do not merge PRs/);
 
   const message = buildStage11ReviewSlackMessage({ ...input, prompt });

--- a/scripts/github-actions/stage-approval-workflow.test.mjs
+++ b/scripts/github-actions/stage-approval-workflow.test.mjs
@@ -23,6 +23,8 @@ test("stage approval merges only reviewed spec PRs for Stage 7 and Stage 9 appro
   assert.match(workflow, /specs\/DUUMBI-\$\{issueNumber\}\/TECHNICAL\.md/);
   assert.match(workflow, /required automated review evidence from/);
   assert.match(workflow, /requiredAutomatedReviewers/);
+  assert.match(workflow, /Greptile is manual-only/);
+  assert.match(workflow, /out of DUUMBI_REQUIRED_SPEC_REVIEWERS/);
   assert.match(workflow, /normalizeReviewerLogin/);
   assert.match(workflow, reviewerBotSuffixReplacement);
   assert.match(workflow, /has unresolved review threads/);
@@ -37,6 +39,8 @@ test("product spec Slack review requests wait for review-clean PRs", () => {
   assert.match(workflow, /PR is still draft/);
   assert.match(workflow, /required automated review evidence missing from/);
   assert.match(workflow, /requiredAutomatedReviewers/);
+  assert.match(workflow, /Greptile is manual-only/);
+  assert.match(workflow, /out of DUUMBI_REQUIRED_SPEC_REVIEWERS/);
   assert.match(workflow, /normalizeReviewerLogin/);
   assert.match(workflow, reviewerBotSuffixReplacement);
   assert.match(workflow, /unresolved review threads remain/);
@@ -55,6 +59,8 @@ test("technical spec Slack review requests wait for review-clean PRs", () => {
   assert.match(workflow, /PR is still draft/);
   assert.match(workflow, /required automated review evidence missing from/);
   assert.match(workflow, /requiredAutomatedReviewers/);
+  assert.match(workflow, /Greptile is manual-only/);
+  assert.match(workflow, /out of DUUMBI_REQUIRED_SPEC_REVIEWERS/);
   assert.match(workflow, /normalizeReviewerLogin/);
   assert.match(workflow, reviewerBotSuffixReplacement);
   assert.match(workflow, /unresolved review threads remain/);

--- a/specs/DUUMBI-587/PRODUCT.md
+++ b/specs/DUUMBI-587/PRODUCT.md
@@ -365,6 +365,8 @@ Constraints:
 - The report preserves failed gate output in a reviewable form.
 - The report says whether all local validation gates passed.
 - The report says human review is required.
+- The report or linked human-review state preserves reviewer rejection or
+  revision decisions for follow-up when available.
 - The report does not mark the candidate accepted for application by default.
 - The report is bounded enough for GitHub review or CI artifacts and does not
   include unbounded raw logs by default.
@@ -379,6 +381,10 @@ Constraints:
   the patch.
 - If patch application fails, report the failed operation and keep original
   source unchanged.
+- If graph parse fails, report parse diagnostics and do not proceed to graph
+  build as a local success path.
+- If graph build fails, report graph construction diagnostics and do not proceed
+  to graph validation as a local success path.
 - If graph validation fails, report diagnostics and do not rebuild as a local
   success path.
 - If rebuild fails, report the rebuild command summary and failure output.

--- a/specs/DUUMBI-587/PRODUCT.md
+++ b/specs/DUUMBI-587/PRODUCT.md
@@ -302,7 +302,7 @@ Constraints:
 - Patch application failed: the patch cannot be applied atomically to the
   source graph.
 - Graph parse failed: patched JSON-LD cannot be parsed into DUUMBI AST.
-- Graph IR build failed: parsed DUUMBI AST cannot be converted to graph IR.
+- Graph build failed: parsed DUUMBI AST cannot be converted to graph IR.
 - Graph validation failed: semantic validation produced diagnostics.
 - Rebuild failed: native rebuild does not complete successfully.
 - Tests failed: relevant tests do not pass.
@@ -509,6 +509,13 @@ When repair validation produces evidence
 Then local validation is marked as passed
 And the evidence report requires human review
 And the repair is not marked accepted for application
+
+Scenario: Human reviewer requests revision after local validation
+Given a repair candidate is pending human review after all local gates pass
+When a reviewer rejects the candidate or requests revision
+Then the repair state is marked as human rejected or revision needed
+And the repair remains not accepted for application
+And the evidence report preserves the reviewer decision for follow-up
 
 Rule: Evidence is traceable and bounded
 

--- a/specs/DUUMBI-587/PRODUCT.md
+++ b/specs/DUUMBI-587/PRODUCT.md
@@ -298,6 +298,8 @@ Constraints:
   is absent.
 - Missing patch candidate: validation cannot start because no proposed patch was
   provided.
+- Source artifact unavailable: validation cannot start because the source graph
+  or workspace artifact is missing or unreadable.
 - Patch malformed: the proposed patch does not parse as GraphPatch.
 - Patch application failed: the patch cannot be applied atomically to the
   source graph.
@@ -468,7 +470,8 @@ And the original graph source remains unchanged
 And the evidence report identifies the failed patch operation
 
 Scenario: Patch-shaped output is not automatically accepted
-Given a Repair agent has produced GraphPatch-shaped output
+Given mapped repair crash context exists
+And a Repair agent has produced GraphPatch-shaped output
 But graph validation, rebuild, tests, and human review have not all completed
 When repair validation is requested for the candidate
 Then the candidate is not accepted for application
@@ -584,14 +587,14 @@ And Query mode does not accept the repair
   - Keep the execution issue open for later workflow stages.
 
 - Validation contract:
-  - Define the required starting inputs: mapped repair crash context and a
-    proposed GraphPatch candidate.
+  - Define the required starting inputs: mapped repair crash context, proposed
+    GraphPatch candidate, and source graph or workspace artifact.
   - Define the required local gates: GraphPatch parse, atomic patch application,
     graph parse, graph build, graph validation, native rebuild, and relevant
     tests.
-  - Define not-ready behavior for missing context, missing patch, malformed
-    patch, failed patch application, graph diagnostics, rebuild failure, and
-    test failure.
+  - Define not-ready behavior for missing context, missing patch, unavailable
+    source artifact, malformed patch, failed patch application, graph
+    diagnostics, rebuild failure, and test failure.
 
 - Evidence report:
   - Define the minimum evidence fields for crash context, patch candidate,
@@ -642,6 +645,7 @@ And Query mode does not accept the repair
 - Implementation PRs should later prove:
   - Missing mapped crash context blocks validation.
   - Missing patch candidate blocks validation.
+  - Missing or unreadable source artifact blocks validation.
   - Malformed GraphPatch data fails before application.
   - Failed patch application preserves the original graph.
   - Graph parse, graph build, and graph validation failures block local success.
@@ -656,6 +660,7 @@ And Query mode does not accept the repair
 - Suggested test coverage for later implementation:
   - Unit tests for evidence serialization and required fields.
   - Unit tests for GraphPatch parse success and failure.
+  - Unit or integration tests for missing or unreadable source artifact handling.
   - Unit tests for atomic patch failure preserving source.
   - Unit tests or integration tests for graph validation failure evidence.
   - Integration coverage using the controlled runtime failure fixture.

--- a/specs/DUUMBI-587/PRODUCT.md
+++ b/specs/DUUMBI-587/PRODUCT.md
@@ -385,8 +385,8 @@ Constraints:
   graph building or validation.
 - If graph building fails, report the graph construction diagnostics and do not
   proceed to graph validation.
-- If graph validation fails, report diagnostics and do not rebuild as a local
-  success path.
+- If graph validation fails, report diagnostics and do not proceed to native
+  rebuild.
 - If rebuild fails, report the rebuild command summary and failure output.
 - If tests fail, report the failed tests and preserve local validation as
   failed.

--- a/specs/DUUMBI-587/PRODUCT.md
+++ b/specs/DUUMBI-587/PRODUCT.md
@@ -303,7 +303,8 @@ Constraints:
   source graph.
 - Graph parse failed: patched JSON-LD cannot be parsed into DUUMBI AST.
 - Graph build failed: parsed DUUMBI AST cannot be converted to graph IR.
-- Graph validation failed: semantic validation produced diagnostics.
+- Graph validation failed: semantic validation produced blocking validation
+  diagnostics.
 - Rebuild failed: native rebuild does not complete successfully.
 - Tests failed: relevant tests do not pass.
 - Local validation passed: every required local gate passed.

--- a/specs/DUUMBI-587/PRODUCT.md
+++ b/specs/DUUMBI-587/PRODUCT.md
@@ -1,0 +1,673 @@
+# DUUMBI-587: Validate Repair Patches And Produce Human-Reviewable Evidence
+
+## Summary
+
+Define the product guardrail for validating a runtime-failure repair candidate
+before DUUMBI treats it as reviewable.
+
+This issue is a focused Phase 13 repair-readiness child under #580. It follows
+the local telemetry/back-mapping foundation and the repair-agent input contract
+from mapped crash evidence. The accepted product behavior is not autonomous
+self-healing. It is a validation and evidence boundary:
+
+```text
+mapped crash context + proposed graph patch -> validation gates ->
+human-reviewable evidence report -> pending human review
+```
+
+A repair candidate is not successful merely because an agent proposed a patch.
+It must parse through the canonical GraphPatch contract, apply atomically, pass
+graph parsing/building, pass graph validation, rebuild natively, pass relevant
+tests, and produce an evidence report that a human can inspect. Even when all
+local gates pass, the repair remains pending human review and is not accepted
+or applied silently.
+
+This specification PR is related to #587 and must leave the execution issue
+open for Stage 7 review, Stage 8 technical specification, implementation,
+review, and Stage 12 closure evidence.
+
+## Problem
+
+Self-healing becomes unsafe if the system accepts a generated patch because it
+looks plausible or because an agent claims success. Runtime crash evidence and
+repair context only establish where a repair might be needed. They do not prove
+that a candidate patch is constrained, valid, buildable, testable, or safe to
+apply.
+
+The current DUUMBI source already has useful pieces:
+
+- mapped crash context can be derived from local trace/crash artifacts.
+- GraphPatch operations apply atomically over JSON-LD values.
+- MCP graph mutation validates patched graph state before writing.
+- telemetry repair validation evidence types can record local gate results
+  while keeping human review required.
+- intent execution has a verifier-failure repair precedent, but that loop is
+  oriented around failed intent tests and can write repaired graph files after a
+  provider mutation.
+
+The missing product contract is the guardrail between a proposed runtime-crash
+repair and any claim that the repair is complete. DUUMBI needs an observable
+validation pipeline and evidence report that links the original crash, the
+proposed change, validation output, rebuild output, relevant tests, and human
+review state. Without that contract, repair behavior could become an opaque
+agent loop that mutates graph source, hides failed validation, or bypasses the
+human acceptance boundary required by Phase 13.
+
+## Outcome
+
+When this issue is implemented:
+
+- A repair candidate can be evaluated only from mapped repair crash context and
+  a proposed GraphPatch-shaped change.
+- Invalid or malformed patch payloads fail before any graph source is changed.
+- Patch application is atomic: a failed patch leaves the original source
+  unchanged.
+- Patched JSON-LD is parsed, converted to DUUMBI graph IR, and graph-validated
+  before the candidate can be reported as locally valid.
+- The candidate must rebuild successfully after validation.
+- Relevant tests must pass before the candidate can be reported as locally
+  valid.
+- The output is a human-reviewable evidence report that links:
+  - the original mapped crash context.
+  - the proposed patch or diff summary.
+  - the graph/source artifacts considered.
+  - each validation gate and result.
+  - rebuild and test output summaries.
+  - the final human-review requirement.
+- A candidate with all local gates passing is marked as pending human review,
+  not accepted for application.
+- Failed gates produce explicit not-ready states and preserve the original
+  crash evidence for inspection.
+- Default behavior stops at reviewable evidence and does not silently apply,
+  accept, merge, deploy, hot-swap, or close the repair.
+- Existing Query mode, graph validation, rebuild, test, and GitHub review
+  boundaries are preserved.
+- The execution issue remains open for later workflow stages. This product spec
+  PR is specification-only.
+
+## Scope
+
+### In Scope
+
+- Define the repair patch validation product contract for #587.
+- Require mapped repair crash context as the starting point for validation.
+- Require a proposed patch to parse through the canonical GraphPatch contract.
+- Require atomic patch behavior so failed patch application does not modify the
+  source graph.
+- Require patched graph parsing, graph building, and graph validation.
+- Require native rebuild before local validation can pass.
+- Require relevant tests before local validation can pass.
+- Require human-reviewable evidence that links crash context, patch candidate,
+  changed graph/source artifacts, validation results, rebuild output, and test
+  output.
+- Require the evidence to separate local validation success from human
+  acceptance.
+- Require failed gates to produce clear, inspectable not-ready states.
+- Reuse existing graph mutation, validation, patch, telemetry, and test
+  primitives where applicable.
+- Keep test selection conservative until stronger impacted-test analysis exists.
+- Keep the first contract local and developer/test oriented.
+
+### Explicitly Out Of Scope
+
+- Technical specification content or implementation instructions during Stage 6.
+- Implementation code, source changes outside this product spec, or Ralph cycles
+  during Stage 6.
+- Generating repair patches from an LLM.
+- Designing the full repair-agent prompt or input contract already covered by
+  #588.
+- Applying a repair automatically after validation.
+- Treating a repair as accepted without explicit human review.
+- Merging, deploying, releasing, hot-swapping, or rolling back repaired
+  binaries.
+- Autonomous retry loops, multi-agent repair orchestration, or production
+  self-healing policy.
+- Studio dashboards, graph overlays, alerting, or operations monitoring.
+- Remote telemetry ingestion, external collectors, account-based artifact
+  upload, retention, privacy consent, release delivery, or customer-production
+  crash handling.
+- Creating or changing GitHub Project fields, labels, or approval semantics as
+  part of the product behavior.
+- Changing Query mode from read-only behavior.
+
+## Constraints And Assumptions
+
+Facts:
+
+- Issue #587 is open and accepted for specification.
+- Issue #587 is labeled `accepted` and `needs-spec`.
+- The Stage 5 decision comment on 2026-06-02 records `Decision: Accept`,
+  `Next state: Spec Needed`, and no remaining open questions.
+- Stage 4 routed #587 to `Needs Human Acceptance` as the Phase 13 repair
+  validation guardrail after telemetry, repair context, and validation evidence
+  became the next self-healing concern.
+- #587 is a child issue of #580.
+- #580 was approved, technically specified, implemented, and closed with local
+  Phase 13 telemetry/back-mapping foundation evidence.
+- #588 defines the related repair-agent input contract from mapped crash
+  evidence and has a review-ready product spec PR at the time this spec was
+  drafted.
+- The active PRD says any repair must pass graph validation, rebuild, tests, and
+  human review before it is accepted.
+- The active Runtime Failure Feedback Loop note says repair validation evidence
+  may report local gate results, but must not silently accept or apply a repair.
+- `src/telemetry/mod.rs` contains `RepairCrashContext`,
+  `RepairValidationGate`, `RepairValidationGateEvidence`,
+  `RepairValidationEvidence`, `required_repair_validation_gates()`,
+  `parse_repair_graph_patch()`, and
+  `repair_validation_evidence_from_graph_patch()`.
+- `src/telemetry/mod.rs` currently identifies these required gates:
+  GraphPatch parse, atomic patch application, graph parse, graph validation,
+  native rebuild, and relevant tests.
+- `RepairValidationEvidence` keeps `requires_human_review = true` and
+  `accepted_for_application = false`.
+- `src/patch.rs` defines GraphPatch operations and an all-or-nothing
+  applicator over JSON-LD values.
+- `src/mcp/tools/graph.rs` validates patched graph state before writing in MCP
+  graph mutation behavior.
+- `src/intent/execute.rs` has verifier-failure repair precedent, but that path
+  is not the same as runtime crash evidence validation and may write repaired
+  graph files after provider mutation.
+
+Assumptions:
+
+- The safest v1 repair validation behavior is local and deterministic, because
+  production repair raises privacy, consent, deployment, rollback, and
+  operational safety questions.
+- The proposed patch should be represented through GraphPatch for v1 because it
+  matches existing atomic graph mutation behavior and keeps the candidate
+  reviewable.
+- Relevant tests should include the controlled crash regression, targeted tests
+  for the changed behavior, and a default untraced behavior guard when
+  applicable.
+- Full `cargo test --all` may be required for broad or shared changes, but the
+  exact test set belongs to Stage 8 and Stage 10 because it depends on affected
+  areas.
+- A human reviewer needs concise command/result summaries and links or paths to
+  artifacts, not raw unbounded logs.
+- The evidence report should be serializable or otherwise stable enough for CI,
+  GitHub review, and later workflow audit.
+
+Constraints:
+
+- Validation must not start without mapped crash context or an explicit
+  proposed patch.
+- Raw logs alone must not be enough to validate a repair candidate.
+- Patch-shaped provider output must not be trusted until it parses through the
+  accepted patch contract.
+- Failed parse, patch, graph, rebuild, or test gates must block local validation
+  success.
+- Local validation success must not imply human acceptance.
+- Evidence must preserve the original crash signal and failed gate output
+  instead of replacing them with a generic success/failure summary.
+- Validation must not require provider credentials, network access, Studio,
+  Slack, GitHub, or external telemetry collectors.
+- This spec PR must not mark #587 complete; it is a Stage 6 review artifact
+  only.
+
+## Decisions
+
+- **Decision:** Use a file-based product spec for #587.
+  **Evidence:** The work is architectural, cross-module, and durable. It spans
+  runtime crash context, GraphPatch behavior, graph validation, rebuild/test
+  evidence, telemetry evidence structures, agent boundaries, and human-review
+  workflow.
+
+- **Decision:** Require mapped repair crash context before validating a repair
+  candidate.
+  **Evidence:** Phase 13 is runtime-evidence-backed. #588 and #580 both frame
+  repair work around mapped crash evidence, not raw logs or generic prompts.
+
+- **Decision:** Use GraphPatch parse as the first repair-candidate gate.
+  **Evidence:** `src/patch.rs` defines the canonical patch contract and
+  `src/telemetry/mod.rs` already exposes repair patch parsing through that
+  contract.
+
+- **Decision:** Treat atomic patch behavior as product-visible, not only an
+  implementation detail.
+  **Evidence:** A failed repair patch must not leave a partially mutated graph.
+  The existing GraphPatch applicator is all-or-nothing, and #587 should preserve
+  that user-visible safety property.
+
+- **Decision:** Require graph parse/build, graph validation, native rebuild, and
+  relevant tests before local validation can pass.
+  **Evidence:** #587 acceptance criteria require graph validation, rebuild, and
+  relevant tests. The active PRD says any repair must pass graph validation,
+  rebuild, tests, and human review before acceptance.
+
+- **Decision:** Separate local validation success from repair acceptance.
+  **Evidence:** `RepairValidationEvidence` already keeps human review required
+  and acceptance false. Phase 13 explicitly excludes automatic repair acceptance
+  from the first local developer/test slice.
+
+- **Decision:** The output is an evidence report, not a silent source write.
+  **Evidence:** #587 asks for human-reviewable evidence linking the crash,
+  changed artifacts, validation, and test output. Human review cannot happen if
+  the result is only an agent claim or an already-applied mutation.
+
+- **Decision:** The v1 contract remains local and developer/test oriented.
+  **Evidence:** The PRD and Runtime Failure Feedback Loop note both exclude
+  production crash ingestion, hot-swap, silent updates, and autonomous repair
+  acceptance from the first Phase 13 slice.
+
+## Behavior
+
+### Defaults
+
+- Repair validation is not run for default untraced runtime failures.
+- Repair validation is not run from raw stderr, raw logs, or crash text alone.
+- Repair validation is local and deterministic for the controlled v1 path.
+- Repair validation does not invoke a provider.
+- Repair validation does not silently write graph source files.
+- Repair validation does not accept, merge, deploy, hot-swap, or close a repair.
+- A locally valid repair candidate remains pending human review.
+
+### Inputs
+
+- A mapped `RepairCrashContext` or equivalent context assembled from local
+  trace/crash artifacts and graph back-mapping evidence.
+- A proposed GraphPatch-shaped repair candidate.
+- The original JSON-LD graph source or workspace graph artifact being repaired.
+- The workspace or build target needed to rebuild after the candidate patch.
+- A relevant test plan or conservative default test selection.
+- Optional paths or identifiers for crash artifacts, trace maps, candidate
+  patch artifacts, build output, and test output.
+
+### Outputs
+
+- A repair validation evidence report.
+- The original crash context or a link/path to it.
+- The proposed patch serialized for review or a patch/diff summary.
+- The source graph or workspace artifact considered.
+- One result per required validation gate.
+- Rebuild result summary.
+- Relevant test result summary.
+- A local validation status.
+- A human-review requirement.
+- A clear acceptance state that remains not accepted until human review happens
+  outside the local validation gate.
+
+### Visible States
+
+- Missing repair context: validation cannot start because mapped crash evidence
+  is absent.
+- Missing patch candidate: validation cannot start because no proposed patch was
+  provided.
+- Patch malformed: the proposed patch does not parse as GraphPatch.
+- Patch application failed: the patch cannot be applied atomically to the
+  source graph.
+- Graph parse failed: patched JSON-LD cannot be parsed into DUUMBI AST.
+- Graph build failed: parsed graph source cannot be converted to graph IR.
+- Graph validation failed: semantic validation produced diagnostics.
+- Rebuild failed: native rebuild does not complete successfully.
+- Tests failed: relevant tests do not pass.
+- Local validation passed: every required local gate passed.
+- Pending human review: local validation passed, but human acceptance is still
+  required.
+- Human rejected or revision needed: a reviewer does not accept the candidate,
+  and the repair remains unaccepted.
+
+### Gate Semantics
+
+- GraphPatch parse gate:
+  - passes only when the candidate deserializes through the canonical GraphPatch
+    contract.
+  - fails before any patch application when the payload is malformed.
+
+- Atomic patch application gate:
+  - passes only when the candidate patch can be applied to a clone or otherwise
+    proves the original source remains unchanged on failure.
+  - fails when any operation targets a missing node, block, function, or invalid
+    JSON-LD structure.
+
+- Graph parse and build gates:
+  - pass only when the patched JSON-LD parses and builds into DUUMBI graph IR.
+  - fail with diagnostics that identify the parse or graph construction problem
+    clearly enough for review.
+
+- Graph validation gate:
+  - passes only when the patched graph has no blocking validation diagnostics.
+  - fails with the diagnostic messages needed to revise the candidate.
+
+- Native rebuild gate:
+  - passes only when the patched graph can be rebuilt through the selected
+    local build path.
+  - fails with command and output summary evidence.
+
+- Relevant tests gate:
+  - passes only when the selected targeted and regression tests pass.
+  - must include enough evidence to explain why the selected tests are relevant.
+  - must stay conservative when impacted-test analysis is unavailable.
+
+- Human review gate:
+  - is not satisfied by local validation.
+  - requires a human reviewer or later accepted workflow to approve the
+    candidate before it can be treated as accepted.
+
+### Evidence Report Requirements
+
+- The report identifies the schema or format version when practical.
+- The report identifies the crash context used for validation.
+- The report identifies the patch candidate used for validation.
+- The report identifies the source graph/workspace artifact validated.
+- The report records each gate as passed or failed.
+- The report includes concise command/result summaries for rebuild and tests.
+- The report preserves failed gate output in a reviewable form.
+- The report says whether all local validation gates passed.
+- The report says human review is required.
+- The report does not mark the candidate accepted for application by default.
+- The report is bounded enough for GitHub review or CI artifacts and does not
+  include unbounded raw logs by default.
+
+### Error And Empty States
+
+- If mapped crash context is missing, report that repair validation requires
+  mapped crash evidence and do not validate a patch.
+- If the candidate patch is missing, report that no repair candidate was
+  provided and do not produce local validation success.
+- If the patch is malformed, report the GraphPatch parse error and do not apply
+  the patch.
+- If patch application fails, report the failed operation and keep original
+  source unchanged.
+- If graph validation fails, report diagnostics and do not rebuild as a local
+  success path.
+- If rebuild fails, report the rebuild command summary and failure output.
+- If tests fail, report the failed tests and preserve local validation as
+  failed.
+- If all local gates pass but no human review exists, report pending human
+  review rather than success.
+
+### Invariants
+
+- Original crash evidence remains traceable from every validation report.
+- Patch-shaped output is not enough to claim repair success.
+- Graph mutation cannot bypass parse/build/validate behavior.
+- Failed gates cannot be hidden behind an agent success message.
+- Local validation success cannot bypass human review.
+- Default untraced behavior remains unchanged unless later approved scope says
+  otherwise.
+- Production self-healing claims are not made from this local guardrail.
+
+## BDD Scenarios
+
+Feature: Repair patch validation and human-reviewable evidence
+
+Rule: Repair validation starts only from mapped evidence and a candidate patch
+
+Scenario: Controlled repair candidate enters validation
+Given mapped repair crash context exists for a traced runtime failure
+And a proposed repair candidate is provided as GraphPatch-shaped data
+When repair validation is requested
+Then the candidate is evaluated through the required local validation gates
+And the original crash context remains linked to the validation result
+And no repair is accepted before the gates and human review are complete
+
+Scenario: Raw crash logs are not enough to validate a repair
+Given a runtime failure message exists in stderr or a log file
+But no mapped repair crash context exists
+When repair validation is requested with a proposed patch
+Then the system reports that mapped crash evidence is required
+And no local validation success is reported
+And no source graph is silently changed
+
+Scenario: Missing patch candidate blocks validation
+Given mapped repair crash context exists
+But no proposed patch candidate is provided
+When repair validation is requested
+Then the system reports that a patch candidate is required
+And no validation gates are reported as passed
+
+Rule: Patch validation is canonical and atomic
+
+Scenario: Malformed patch fails before application
+Given mapped repair crash context exists
+And the proposed patch cannot parse as GraphPatch
+When repair validation is requested
+Then the GraphPatch parse gate fails
+And the patch is not applied
+And the evidence report records the parse failure
+
+Scenario: Patch application failure preserves the original graph
+Given mapped repair crash context exists
+And a proposed GraphPatch references a missing graph node
+When repair validation applies the patch candidate
+Then the atomic patch application gate fails
+And the original graph source remains unchanged
+And the evidence report identifies the failed patch operation
+
+Scenario: Patch-shaped output is not automatically accepted
+Given a Repair agent has produced GraphPatch-shaped output
+But graph validation, rebuild, tests, and human review have not all completed
+When the candidate is inspected
+Then the candidate is not accepted for application
+And the evidence report shows the remaining gates
+
+Rule: Graph, rebuild, and test gates must pass
+
+Scenario: Graph validation failure blocks local success
+Given a proposed patch parses and applies atomically
+But the patched graph produces validation diagnostics
+When repair validation runs
+Then the graph validation gate fails
+And local validation is not marked as passed
+And the evidence report includes the validation diagnostics
+
+Scenario: Native rebuild failure blocks local success
+Given a proposed patch passes graph validation
+But the native rebuild fails
+When repair validation runs
+Then the native rebuild gate fails
+And local validation is not marked as passed
+And the evidence report includes rebuild command and output summary
+
+Scenario: Relevant test failure blocks local success
+Given a proposed patch passes graph validation
+And the native rebuild succeeds
+But a relevant targeted or regression test fails
+When repair validation runs
+Then the relevant tests gate fails
+And local validation is not marked as passed
+And the evidence report identifies the failed tests
+
+Scenario: All local gates pass but human review is still required
+Given mapped repair crash context exists
+And a proposed patch parses as GraphPatch
+And patch application is atomic
+And the patched graph parses, builds, and validates
+And the native rebuild succeeds
+And relevant tests pass
+When repair validation produces evidence
+Then local validation is marked as passed
+And the evidence report requires human review
+And the repair is not marked accepted for application
+
+Rule: Evidence is traceable and bounded
+
+Scenario: Evidence report links crash, patch, validation, rebuild, and tests
+Given a repair candidate has been evaluated
+When the evidence report is produced
+Then the report links the mapped crash context
+And the report links or summarizes the proposed patch
+And the report records each validation gate result
+And the report summarizes rebuild output
+And the report summarizes relevant test output
+And the report states the human-review requirement
+
+Scenario: Failed validation remains reviewable
+Given a repair candidate fails one required gate
+When the evidence report is produced
+Then the failed gate output remains visible for review
+And earlier passed gate evidence remains visible
+And the original crash evidence remains linked
+And the result is not reported as locally validated
+
+Rule: Product boundaries remain explicit
+
+Scenario: Production self-healing is requested from the validation guardrail
+Given the repair validation guardrail is available for local developer/test
+evidence
+When a user asks it to ingest production crashes or automatically deploy a
+repair
+Then the request is out of scope for #587
+And it must be routed to later product specification
+And no automatic acceptance is reported
+
+Scenario: Query mode asks about repair validation evidence
+Given repair validation evidence exists
+When Query mode is used to inspect the evidence
+Then Query mode can describe the evidence read-only
+And Query mode does not mutate graph source
+And Query mode does not accept the repair
+
+## Tasks
+
+- Product and workflow setup:
+  - Keep #587 as the repair validation and human-reviewable evidence child
+    issue under #580.
+  - Use non-closing workflow references such as `Related to #587`.
+  - Keep the execution issue open for later workflow stages.
+
+- Validation contract:
+  - Define the required starting inputs: mapped repair crash context and a
+    proposed GraphPatch candidate.
+  - Define the required local gates: GraphPatch parse, atomic patch application,
+    graph parse/build, graph validation, native rebuild, and relevant tests.
+  - Define not-ready behavior for missing context, missing patch, malformed
+    patch, failed patch application, graph diagnostics, rebuild failure, and
+    test failure.
+
+- Evidence report:
+  - Define the minimum evidence fields for crash context, patch candidate,
+    source artifact, gate results, rebuild summary, test summary, local
+    validation status, and human-review requirement.
+  - Require failed gate output to remain inspectable.
+  - Require local validation and human acceptance to remain separate states.
+
+- Human-review boundary:
+  - Define that all local gates passing means pending human review, not repair
+    acceptance.
+  - Keep automatic apply, merge, deploy, hot-swap, and production self-healing
+    outside this issue.
+
+- Test and review planning:
+  - Require later implementation tests for each pass/fail gate.
+  - Require evidence that failed patch application preserves the original graph.
+  - Require evidence that default untraced behavior remains unchanged.
+  - Require the controlled crash path and relevant regression to be represented
+    in later test evidence.
+
+## Checks
+
+- Stage 7 product review confirms:
+  - Stage 5 acceptance is correctly represented.
+  - The product spec stays within #587 and does not create a technical spec.
+  - Repair validation starts from mapped crash context and a proposed patch.
+  - GraphPatch parse and atomic patch behavior are product-visible gates.
+  - Graph parse/build, graph validation, native rebuild, and relevant tests are
+    required before local validation success.
+  - Local validation success remains distinct from human acceptance.
+  - Evidence report requirements are reviewable and bounded.
+  - Production self-healing, hot-swap, deployment, and autonomous acceptance are
+    out of scope.
+  - No auto-closing issue references are used in the spec-only PR.
+
+- Stage 8 technical spec should later define:
+  - The exact evidence report schema.
+  - How the original source graph is preserved while validating a candidate.
+  - How candidate patch artifacts are represented and diffed.
+  - How graph parse/build/validation gates map to existing parser, builder, and
+    validator APIs.
+  - How rebuild commands are selected for single-file and workspace cases.
+  - How relevant tests are selected conservatively.
+  - How large command output is summarized and linked.
+  - How human-review state is represented without accepting the repair locally.
+
+- Implementation PRs should later prove:
+  - Missing mapped crash context blocks validation.
+  - Missing patch candidate blocks validation.
+  - Malformed GraphPatch data fails before application.
+  - Failed patch application preserves the original graph.
+  - Graph parse/build/validation failures block local success.
+  - Native rebuild failure blocks local success.
+  - Relevant test failure blocks local success.
+  - All local gates passing still keeps human review required and acceptance
+    false.
+  - The evidence report links crash context, candidate patch, validation gates,
+    rebuild output, and test output.
+  - Default untraced behavior remains unchanged.
+
+- Suggested test coverage for later implementation:
+  - Unit tests for evidence serialization and required fields.
+  - Unit tests for GraphPatch parse success and failure.
+  - Unit tests for atomic patch failure preserving source.
+  - Unit tests or integration tests for graph validation failure evidence.
+  - Integration coverage using the controlled runtime failure fixture.
+  - Rebuild and targeted-test evidence for a candidate patch path.
+  - Regression coverage that a locally validated candidate remains pending human
+    review.
+
+- Manual review evidence for later implementation:
+  - The controlled failing DUUMBI graph program.
+  - The mapped crash context used.
+  - The proposed patch candidate.
+  - The graph/source diff or patch summary.
+  - The validation diagnostics or pass result.
+  - The rebuild command and result.
+  - The relevant test command(s) and result(s).
+  - The final evidence report showing local validation state and human-review
+    requirement.
+
+## Open Questions
+
+No blocking open questions for Stage 7 product review.
+
+Non-blocking questions for Stage 8 or later implementation:
+
+- Should the evidence report be a JSON artifact, a Markdown report, or both?
+- Where should local validation evidence be written by default so it is easy to
+  review but not accidentally committed?
+- What exact command set is required for native rebuild in single-file versus
+  workspace repair cases?
+- How should relevant tests be selected before DUUMBI has stronger impacted-test
+  analysis?
+- Should the validation guardrail support source-code patch evidence in addition
+  to GraphPatch evidence after later work expands repair scope?
+- What later human-review workflow should turn pending-review evidence into an
+  accepted repair state, if any?
+
+## Sources
+
+- Issue #587: https://github.com/hgahub/duumbi/issues/587
+- Stage 4 triage refill for #587:
+  https://github.com/hgahub/duumbi/issues/587#issuecomment-4601062097
+- Stage 5 human acceptance decision for #587:
+  https://github.com/hgahub/duumbi/issues/587#issuecomment-4606336397
+- Parent issue #580:
+  https://github.com/hgahub/duumbi/issues/580
+- Phase 13 decomposition comment:
+  https://github.com/hgahub/duumbi/issues/580#issuecomment-4505735849
+- Stage 12 closure evidence for #580:
+  https://github.com/hgahub/duumbi/issues/580#issuecomment-4525647674
+- Parent product spec: `specs/DUUMBI-580/PRODUCT.md`
+- Parent technical spec: `specs/DUUMBI-580/TECHNICAL.md`
+- Related child #588, repair-agent input contract:
+  https://github.com/hgahub/duumbi/issues/588
+- #588 product spec PR:
+  https://github.com/hgahub/duumbi/pull/651
+- Related child #585, local crash dumps and trace-to-graph mapping artifacts:
+  https://github.com/hgahub/duumbi/issues/585
+- DUUMBI PRD:
+  `/Users/heizergabor/space/hgahub/duumbi-vault/Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - PRD.md`
+- Runtime Failure Feedback Loop:
+  `/Users/heizergabor/space/hgahub/duumbi-vault/Duumbi/01 Atlas (Knowledge Base)/Dots (Atomic Ideas)/Runtime Failure Feedback Loop.md`
+- DUUMBI Service and Research Direction:
+  `/Users/heizergabor/space/hgahub/duumbi-vault/Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - Service and Research Direction.md`
+- DUUMBI Product Roadmap 2026-05:
+  `/Users/heizergabor/space/hgahub/duumbi-vault/Duumbi/05 Archive/Execution and Roadmap Docs/DUUMBI - Product Roadmap 2026-05.md`
+- DUUMBI Phase 13 Self-Healing and Telemetry archive:
+  `/Users/heizergabor/space/hgahub/duumbi-vault/Duumbi/05 Archive/Execution and Roadmap Docs/DUUMBI - Phase 13 - Self-Healing & Telemetry.md`
+- Architecture reference: `docs/architecture.md`
+- Telemetry and repair validation source: `src/telemetry/mod.rs`
+- GraphPatch source: `src/patch.rs`
+- MCP graph tools source: `src/mcp/tools/graph.rs`
+- Intent verifier-repair precedent: `src/intent/execute.rs`

--- a/specs/DUUMBI-587/PRODUCT.md
+++ b/specs/DUUMBI-587/PRODUCT.md
@@ -197,6 +197,8 @@ Constraints:
 
 - Validation must not start without mapped crash context or an explicit
   proposed patch.
+- Validation must not start without the source graph or workspace artifact being
+  present and readable.
 - Raw logs alone must not be enough to validate a repair candidate.
 - Patch-shaped provider output must not be trusted until it parses through the
   accepted patch contract.
@@ -480,7 +482,8 @@ And the evidence report records the gates that have not passed
 Rule: Graph, rebuild, and test gates must pass
 
 Scenario: Graph parse failure blocks local success
-Given a proposed patch parses and applies atomically
+Given mapped repair crash context exists
+And a proposed patch parses and applies atomically
 But the patched JSON-LD cannot be parsed into the DUUMBI AST
 When repair validation runs
 Then the graph parse gate fails
@@ -488,7 +491,8 @@ And local validation is not marked as passed
 And the evidence report includes the parse diagnostics
 
 Scenario: Graph build failure blocks local success
-Given a proposed patch parses and applies atomically
+Given mapped repair crash context exists
+And a proposed patch parses and applies atomically
 And the patched JSON-LD parses into the DUUMBI AST
 But the parsed DUUMBI AST cannot be converted to graph IR
 When repair validation runs
@@ -497,7 +501,8 @@ And local validation is not marked as passed
 And the evidence report includes the graph construction diagnostics
 
 Scenario: Graph validation failure blocks local success
-Given a proposed patch parses and applies atomically
+Given mapped repair crash context exists
+And a proposed patch parses and applies atomically
 And the patched JSON-LD parses into the DUUMBI AST
 And the parsed DUUMBI AST builds into graph IR
 But the patched graph produces blocking validation diagnostics
@@ -507,7 +512,8 @@ And local validation is not marked as passed
 And the evidence report includes the validation diagnostics
 
 Scenario: Native rebuild failure blocks local success
-Given a proposed patch passes graph validation
+Given mapped repair crash context exists
+And a proposed patch passes graph validation
 But the native rebuild fails
 When repair validation runs
 Then the native rebuild gate fails
@@ -515,7 +521,8 @@ And local validation is not marked as passed
 And the evidence report includes rebuild command and output summary
 
 Scenario: Relevant test failure blocks local success
-Given a proposed patch passes graph validation
+Given mapped repair crash context exists
+And a proposed patch passes graph validation
 And the native rebuild succeeds
 But a relevant targeted or regression test fails
 When repair validation runs

--- a/specs/DUUMBI-587/PRODUCT.md
+++ b/specs/DUUMBI-587/PRODUCT.md
@@ -450,7 +450,7 @@ Given a Repair agent has produced GraphPatch-shaped output
 But graph validation, rebuild, tests, and human review have not all completed
 When the candidate is inspected
 Then the candidate is not accepted for application
-And the evidence report shows the remaining gates
+And the evidence report records the gates that have not passed
 
 Rule: Graph, rebuild, and test gates must pass
 
@@ -467,7 +467,7 @@ Given a proposed patch parses and applies atomically
 And the patched JSON-LD parses into the DUUMBI AST
 But the parsed DUUMBI AST cannot be converted to graph IR
 When repair validation runs
-Then the graph build evidence fails
+Then the graph build gate fails
 And local validation is not marked as passed
 And the evidence report includes the graph construction diagnostics
 

--- a/specs/DUUMBI-587/PRODUCT.md
+++ b/specs/DUUMBI-587/PRODUCT.md
@@ -381,10 +381,10 @@ Constraints:
   the patch.
 - If patch application fails, report the failed operation and keep original
   source unchanged.
-- If graph parse fails, report parse diagnostics and do not proceed to graph
-  build as a local success path.
-- If graph build fails, report graph construction diagnostics and do not proceed
-  to graph validation as a local success path.
+- If graph parsing fails, report the parse diagnostics and do not proceed to
+  graph building or validation.
+- If graph building fails, report the graph construction diagnostics and do not
+  proceed to graph validation.
 - If graph validation fails, report diagnostics and do not rebuild as a local
   success path.
 - If rebuild fails, report the rebuild command summary and failure output.

--- a/specs/DUUMBI-587/PRODUCT.md
+++ b/specs/DUUMBI-587/PRODUCT.md
@@ -481,7 +481,7 @@ Scenario: Graph validation failure blocks local success
 Given a proposed patch parses and applies atomically
 And the patched JSON-LD parses into the DUUMBI AST
 And the parsed DUUMBI AST builds into graph IR
-But the patched graph produces validation diagnostics
+But the patched graph produces blocking validation diagnostics
 When repair validation runs
 Then the graph validation gate fails
 And local validation is not marked as passed
@@ -521,7 +521,7 @@ Given a repair candidate is pending human review after all local gates pass
 When a reviewer rejects the candidate or requests revision
 Then the repair state is marked as human rejected or revision needed
 And the repair remains not accepted for application
-And the evidence report preserves the reviewer decision for follow-up
+And the evidence report or linked human-review state preserves the reviewer decision for follow-up
 
 Rule: Evidence is traceable and bounded
 

--- a/specs/DUUMBI-587/PRODUCT.md
+++ b/specs/DUUMBI-587/PRODUCT.md
@@ -530,7 +530,7 @@ And the patch is applied atomically
 And the patched graph parses, builds, and validates
 And the native rebuild succeeds
 And relevant tests pass
-When repair validation produces evidence
+When repair validation is requested
 Then local validation is marked as passed
 And the evidence report requires human review
 And the repair is not marked accepted for application

--- a/specs/DUUMBI-587/PRODUCT.md
+++ b/specs/DUUMBI-587/PRODUCT.md
@@ -396,8 +396,9 @@ Constraints:
   not proceed to relevant tests.
 - If tests fail, report the failed tests and preserve local validation as
   failed.
-- If all local gates pass but no human review exists, report pending human
-  review rather than success.
+- If all local gates pass but no human review exists, report both local
+  validation passed and pending human review; do not mark the repair accepted for
+  application.
 
 ### Invariants
 
@@ -461,7 +462,7 @@ And the evidence report records the parse failure
 Scenario: Patch application failure preserves the original graph
 Given mapped repair crash context exists
 And a proposed GraphPatch references a missing graph node
-When repair validation applies the patch candidate
+When repair validation is requested
 Then the atomic patch application gate fails
 And the original graph source remains unchanged
 And the evidence report identifies the failed patch operation

--- a/specs/DUUMBI-587/PRODUCT.md
+++ b/specs/DUUMBI-587/PRODUCT.md
@@ -17,10 +17,10 @@ human-reviewable evidence report -> pending human review
 
 A repair candidate is not successful merely because an agent proposed a patch.
 It must parse through the canonical GraphPatch contract, apply atomically, pass
-graph parsing/building, pass graph validation, rebuild natively, pass relevant
-tests, and produce an evidence report that a human can inspect. Even when all
-local gates pass, the repair remains pending human review and is not accepted
-or applied silently.
+graph parsing, pass graph building, pass graph validation, rebuild natively,
+pass relevant tests, and produce an evidence report that a human can inspect.
+Even when all local gates pass, the repair remains pending human review and is
+not accepted or applied silently.
 
 This specification PR is related to #587 and must leave the execution issue
 open for Stage 7 review, Stage 8 technical specification, implementation,
@@ -229,8 +229,8 @@ Constraints:
   The existing GraphPatch applicator is all-or-nothing, and #587 should preserve
   that user-visible safety property.
 
-- **Decision:** Require graph parse/build, graph validation, native rebuild, and
-  relevant tests before local validation can pass.
+- **Decision:** Require graph parse, graph build, graph validation, native
+  rebuild, and relevant tests before local validation can pass.
   **Evidence:** #587 acceptance criteria require graph validation, rebuild, and
   relevant tests. The active PRD says any repair must pass graph validation,
   rebuild, tests, and human review before acceptance.
@@ -315,15 +315,20 @@ Constraints:
   - fails before any patch application when the payload is malformed.
 
 - Atomic patch application gate:
-  - passes only when the candidate patch can be applied to a clone or otherwise
-    proves the original source remains unchanged on failure.
+  - passes only when the candidate patch can be applied to a clone of the
+    source and the original source is structurally preserved on any failure.
   - fails when any operation targets a missing node, block, function, or invalid
     JSON-LD structure.
 
-- Graph parse and build gates:
-  - pass only when the patched JSON-LD parses and builds into DUUMBI graph IR.
-  - fail with diagnostics that identify the parse or graph construction problem
-    clearly enough for review.
+- Graph parse gate:
+  - passes only when the patched JSON-LD parses into the DUUMBI AST.
+  - fails with diagnostics that identify the parse problem clearly enough for
+    review.
+
+- Graph build gate:
+  - passes only when the parsed DUUMBI AST builds into graph IR.
+  - fails with diagnostics that identify the graph construction problem clearly
+    enough for review.
 
 - Graph validation gate:
   - passes only when the patched graph has no blocking validation diagnostics.
@@ -504,10 +509,8 @@ And the result is not reported as locally validated
 Rule: Product boundaries remain explicit
 
 Scenario: Production self-healing is requested from the validation guardrail
-Given the repair validation guardrail is available for local developer/test
-evidence
-When a user asks it to ingest production crashes or automatically deploy a
-repair
+Given the repair validation guardrail is available for local developer/test evidence
+When a user asks it to ingest production crashes or automatically deploy a repair
 Then the request is out of scope for #587
 And it must be routed to later product specification
 And no automatic acceptance is reported
@@ -531,7 +534,8 @@ And Query mode does not accept the repair
   - Define the required starting inputs: mapped repair crash context and a
     proposed GraphPatch candidate.
   - Define the required local gates: GraphPatch parse, atomic patch application,
-    graph parse/build, graph validation, native rebuild, and relevant tests.
+    graph parse, graph build, graph validation, native rebuild, and relevant
+    tests.
   - Define not-ready behavior for missing context, missing patch, malformed
     patch, failed patch application, graph diagnostics, rebuild failure, and
     test failure.
@@ -575,8 +579,8 @@ And Query mode does not accept the repair
   - The exact evidence report schema.
   - How the original source graph is preserved while validating a candidate.
   - How candidate patch artifacts are represented and diffed.
-  - How graph parse/build/validation gates map to existing parser, builder, and
-    validator APIs.
+  - How graph parse, graph build, and graph validation gates map to existing
+    parser, builder, and validator APIs.
   - How rebuild commands are selected for single-file and workspace cases.
   - How relevant tests are selected conservatively.
   - How large command output is summarized and linked.
@@ -657,15 +661,15 @@ Non-blocking questions for Stage 8 or later implementation:
 - Related child #585, local crash dumps and trace-to-graph mapping artifacts:
   https://github.com/hgahub/duumbi/issues/585
 - DUUMBI PRD:
-  `/Users/heizergabor/space/hgahub/duumbi-vault/Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - PRD.md`
+  `Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - PRD.md`
 - Runtime Failure Feedback Loop:
-  `/Users/heizergabor/space/hgahub/duumbi-vault/Duumbi/01 Atlas (Knowledge Base)/Dots (Atomic Ideas)/Runtime Failure Feedback Loop.md`
+  `Duumbi/01 Atlas (Knowledge Base)/Dots (Atomic Ideas)/Runtime Failure Feedback Loop.md`
 - DUUMBI Service and Research Direction:
-  `/Users/heizergabor/space/hgahub/duumbi-vault/Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - Service and Research Direction.md`
+  `Duumbi/01 Atlas (Knowledge Base)/Works (Developed Materials)/DUUMBI - Service and Research Direction.md`
 - DUUMBI Product Roadmap 2026-05:
-  `/Users/heizergabor/space/hgahub/duumbi-vault/Duumbi/05 Archive/Execution and Roadmap Docs/DUUMBI - Product Roadmap 2026-05.md`
+  `Duumbi/05 Archive/Execution and Roadmap Docs/DUUMBI - Product Roadmap 2026-05.md`
 - DUUMBI Phase 13 Self-Healing and Telemetry archive:
-  `/Users/heizergabor/space/hgahub/duumbi-vault/Duumbi/05 Archive/Execution and Roadmap Docs/DUUMBI - Phase 13 - Self-Healing & Telemetry.md`
+  `Duumbi/05 Archive/Execution and Roadmap Docs/DUUMBI - Phase 13 - Self-Healing & Telemetry.md`
 - Architecture reference: `docs/architecture.md`
 - Telemetry and repair validation source: `src/telemetry/mod.rs`
 - GraphPatch source: `src/patch.rs`

--- a/specs/DUUMBI-587/PRODUCT.md
+++ b/specs/DUUMBI-587/PRODUCT.md
@@ -388,7 +388,8 @@ Constraints:
   proceed to graph validation.
 - If graph validation fails, report diagnostics and do not proceed to native
   rebuild.
-- If rebuild fails, report the rebuild command summary and failure output.
+- If rebuild fails, report the rebuild command summary and failure output and do
+  not proceed to relevant tests.
 - If tests fail, report the failed tests and preserve local validation as
   failed.
 - If all local gates pass but no human review exists, report pending human
@@ -508,7 +509,7 @@ And the evidence report identifies the failed tests
 Scenario: All local gates pass but human review is still required
 Given mapped repair crash context exists
 And a proposed patch parses as GraphPatch
-And patch application is atomic
+And the patch is applied atomically
 And the patched graph parses, builds, and validates
 And the native rebuild succeeds
 And relevant tests pass

--- a/specs/DUUMBI-587/PRODUCT.md
+++ b/specs/DUUMBI-587/PRODUCT.md
@@ -159,6 +159,11 @@ Facts:
 - `src/telemetry/mod.rs` currently identifies these required gates:
   GraphPatch parse, atomic patch application, graph parse, graph validation,
   native rebuild, and relevant tests.
+- In current source, the graph validation gate description includes both graph
+  building and graph validation. This product spec separates graph build failure
+  and graph validation failure as product-visible evidence states so Stage 8 can
+  decide whether to expose graph build as a distinct enum gate or as an explicit
+  sub-result of the existing graph validation gate.
 - `RepairValidationEvidence` keeps `requires_human_review = true` and
   `accepted_for_application = false`.
 - `src/patch.rs` defines GraphPatch operations and an all-or-nothing
@@ -448,6 +453,23 @@ Then the candidate is not accepted for application
 And the evidence report shows the remaining gates
 
 Rule: Graph, rebuild, and test gates must pass
+
+Scenario: Graph parse failure blocks local success
+Given a proposed patch parses and applies atomically
+But the patched JSON-LD cannot be parsed into the DUUMBI AST
+When repair validation runs
+Then the graph parse gate fails
+And local validation is not marked as passed
+And the evidence report includes the parse diagnostics
+
+Scenario: Graph build failure blocks local success
+Given a proposed patch parses and applies atomically
+And the patched JSON-LD parses into the DUUMBI AST
+But the parsed DUUMBI AST cannot be converted to graph IR
+When repair validation runs
+Then the graph build evidence fails
+And local validation is not marked as passed
+And the evidence report includes the graph construction diagnostics
 
 Scenario: Graph validation failure blocks local success
 Given a proposed patch parses and applies atomically

--- a/specs/DUUMBI-587/PRODUCT.md
+++ b/specs/DUUMBI-587/PRODUCT.md
@@ -431,8 +431,9 @@ And no repair is accepted before the gates and human review are complete
 
 Scenario: Raw crash logs are not enough to validate a repair
 Given a runtime failure message exists in stderr or a log file
+And a proposed patch candidate is provided
 But no mapped repair crash context exists
-When repair validation is requested with a proposed patch
+When repair validation is requested
 Then the system reports that mapped crash evidence is required
 And no local validation success is reported
 And no source graph is silently changed
@@ -475,7 +476,7 @@ Scenario: Patch-shaped output is not automatically accepted
 Given mapped repair crash context exists
 And a Repair agent has produced GraphPatch-shaped output
 But graph validation, rebuild, tests, and human review have not all completed
-When repair validation is requested for the candidate
+When repair validation is requested
 Then the candidate is not accepted for application
 And the evidence report records the gates that have not passed
 
@@ -485,7 +486,7 @@ Scenario: Graph parse failure blocks local success
 Given mapped repair crash context exists
 And a proposed patch parses and applies atomically
 But the patched JSON-LD cannot be parsed into the DUUMBI AST
-When repair validation runs
+When repair validation is requested
 Then the graph parse gate fails
 And local validation is not marked as passed
 And the evidence report includes the parse diagnostics
@@ -495,7 +496,7 @@ Given mapped repair crash context exists
 And a proposed patch parses and applies atomically
 And the patched JSON-LD parses into the DUUMBI AST
 But the parsed DUUMBI AST cannot be converted to graph IR
-When repair validation runs
+When repair validation is requested
 Then the graph build gate fails
 And local validation is not marked as passed
 And the evidence report includes the graph construction diagnostics
@@ -506,7 +507,7 @@ And a proposed patch parses and applies atomically
 And the patched JSON-LD parses into the DUUMBI AST
 And the parsed DUUMBI AST builds into graph IR
 But the patched graph produces blocking validation diagnostics
-When repair validation runs
+When repair validation is requested
 Then the graph validation gate fails
 And local validation is not marked as passed
 And the evidence report includes the validation diagnostics
@@ -515,7 +516,7 @@ Scenario: Native rebuild failure blocks local success
 Given mapped repair crash context exists
 And a proposed patch passes graph validation
 But the native rebuild fails
-When repair validation runs
+When repair validation is requested
 Then the native rebuild gate fails
 And local validation is not marked as passed
 And the evidence report includes rebuild command and output summary
@@ -525,7 +526,7 @@ Given mapped repair crash context exists
 And a proposed patch passes graph validation
 And the native rebuild succeeds
 But a relevant targeted or regression test fails
-When repair validation runs
+When repair validation is requested
 Then the relevant tests gate fails
 And local validation is not marked as passed
 And the evidence report identifies the failed tests

--- a/specs/DUUMBI-587/PRODUCT.md
+++ b/specs/DUUMBI-587/PRODUCT.md
@@ -347,8 +347,7 @@ Constraints:
 
 - Relevant tests gate:
   - passes only when the selected targeted and regression tests pass.
-  - must include enough evidence to explain why the selected tests are relevant.
-  - must stay conservative when impacted-test analysis is unavailable.
+  - fails with failed-test summaries when any selected relevant test fails.
 
 - Human review gate:
   - is not satisfied by local validation.
@@ -363,6 +362,9 @@ Constraints:
 - The report identifies the source graph/workspace artifact validated.
 - The report records each gate as passed or failed.
 - The report includes concise command/result summaries for rebuild and tests.
+- The report explains why selected tests are relevant.
+- The report records conservative test selection when impacted-test analysis is
+  unavailable.
 - The report preserves failed gate output in a reviewable form.
 - The report says whether all local validation gates passed.
 - The report says human review is required.
@@ -378,6 +380,8 @@ Constraints:
   mapped crash evidence and do not validate a patch.
 - If the candidate patch is missing, report that no repair candidate was
   provided and do not produce local validation success.
+- If the source graph or workspace artifact is missing or unreadable, report that
+  the source artifact is required and do not attempt patch application.
 - If the patch is malformed, report the GraphPatch parse error and do not apply
   the patch.
 - If patch application fails, report the failed operation and keep original
@@ -434,6 +438,15 @@ But no proposed patch candidate is provided
 When repair validation is requested
 Then the system reports that a patch candidate is required
 And no validation gates are reported as passed
+
+Scenario: Unavailable source artifact blocks validation
+Given mapped repair crash context exists
+And a proposed patch candidate is provided
+But the source graph or workspace artifact is missing or unreadable
+When repair validation is requested
+Then the system reports that the source artifact is required
+And patch application is not attempted
+And no local validation success is reported
 
 Rule: Patch validation is canonical and atomic
 

--- a/specs/DUUMBI-587/PRODUCT.md
+++ b/specs/DUUMBI-587/PRODUCT.md
@@ -448,7 +448,7 @@ And the evidence report identifies the failed patch operation
 Scenario: Patch-shaped output is not automatically accepted
 Given a Repair agent has produced GraphPatch-shaped output
 But graph validation, rebuild, tests, and human review have not all completed
-When the candidate is inspected
+When repair validation is requested for the candidate
 Then the candidate is not accepted for application
 And the evidence report records the gates that have not passed
 
@@ -473,6 +473,8 @@ And the evidence report includes the graph construction diagnostics
 
 Scenario: Graph validation failure blocks local success
 Given a proposed patch parses and applies atomically
+And the patched JSON-LD parses into the DUUMBI AST
+And the parsed DUUMBI AST builds into graph IR
 But the patched graph produces validation diagnostics
 When repair validation runs
 Then the graph validation gate fails
@@ -533,8 +535,8 @@ Rule: Product boundaries remain explicit
 Scenario: Production self-healing is requested from the validation guardrail
 Given the repair validation guardrail is available for local developer/test evidence
 When a user asks it to ingest production crashes or automatically deploy a repair
-Then the request is out of scope for #587
-And it must be routed to later product specification
+Then the system reports that production crash ingestion and automatic deployment are unavailable for this guardrail
+And it does not ingest production crash artifacts or start deployment
 And no automatic acceptance is reported
 
 Scenario: Query mode asks about repair validation evidence

--- a/specs/DUUMBI-587/PRODUCT.md
+++ b/specs/DUUMBI-587/PRODUCT.md
@@ -195,7 +195,7 @@ Assumptions:
 
 Constraints:
 
-- Validation must not start without mapped crash context or an explicit
+- Validation must not start without mapped crash context and an explicit
   proposed patch.
 - Validation must not start without the source graph or workspace artifact being
   present and readable.
@@ -514,7 +514,10 @@ And the evidence report includes the validation diagnostics
 
 Scenario: Native rebuild failure blocks local success
 Given mapped repair crash context exists
-And a proposed patch passes graph validation
+And a proposed patch parses and applies atomically
+And the patched JSON-LD parses into the DUUMBI AST
+And the parsed DUUMBI AST builds into graph IR
+And the patched graph passes graph validation
 But the native rebuild fails
 When repair validation is requested
 Then the native rebuild gate fails
@@ -523,7 +526,10 @@ And the evidence report includes rebuild command and output summary
 
 Scenario: Relevant test failure blocks local success
 Given mapped repair crash context exists
-And a proposed patch passes graph validation
+And a proposed patch parses and applies atomically
+And the patched JSON-LD parses into the DUUMBI AST
+And the parsed DUUMBI AST builds into graph IR
+And the patched graph passes graph validation
 And the native rebuild succeeds
 But a relevant targeted or regression test fails
 When repair validation is requested

--- a/specs/DUUMBI-587/PRODUCT.md
+++ b/specs/DUUMBI-587/PRODUCT.md
@@ -297,7 +297,7 @@ Constraints:
 - Patch application failed: the patch cannot be applied atomically to the
   source graph.
 - Graph parse failed: patched JSON-LD cannot be parsed into DUUMBI AST.
-- Graph build failed: parsed graph source cannot be converted to graph IR.
+- Graph IR build failed: parsed DUUMBI AST cannot be converted to graph IR.
 - Graph validation failed: semantic validation produced diagnostics.
 - Rebuild failed: native rebuild does not complete successfully.
 - Tests failed: relevant tests do not pass.
@@ -386,7 +386,7 @@ Constraints:
 
 - Original crash evidence remains traceable from every validation report.
 - Patch-shaped output is not enough to claim repair success.
-- Graph mutation cannot bypass parse/build/validate behavior.
+- Graph mutation cannot bypass parse, build, or validate behavior.
 - Failed gates cannot be hidden behind an agent success message.
 - Local validation success cannot bypass human review.
 - Default untraced behavior remains unchanged unless later approved scope says
@@ -567,8 +567,8 @@ And Query mode does not accept the repair
   - The product spec stays within #587 and does not create a technical spec.
   - Repair validation starts from mapped crash context and a proposed patch.
   - GraphPatch parse and atomic patch behavior are product-visible gates.
-  - Graph parse/build, graph validation, native rebuild, and relevant tests are
-    required before local validation success.
+  - Graph parse, graph build, graph validation, native rebuild, and relevant
+    tests are required before local validation success.
   - Local validation success remains distinct from human acceptance.
   - Evidence report requirements are reviewable and bounded.
   - Production self-healing, hot-swap, deployment, and autonomous acceptance are
@@ -591,7 +591,7 @@ And Query mode does not accept the repair
   - Missing patch candidate blocks validation.
   - Malformed GraphPatch data fails before application.
   - Failed patch application preserves the original graph.
-  - Graph parse/build/validation failures block local success.
+  - Graph parse, graph build, and graph validation failures block local success.
   - Native rebuild failure blocks local success.
   - Relevant test failure blocks local success.
   - All local gates passing still keeps human review required and acceptance


### PR DESCRIPTION
## Summary
- Add DUUMBI AI code review policy and Greptile manual-only config.
- Update stage skills, Copilot instructions, PR template, and GitHub workflows to use Codex self-review plus Copilot as the default gate.
- Keep Greptile manual-only for high-risk implementation PRs and out of DUUMBI_REQUIRED_SPEC_REVIEWERS.

## Validation
- git diff --check
- node --test scripts/github-actions/stage-approval-workflow.test.mjs scripts/github-actions/duumbi-stage-handoff.test.mjs
- JSON parse for .greptile/config.json and .greptile/files.json

## Notes
- Companion vault documentation PR follows in hgahub/duumbi-vault.