### PR TITLE
Implement #585 telemetry artifact directory cohesion

### DIFF
--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 
 use crate::compiler::{linker, lowering};
 use crate::deps;
-use crate::telemetry::BuildOptions;
+use crate::telemetry::{BuildOptions, TELEMETRY_DIR_ENV};
 
 const RUNTIME_C_SOURCE: &str = include_str!("../runtime/duumbi_runtime.c");
 
@@ -224,9 +224,15 @@ pub fn run_workspace_binary(workspace_root: &Path, args: &[String]) -> Result<Bi
         );
     }
 
-    let output = std::process::Command::new(&output_path)
-        .args(args)
-        .current_dir(workspace_root)
+    let mut command = std::process::Command::new(&output_path);
+    command.args(args).current_dir(workspace_root);
+    if std::env::var_os(TELEMETRY_DIR_ENV).is_none()
+        && let Some(telemetry_dir) = workspace_runtime_telemetry_dir(workspace_root)
+    {
+        command.env(TELEMETRY_DIR_ENV, telemetry_dir);
+    }
+
+    let output = command
         .output()
         .with_context(|| format!("Failed to execute '{}'", output_path.display()))?;
 
@@ -235,6 +241,15 @@ pub fn run_workspace_binary(workspace_root: &Path, args: &[String]) -> Result<Bi
         stdout: String::from_utf8_lossy(&output.stdout).to_string(),
         stderr: String::from_utf8_lossy(&output.stderr).to_string(),
     })
