### PR TITLE
Test telemetry back-mapping evidence for #586

### DIFF
--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -1409,6 +1409,30 @@ mod tests {
     }
 
     #[test]
+    fn inspect_crash_artifacts_rejects_unmapped_crash_ids() {
+        let dir = TempDir::new().expect("invariant: temp dir creation must succeed");
+        let map = TraceMap::from_graph(&test_graph()).expect("trace map should be generated");
+        write_trace_map(&map, dir.path()).expect("trace map should be written");
+
+        let crash = serde_json::json!({
+            "schema_version": CRASH_SCHEMA_VERSION,
+            "event": "panic",
+            "message": "failure",
+            "function_id": u64::MAX,
+            "block_id": u64::MAX,
+            "trace_active": true
+        });
+        std::fs::write(dir.path().join(CRASH_DUMP_FILE), format!("{crash}\n"))
+            .expect("crash artifact should be written");
+
+        let result = inspect_crash_artifacts(dir.path(), None, None);
+
+        assert!(
+            matches!(result, Err(TelemetryError::Unmapped(message)) if message.contains("function trace ID"))
+        );
+    }
+
+    #[test]
     fn telemetry_artifact_dir_resolves_relative_to_workspace() {
         let workspace = TempDir::new().expect("invariant: temp dir creation must succeed");
         let section = TelemetrySection {

--- a/tests/integration_telemetry.rs
+++ b/tests/integration_telemetry.rs
@@ -93,6 +93,11 @@ fn default_untraced_option_none_unwrap_is_not_back_mapping_proof() {
         !inspect.status.success(),
         "untraced failure must not inspect as mapped telemetry evidence"
     );
+    let stderr = String::from_utf8_lossy(&inspect.stderr);
+    assert!(
+        stderr.contains("Failed to read crash artifact") && stderr.contains("crash_dump.jsonl"),
+        "untraced failure should fail because crash evidence is missing, got: {stderr}"
+    );
     let stdout = String::from_utf8_lossy(&inspect.stdout);
     assert!(
         !stdout.contains("Function:") && !stdout.contains("Block:"),

--- a/tests/integration_telemetry.rs
+++ b/tests/integration_telemetry.rs
@@ -19,6 +19,11 @@ fn traced_option_none_unwrap_writes_crash_evidence_and_inspects() {
     assert!(stdout.contains("Exact node evidence: unavailable in v1"));
 
     assert_trace_events_join_trace_map(&evidence, &["function_enter", "block_enter"]);
+    assert_latest_crash_joins_trace_map(
+        &evidence,
+        "duumbi:telemetry/main",
+        "duumbi:telemetry/main/entry",
+    );
 }
 
 #[test]
@@ -42,6 +47,56 @@ fn traced_call_then_panic_preserves_caller_context() {
             "block_enter",
             "block_exit",
         ],
+    );
+    assert_latest_crash_joins_trace_map(
+        &evidence,
+        "duumbi:telemetry_call/main",
+        "duumbi:telemetry_call/main/entry",
+    );
+}
+
+#[test]
+fn default_untraced_option_none_unwrap_is_not_back_mapping_proof() {
+    let evidence = untraced_fixture_failure(
+        "tests/fixtures/telemetry/option_none_unwrap.jsonld",
+        "untraced_panic",
+    );
+
+    assert!(
+        !evidence.telemetry_dir.join("trace_map.json").exists(),
+        "default untraced build must not write trace map evidence"
+    );
+    assert!(
+        !evidence.telemetry_dir.join("traces.jsonl").exists(),
+        "default untraced run must not write trace event evidence"
+    );
+    assert!(
+        !evidence.telemetry_dir.join("crash_dump.jsonl").exists(),
+        "default untraced run must not write crash back-mapping evidence"
+    );
+
+    let duumbi = env!("CARGO_BIN_EXE_duumbi");
+    let inspect = Command::new(duumbi)
+        .args([
+            "telemetry",
+            "inspect",
+            "--telemetry-dir",
+            evidence
+                .telemetry_dir
+                .to_str()
+                .expect("invariant: telemetry path must be UTF-8"),
+        ])
+        .output()
+        .expect("invariant: telemetry inspect must run");
+
+    assert!(
+        !inspect.status.success(),
+        "untraced failure must not inspect as mapped telemetry evidence"
+    );
+    let stdout = String::from_utf8_lossy(&inspect.stdout);
+    assert!(
+        !stdout.contains("Function:") && !stdout.contains("Block:"),
+        "untraced failure must not report mapped graph context, got: {stdout}"
     );
 }
 
@@ -115,6 +170,7 @@ fn traced_fixture_evidence(fixture: &str, binary_name: &str) -> TraceFixtureEvid
 
     let trace_map = read_trace_map(&telemetry_dir);
     let trace_events = read_trace_events(&telemetry_dir);
+    let crash_records = read_crash_records(&telemetry_dir);
 
     let inspect = Command::new(duumbi)
         .args([
@@ -137,6 +193,7 @@ fn traced_fixture_evidence(fixture: &str, binary_name: &str) -> TraceFixtureEvid
             .expect("invariant: inspect stdout must be UTF-8"),
         trace_map,
         trace_events,
+        crash_records,
     }
 }
 
@@ -145,12 +202,67 @@ struct TraceFixtureEvidence {
     inspect_stdout: String,
     trace_map: TraceMap,
     trace_events: Vec<TraceEvent>,
+    crash_records: Vec<CrashRecord>,
+}
+
+#[derive(Debug)]
+struct UntracedFailureEvidence {
+    _tmp: tempfile::TempDir,
+    telemetry_dir: std::path::PathBuf,
 }
 
 #[derive(Debug, Deserialize)]
 struct TraceEvent {
     event: String,
     trace_id: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CrashRecord {
+    event: String,
+    function_id: u64,
+    block_id: u64,
+    trace_active: bool,
+}
+
+fn untraced_fixture_failure(fixture: &str, binary_name: &str) -> UntracedFailureEvidence {
+    let duumbi = env!("CARGO_BIN_EXE_duumbi");
+    let tmp = tempfile::TempDir::new().expect("invariant: temp dir must be created");
+    let telemetry_dir = tmp.path().join("telemetry");
+    let binary = tmp
+        .path()
+        .join(format!("{binary_name}{}", std::env::consts::EXE_SUFFIX));
+
+    let build = Command::new(duumbi)
+        .args(["build", fixture, "-o"])
+        .arg(binary.to_str().expect("invariant: temp path must be UTF-8"))
+        .env("DUUMBI_TELEMETRY_DIR", &telemetry_dir)
+        .output()
+        .expect("invariant: duumbi build must run");
+    assert!(
+        build.status.success(),
+        "untraced build failed: {}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    let run = Command::new(&binary)
+        .env("DUUMBI_TELEMETRY_DIR", &telemetry_dir)
+        .output()
+        .expect("invariant: untraced binary must run");
+    assert!(
+        !run.status.success(),
+        "controlled panic fixture must exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&run.stderr);
+    assert!(
+        stderr.contains("duumbi panic: called Option::unwrap() on a None value"),
+        "panic stderr must preserve original message, got: {stderr}"
+    );
+
+    UntracedFailureEvidence {
+        _tmp: tmp,
+        telemetry_dir: telemetry_dir.clone(),
+    }
 }
 
 fn read_trace_map(telemetry_dir: &std::path::Path) -> TraceMap {
@@ -165,6 +277,15 @@ fn read_trace_events(telemetry_dir: &std::path::Path) -> Vec<TraceEvent> {
     content
         .lines()
         .map(|line| serde_json::from_str(line).expect("invariant: trace event must parse"))
+        .collect()
+}
+
+fn read_crash_records(telemetry_dir: &std::path::Path) -> Vec<CrashRecord> {
+    let content = fs::read_to_string(telemetry_dir.join("crash_dump.jsonl"))
+        .expect("invariant: crash records must be readable");
+    content
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("invariant: crash record must parse"))
         .collect()
 }
 
@@ -200,4 +321,46 @@ fn assert_trace_events_join_trace_map(evidence: &TraceFixtureEvidence, required_
             );
         }
     }
+}
+
+fn assert_latest_crash_joins_trace_map(
+    evidence: &TraceFixtureEvidence,
+    expected_function: &str,
+    expected_block: &str,
+) {
+    let crash = evidence
+        .crash_records
+        .last()
+        .expect("crash evidence must contain a panic record");
+    assert_eq!(crash.event, "panic");
+    assert!(
+        crash.trace_active,
+        "crash record must come from a traced run"
+    );
+
+    let function = evidence
+        .trace_map
+        .entries
+        .iter()
+        .find(|entry| entry.kind == TraceMapKind::Function && entry.trace_id == crash.function_id)
+        .unwrap_or_else(|| {
+            panic!(
+                "crash function_id {} did not join to a function trace map entry",
+                crash.function_id
+            )
+        });
+    assert_eq!(function.graph_id, expected_function);
+
+    let block = evidence
+        .trace_map
+        .entries
+        .iter()
+        .find(|entry| entry.kind == TraceMapKind::Block && entry.trace_id == crash.block_id)
+        .unwrap_or_else(|| {
+            panic!(
+                "crash block_id {} did not join to a block trace map entry",
+                crash.block_id
+            )
+        });
+    assert_eq!(block.graph_id, expected_block);
 }


### PR DESCRIPTION
Related to #586.

## Summary
- Hardens controlled traced telemetry fixture evidence by parsing crash_dump.jsonl and asserting crash function/block IDs join trace_map.json entries.
- Adds the default untraced failure negative proof so an untraced panic is not accepted as back-mapping evidence.
- Adds a focused telemetry unit test for unmapped crash IDs failing closed.

## Specs
- Product spec: https://github.com/hgahub/duumbi/pull/649
- Technical spec: https://github.com/hgahub/duumbi/pull/653
- Stage 10 resource authorization: https://github.com/hgahub/duumbi/issues/586#issuecomment-4624815764
- Ralph Cycle 1 evidence: https://github.com/hgahub/duumbi/issues/586#issuecomment-4624914697

## Local checks
- cargo fmt --check: passed
- git diff --check: passed
- cargo test telemetry --lib: passed, 28 passed
- cargo clippy --all-targets -- -D warnings: passed
- cargo test --test integration_telemetry: blocked locally by the authorized pre-existing macOS linker/platform error: ld: unknown platform ... output.o

## CI evidence
- check (ubuntu-latest): passed
- check (windows-latest): passed
- check: passed
- coverage: passed

## Scope notes
No product specs, technical specs, generated artifacts, runtime assets, compiler code, CLI code, telemetry schema, provider/model behavior, Studio code, external services, or repair automation were changed.

Workflow note: this implementation PR uses non-closing issue references and must leave the execution issue open for Stage 11 and closure gates.