+}
+
+fn workspace_runtime_telemetry_dir(workspace_root: &Path) -> Option<PathBuf> {
+    let section = crate::config::load_effective_config(workspace_root)
+        .ok()?
+        .config
+        .telemetry
+        .unwrap_or_default();
+    Some(section.resolve_for_trace(workspace_root).ok()?.artifact_dir)
 }
 
 fn find_runtime_c() -> Result<PathBuf> {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -226,7 +226,7 @@ pub fn run_workspace_binary(workspace_root: &Path, args: &[String]) -> Result<Bi
 
     let mut command = std::process::Command::new(&output_path);
     command.args(args).current_dir(workspace_root);
-    if std::env::var_os(TELEMETRY_DIR_ENV).is_none()
+    if std::env::var_os(TELEMETRY_DIR_ENV).is_none_or(|value| value.is_empty())
         && let Some(telemetry_dir) = workspace_runtime_telemetry_dir(workspace_root)
     {
         command.env(TELEMETRY_DIR_ENV, telemetry_dir);

--- a/tests/integration_telemetry.rs
+++ b/tests/integration_telemetry.rs
@@ -283,8 +283,10 @@ fn workspace_run_uses_configured_telemetry_artifact_dir() {
     )
     .expect("invariant: workspace config must be written");
 
+    let output_path = format!(".duumbi/build/output{}", std::env::consts::EXE_SUFFIX);
     let build = Command::new(duumbi)
-        .args(["build", "--trace", "-o", ".duumbi/build/output"])
+        .args(["build", "--trace", "-o"])
+        .arg(&output_path)
         .current_dir(&workspace)
         .env_remove("DUUMBI_TELEMETRY_DIR")
         .output()

--- a/tests/integration_telemetry.rs
+++ b/tests/integration_telemetry.rs
@@ -298,7 +298,7 @@ fn workspace_run_uses_configured_telemetry_artifact_dir() {
     let run = Command::new(duumbi)
         .arg("run")
         .current_dir(&workspace)
-        .env_remove("DUUMBI_TELEMETRY_DIR")
+        .env("DUUMBI_TELEMETRY_DIR", "")
         .output()
         .expect("invariant: duumbi run must run");
     assert!(

--- a/tests/integration_telemetry.rs
+++ b/tests/integration_telemetry.rs
@@ -264,6 +264,85 @@ fn default_untraced_option_none_unwrap_is_not_back_mapping_proof() {
 }
 
 #[test]
+fn workspace_run_uses_configured_telemetry_artifact_dir() {
+    let duumbi = env!("CARGO_BIN_EXE_duumbi");
+    let tmp = tempfile::TempDir::new().expect("invariant: temp dir must be created");
+    let workspace = tmp.path().join("workspace");
+    let graph_dir = workspace.join(".duumbi/graph");
+    let build_dir = workspace.join(".duumbi/build");
+    fs::create_dir_all(&graph_dir).expect("invariant: graph dir must be created");
+    fs::create_dir_all(&build_dir).expect("invariant: build dir must be created");
+
+    let fixture = "tests/fixtures/telemetry/option_none_unwrap.jsonld";
+    let original_graph = fs::read(fixture).expect("invariant: fixture must be readable");
+    let graph_path = graph_dir.join("main.jsonld");
+    fs::write(&graph_path, &original_graph).expect("invariant: graph fixture must be copied");
+    fs::write(
+        workspace.join(".duumbi/config.toml"),
+        "[workspace]\nname = \"telemetry-config-e2e\"\n\n[telemetry]\nartifact-dir = \"custom/telemetry\"\n",
+    )
+    .expect("invariant: workspace config must be written");
+
+    let build = Command::new(duumbi)
+        .args(["build", "--trace", "-o", ".duumbi/build/output"])
+        .current_dir(&workspace)
+        .env_remove("DUUMBI_TELEMETRY_DIR")
+        .output()
+        .expect("invariant: duumbi build must run");
+    assert!(
+        build.status.success(),
+        "workspace traced build failed: {}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    let run = Command::new(duumbi)
+        .arg("run")
+        .current_dir(&workspace)
+        .env_remove("DUUMBI_TELEMETRY_DIR")
+        .output()
+        .expect("invariant: duumbi run must run");
+    assert!(
+        !run.status.success(),
+        "controlled panic fixture must exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&run.stderr);
+    assert!(
+        stderr.contains("duumbi panic: called Option::unwrap() on a None value"),
+        "panic stderr must preserve original message, got: {stderr}"
+    );
+
+    let configured_dir = workspace.join("custom/telemetry");
+    assert!(configured_dir.join("trace_map.json").exists());
+    assert!(configured_dir.join("traces.jsonl").exists());
+    assert!(configured_dir.join("crash_dump.jsonl").exists());
+    assert!(
+        !workspace.join(".duumbi/telemetry/traces.jsonl").exists(),
+        "workspace run should not split trace events into the default telemetry dir"
+    );
+    assert_eq!(
+        fs::read(&graph_path).expect("invariant: graph file must be readable"),
+        original_graph,
+        "workspace run must not mutate source graph files"
+    );
+
+    let inspect = Command::new(duumbi)
+        .args(["telemetry", "inspect"])
+        .current_dir(&workspace)
+        .env_remove("DUUMBI_TELEMETRY_DIR")
+        .output()
+        .expect("invariant: telemetry inspect must run");
+    assert!(
+        inspect.status.success(),
+        "telemetry inspect failed: {}",
+        String::from_utf8_lossy(&inspect.stderr)
+    );
+    let stdout = String::from_utf8(inspect.stdout).expect("invariant: inspect stdout is UTF-8");
+    assert!(stdout.contains("Function: duumbi:telemetry/main"));
+    assert!(stdout.contains("Block: duumbi:telemetry/main/entry"));
+    assert!(stdout.contains("Exact node evidence: unavailable in v1"));
+}
+
+#[test]
 fn telemetry_inspect_without_dir_reports_malformed_config() {
     let duumbi = env!("CARGO_BIN_EXE_duumbi");
     let workspace = tempfile::TempDir::new().expect("invariant: temp dir must be created");


### PR DESCRIPTION
Related to #585.

## Summary

This PR completes the Stage 10 Ralph Cycle 1 hardening for the configured telemetry artifact directory gap found during the required audit/evidence cycle.

The pre-change audit showed that a workspace traced build with `[telemetry] artifact-dir = "custom/telemetry"` wrote `trace_map.json` under `custom/telemetry`, while `duumbi run` let the C runtime fall back to `.duumbi/telemetry` for `traces.jsonl` and `crash_dump.jsonl`. As a result, `duumbi telemetry inspect` failed against the configured directory.

## Changes

- `src/workspace.rs`: when `duumbi run` executes a workspace binary and the user has not set `DUUMBI_TELEMETRY_DIR`, pass the resolved workspace telemetry artifact directory to the runtime process.
- `tests/integration_telemetry.rs`: add a workspace E2E regression proving traced build, run, and inspect all use the configured artifact directory without an env override.

## BDD Evidence

- Traced runtime failure produces the three local evidence artifacts: covered by existing traced integration test and live direct smoke.
- Trace map entries preserve graph function/block identity: covered by telemetry unit tests and integration trace-map parsing.
- Crash evidence joins to graph context: covered by integration inspect output and helper joins.
- Default untraced failure is not accepted as back-mapping evidence: covered by existing integration test.
- Missing/malformed/unmapped evidence fails closed: covered by telemetry unit tests and malformed-config integration coverage.
- Local artifact path override is honored: covered by existing traced integration test and live direct smoke.
- Configured artifact directory keeps evidence together: fixed and covered by new `workspace_run_uses_configured_telemetry_artifact_dir` integration test plus live configured smoke.
- Config-only runtime artifact routing gap is reported: pre-change audit recorded the split; this PR addresses it through the approved CLI/workspace scope.
- Value capture remains absent in v1: covered by telemetry unit tests and repair-context integration assertions.
- Source reconciliation avoids duplicate telemetry work: no new schema, runtime writer, compiler lowering, provider path, or generated artifact is added.

## Ralph Cycle 1 Evidence

Cycle goal: audit current #585 behavior, then harden the configured artifact-dir workspace path only if a concrete gap is proven.

Pre-change configured smoke:
- `trace_map.json`: `$workspace/custom/telemetry/trace_map.json`
- `traces.jsonl` and `crash_dump.jsonl`: `$workspace/.duumbi/telemetry/`
- `duumbi telemetry inspect`: failed reading `./custom/telemetry/crash_dump.jsonl`

Post-change configured smoke:
- all three artifacts exist under `$workspace/custom/telemetry`
- no split `traces.jsonl` under `$workspace/.duumbi/telemetry`
- `duumbi telemetry inspect` reports `Function: duumbi:telemetry/main`, `Block: duumbi:telemetry/main/entry`, and exact node evidence unavailable in v1

## Checks

- `cargo fmt --check`: passed
- `git diff --check`: passed
- `cargo test telemetry --lib`: passed, 60 tests
- `cargo test --test integration_telemetry`: passed, 7 tests
- live traced-failure smoke with `DUUMBI_TELEMETRY_DIR`: passed
- live configured artifact-dir smoke without `DUUMBI_TELEMETRY_DIR`: failed before the change, passed after the change
- `cargo clippy --all-targets -- -D warnings`: passed
- `cargo test --all`: passed

## Resource Use

- External LLM calls: 0
- Estimated external LLM cost: USD 0
- Scope: approved narrow CLI/workspace hardening plus one integration regression
- No runtime C, compiler lowering, schema, migration, dependency, provider, generated artifact, product spec, or technical spec changes
- Greptile was not invoked

## Review Plan

- Codex self-review required before moving to In Review.
- Copilot automated review should be inspected when submitted.
- Stage 11 should verify CI, review feedback, and evidence before merge/closure routing.
