### PR TITLE
Implement DUUMBI-378 stdlib IO and file APIs

### DIFF
--- a/runtime/duumbi_runtime.c
+++ b/runtime/duumbi_runtime.c
@@ -9,11 +9,16 @@
 
 #if defined(_WIN32)
 #include <direct.h>
+#include <io.h>
 #define DUUMBI_MKDIR(path) _mkdir(path)
 #define DUUMBI_PATH_SEP '\\'
+#define DUUMBI_REALPATH(path, resolved) _fullpath((resolved), (path), DUUMBI_PATH_BUFFER_LEN)
 #else
+#include <dirent.h>
+#include <unistd.h>
 #define DUUMBI_MKDIR(path) mkdir(path, 0777)
 #define DUUMBI_PATH_SEP '/'
+#define DUUMBI_REALPATH(path, resolved) realpath((path), (resolved))
 #endif
 
 #if defined(_MSC_VER)
@@ -28,6 +33,7 @@
 #define DUUMBI_CRASH_SCHEMA_VERSION "duumbi.telemetry.crash.v1"
 #define DUUMBI_PATH_BUFFER_LEN 4096
 #define DUUMBI_TRACE_STACK_LIMIT 1024
+#define DUUMBI_WORKSPACE_ROOT_ENV "DUUMBI_WORKSPACE_ROOT"
 
 /* ── Internal types ────────────────────────────────────────────────── */
 
@@ -747,4 +753,464 @@ void *duumbi_string_replace(void *haystack, void *needle, void *replacement) {
            (size_t)(h->len - match_pos - n->len));
     result->data[new_len] = '\0';
     return result;
+}
+
+/* ── DUUMBI-378 text I/O and workspace-confined file APIs ─────────── */
+
+static int duumbi_utf8_valid(const char *data, uint64_t len) {
+    uint64_t i = 0;
+    while (i < len) {
+        unsigned char c = (unsigned char)data[i];
+        if (c <= 0x7f) {
+            i++;
+        } else if ((c & 0xe0) == 0xc0) {
+            if (i + 1 >= len) return 0;
+            unsigned char c1 = (unsigned char)data[i + 1];
+            if ((c1 & 0xc0) != 0x80 || c < 0xc2) return 0;
+            i += 2;
+        } else if ((c & 0xf0) == 0xe0) {
+            if (i + 2 >= len) return 0;
+            unsigned char c1 = (unsigned char)data[i + 1];
+            unsigned char c2 = (unsigned char)data[i + 2];
+            if ((c1 & 0xc0) != 0x80 || (c2 & 0xc0) != 0x80) return 0;
+            if (c == 0xe0 && c1 < 0xa0) return 0;
+            if (c == 0xed && c1 >= 0xa0) return 0;
+            i += 3;
+        } else if ((c & 0xf8) == 0xf0) {
+            if (i + 3 >= len) return 0;
+            unsigned char c1 = (unsigned char)data[i + 1];
+            unsigned char c2 = (unsigned char)data[i + 2];
+            unsigned char c3 = (unsigned char)data[i + 3];
+            if ((c1 & 0xc0) != 0x80 || (c2 & 0xc0) != 0x80 || (c3 & 0xc0) != 0x80) return 0;
+            if (c == 0xf0 && c1 < 0x90) return 0;
+            if (c > 0xf4 || (c == 0xf4 && c1 > 0x8f)) return 0;
+            i += 4;
+        } else {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static void *duumbi_ok_i64(int64_t value) {
+    return duumbi_result_new_ok(value);
+}
+
+static void *duumbi_ok_string(const char *data, uint64_t len) {
+    return duumbi_result_new_ok((int64_t)(intptr_t)duumbi_string_new(data, len));
+}
+
+static void *duumbi_ok_bool(int8_t value) {
+    return duumbi_result_new_ok((int64_t)value);
+}
+
+static void *duumbi_err_cstr(const char *message) {
+    return duumbi_result_new_err((int64_t)(intptr_t)duumbi_string_new(message, strlen(message)));
+}
+
+static int duumbi_string_to_cstr(void *ptr, char *out, size_t out_len) {
+    DuumbiString *s = (DuumbiString *)ptr;
+    if (s == NULL || s->len == 0 || s->len >= out_len) {
+        return -1;
+    }
+    memcpy(out, s->data, (size_t)s->len);
+    out[s->len] = '\0';
+    return 0;
+}
+
+static int duumbi_has_url_prefix(const char *path) {
+    return strstr(path, "://") != NULL;
+}
+
+static int duumbi_normalize_relative_path(const char *input, char *out, size_t out_len) {
+    if (input == NULL || input[0] == '\0') {
+        return -1;
+    }
+    if (input[0] == '/' || input[0] == '\\' || input[0] == '~' || input[0] == '$' ||
+        strchr(input, ':') != NULL || duumbi_has_url_prefix(input)) {
+        return -1;
+    }
+    if (strchr(input, '\\') != NULL) {
+        return -1;
+    }
+
+    out[0] = '\0';
+    size_t out_used = 0;
+    const char *cursor = input;
+    while (*cursor != '\0') {
+        while (*cursor == '/') {
+            cursor++;
+        }
+        const char *start = cursor;
+        while (*cursor != '\0' && *cursor != '/') {
+            cursor++;
+        }
+        size_t len = (size_t)(cursor - start);
+        if (len == 0) {
+            continue;
+        }
+        if (len == 1 && start[0] == '.') {
+            continue;
+        }
+        if (len == 2 && start[0] == '.' && start[1] == '.') {
+            return -1;
+        }
+        if (out_used != 0) {
+            if (out_used + 1 >= out_len) return -1;
+            out[out_used++] = '/';
+        }
+        if (out_used + len >= out_len) return -1;
+        memcpy(out + out_used, start, len);
+        out_used += len;
+        out[out_used] = '\0';
+    }
+
+    return out_used == 0 ? -1 : 0;
+}
+
+static int duumbi_join_workspace_path(const char *normalized, char *out, size_t out_len) {
+    const char *root = getenv(DUUMBI_WORKSPACE_ROOT_ENV);
+    if (root == NULL || root[0] == '\0') {
+        return -1;
+    }
+    int written = snprintf(out, out_len, "%s%c%s", root, DUUMBI_PATH_SEP, normalized);
+    if (written < 0 || (size_t)written >= out_len) {
+        return -1;
+    }
+    return 0;
+}
+
+static int duumbi_canonical_workspace_root(char *out, size_t out_len) {
+    const char *root = getenv(DUUMBI_WORKSPACE_ROOT_ENV);
+    if (root == NULL || root[0] == '\0') {
+        return -1;
+    }
+    char resolved[DUUMBI_PATH_BUFFER_LEN];
+    if (DUUMBI_REALPATH(root, resolved) == NULL) {
+        return -1;
+    }
+    size_t len = strlen(resolved);
+    if (len == 0 || len >= out_len) {
+        return -1;
+    }
+    memcpy(out, resolved, len + 1);
+    return 0;
+}
+
+static int duumbi_path_inside_root(const char *root, const char *path) {
+    size_t root_len = strlen(root);
+    if (strncmp(root, path, root_len) != 0) {
+        return 0;
+    }
+    return path[root_len] == '\0' || path[root_len] == '/' || path[root_len] == '\\';
+}
+
+static int duumbi_resolve_existing_workspace_path(void *path_ptr, char *out, size_t out_len) {
+    char raw[DUUMBI_PATH_BUFFER_LEN];
+    char normalized[DUUMBI_PATH_BUFFER_LEN];
+    char joined[DUUMBI_PATH_BUFFER_LEN];
+    char root[DUUMBI_PATH_BUFFER_LEN];
+    char resolved[DUUMBI_PATH_BUFFER_LEN];
+
+    if (duumbi_string_to_cstr(path_ptr, raw, sizeof(raw)) != 0 ||
+        duumbi_normalize_relative_path(raw, normalized, sizeof(normalized)) != 0 ||
+        duumbi_join_workspace_path(normalized, joined, sizeof(joined)) != 0 ||
+        duumbi_canonical_workspace_root(root, sizeof(root)) != 0 ||
+        DUUMBI_REALPATH(joined, resolved) == NULL ||
+        !duumbi_path_inside_root(root, resolved)) {
+        return -1;
+    }
+
+    size_t len = strlen(resolved);
+    if (len >= out_len) {
+        return -1;
+    }
+    memcpy(out, resolved, len + 1);
+    return 0;
+}
+
+static int duumbi_resolve_write_workspace_path(void *path_ptr, char *out, size_t out_len) {
+    char raw[DUUMBI_PATH_BUFFER_LEN];
+    char normalized[DUUMBI_PATH_BUFFER_LEN];
+    char joined[DUUMBI_PATH_BUFFER_LEN];
+    char root[DUUMBI_PATH_BUFFER_LEN];
+    char resolved[DUUMBI_PATH_BUFFER_LEN];
+
+    if (duumbi_string_to_cstr(path_ptr, raw, sizeof(raw)) != 0 ||
+        duumbi_normalize_relative_path(raw, normalized, sizeof(normalized)) != 0 ||
+        duumbi_join_workspace_path(normalized, joined, sizeof(joined)) != 0 ||
+        duumbi_canonical_workspace_root(root, sizeof(root)) != 0) {
+        return -1;
+    }
+
+    if (DUUMBI_REALPATH(joined, resolved) != NULL && !duumbi_path_inside_root(root, resolved)) {
+        return -1;
+    }
+
+    char parent[DUUMBI_PATH_BUFFER_LEN];
+    size_t joined_len = strlen(joined);
+    if (joined_len >= sizeof(parent)) {
+        return -1;
+    }
+    memcpy(parent, joined, joined_len + 1);
+    char *slash = strrchr(parent, DUUMBI_PATH_SEP);
+    if (slash == NULL) {
+        return -1;
+    }
+    *slash = '\0';
+    if (DUUMBI_REALPATH(parent, resolved) == NULL || !duumbi_path_inside_root(root, resolved)) {
+        return -1;
+    }
+
+    if (joined_len >= out_len) {
+        return -1;
+    }
+    memcpy(out, joined, joined_len + 1);
+    return 0;
+}
+
+void *duumbi_read_line(void) {
+    size_t capacity = 128;
+    size_t len = 0;
+    char *buffer = (char *)malloc(capacity);
+    if (buffer == NULL) {
+        return duumbi_err_cstr("out of memory");
+    }
+
+    int ch;
+    while ((ch = fgetc(stdin)) != EOF) {
+        if (len + 1 >= capacity) {
+            capacity *= 2;
+            char *grown = (char *)realloc(buffer, capacity);
+            if (grown == NULL) {
+                free(buffer);
+                return duumbi_err_cstr("out of memory");
+            }
+            buffer = grown;
+        }
+        buffer[len++] = (char)ch;
+        if (ch == '\n') {
+            break;
+        }
+    }
+
+    if (ferror(stdin)) {
+        free(buffer);
+        return duumbi_err_cstr("failed to read stdin");
+    }
+    if (len == 0 && ch == EOF) {
+        free(buffer);
+        return duumbi_err_cstr("end of input");
+    }
+    if (len > 0 && buffer[len - 1] == '\n') {
+        len--;
+        if (len > 0 && buffer[len - 1] == '\r') {
+            len--;
+        }
+    }
+    if (!duumbi_utf8_valid(buffer, (uint64_t)len)) {
+        free(buffer);
+        return duumbi_err_cstr("stdin line is not valid UTF-8");
+    }
+
+    void *result = duumbi_ok_string(buffer, (uint64_t)len);
+    free(buffer);
+    return result;
+}
+
+void *duumbi_print_ln(void *ptr) {
+    DuumbiString *s = (DuumbiString *)ptr;
+    if (s == NULL) {
+        return duumbi_err_cstr("print_ln received null string");
+    }
+    if ((s->len > 0 && fwrite(s->data, 1, (size_t)s->len, stdout) != s->len) ||
+        fputc('\n', stdout) == EOF || fflush(stdout) != 0) {
+        return duumbi_err_cstr("failed to write stdout");
+    }
+    return duumbi_ok_i64(0);
+}
+
+void *duumbi_file_read(void *path_ptr, int64_t max_bytes) {
+    if (max_bytes < 0) {
+        return duumbi_err_cstr("max_bytes must be non-negative");
+    }
+
+    char path[DUUMBI_PATH_BUFFER_LEN];
+    if (duumbi_resolve_existing_workspace_path(path_ptr, path, sizeof(path)) != 0) {
+        return duumbi_err_cstr("path is outside the workspace or does not exist");
+    }
+
+    FILE *file = fopen(path, "rb");
+    if (file == NULL) {
+        return duumbi_err_cstr("failed to open file");
+    }
+    if (fseek(file, 0, SEEK_END) != 0) {
+        fclose(file);
+        return duumbi_err_cstr("failed to inspect file");
+    }
+    long size = ftell(file);
+    if (size < 0) {
+        fclose(file);
+        return duumbi_err_cstr("failed to inspect file");
+    }
+    if ((int64_t)size > max_bytes) {
+        fclose(file);
+        return duumbi_err_cstr("file exceeds max_bytes");
+    }
+    rewind(file);
+
+    char *buffer = (char *)malloc((size_t)size + 1);
+    if (buffer == NULL) {
+        fclose(file);
+        return duumbi_err_cstr("out of memory");
+    }
+    size_t read = fread(buffer, 1, (size_t)size, file);
+    int read_error = ferror(file);
+    fclose(file);
+    if (read_error || read != (size_t)size) {
+        free(buffer);
+        return duumbi_err_cstr("failed to read file");
+    }
+    if (!duumbi_utf8_valid(buffer, (uint64_t)size)) {
+        free(buffer);
+        return duumbi_err_cstr("file is not valid UTF-8");
+    }
+
+    void *result = duumbi_ok_string(buffer, (uint64_t)size);
+    free(buffer);
+    return result;
+}
+
+void *duumbi_file_write(void *path_ptr, void *contents_ptr) {
+    DuumbiString *contents = (DuumbiString *)contents_ptr;
+    if (contents == NULL) {
+        return duumbi_err_cstr("write_file received null contents");
+    }
+
+    char path[DUUMBI_PATH_BUFFER_LEN];
+    if (duumbi_resolve_write_workspace_path(path_ptr, path, sizeof(path)) != 0) {
+        return duumbi_err_cstr("path is outside the workspace");
+    }
+
+    FILE *file = fopen(path, "wb");
+    if (file == NULL) {
+        return duumbi_err_cstr("failed to open file for writing");
+    }
+    size_t written = fwrite(contents->data, 1, (size_t)contents->len, file);
+    int close_error = fclose(file);
+    if (written != contents->len || close_error != 0) {
+        return duumbi_err_cstr("failed to write file");
+    }
+    return duumbi_ok_i64(0);
+}
+
+void *duumbi_file_exists(void *path_ptr) {
+    char raw[DUUMBI_PATH_BUFFER_LEN];
+    char normalized[DUUMBI_PATH_BUFFER_LEN];
+    char joined[DUUMBI_PATH_BUFFER_LEN];
+    char root[DUUMBI_PATH_BUFFER_LEN];
+    char resolved[DUUMBI_PATH_BUFFER_LEN];
+
+    if (duumbi_string_to_cstr(path_ptr, raw, sizeof(raw)) != 0 ||
+        duumbi_normalize_relative_path(raw, normalized, sizeof(normalized)) != 0 ||
+        duumbi_join_workspace_path(normalized, joined, sizeof(joined)) != 0 ||
+        duumbi_canonical_workspace_root(root, sizeof(root)) != 0) {
+        return duumbi_err_cstr("path is outside the workspace");
+    }
+    if (DUUMBI_REALPATH(joined, resolved) == NULL) {
+        return duumbi_ok_bool(0);
+    }
+    if (!duumbi_path_inside_root(root, resolved)) {
+        return duumbi_err_cstr("path is outside the workspace");
+    }
+    return duumbi_ok_bool(1);
+}
+
+static int duumbi_compare_names(const void *a, const void *b) {
+    const char *const *sa = (const char *const *)a;
+    const char *const *sb = (const char *const *)b;
+    return strcmp(*sa, *sb);
+}
+
+void *duumbi_list_dir(void *path_ptr) {
+    char path[DUUMBI_PATH_BUFFER_LEN];
+    if (duumbi_resolve_existing_workspace_path(path_ptr, path, sizeof(path)) != 0) {
+        return duumbi_err_cstr("path is outside the workspace or does not exist");
+    }
+
+    DIR *dir = opendir(path);
+    if (dir == NULL) {
+        return duumbi_err_cstr("failed to open directory");
+    }
+
+    size_t count = 0;
+    size_t capacity = 8;
+    char **names = (char **)calloc(capacity, sizeof(char *));
+    if (names == NULL) {
+        closedir(dir);
+        return duumbi_err_cstr("out of memory");
+    }
+
+    struct dirent *entry;
+    while ((entry = readdir(dir)) != NULL) {
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
+            continue;
+        }
+        size_t len = strlen(entry->d_name);
+        if (!duumbi_utf8_valid(entry->d_name, (uint64_t)len)) {
+            closedir(dir);
+            for (size_t i = 0; i < count; i++) free(names[i]);
+            free(names);
+            return duumbi_err_cstr("directory entry is not valid UTF-8");
+        }
+        if (count == capacity) {
+            capacity *= 2;
+            char **grown = (char **)realloc(names, capacity * sizeof(char *));
+            if (grown == NULL) {
+                closedir(dir);
+                for (size_t i = 0; i < count; i++) free(names[i]);
+                free(names);
+                return duumbi_err_cstr("out of memory");
+            }
+            names = grown;
+        }
+        names[count] = (char *)malloc(len + 1);
+        if (names[count] == NULL) {
+            closedir(dir);
+            for (size_t i = 0; i < count; i++) free(names[i]);
+            free(names);
+            return duumbi_err_cstr("out of memory");
+        }
+        memcpy(names[count], entry->d_name, len + 1);
+        count++;
+    }
+    closedir(dir);
+    qsort(names, count, sizeof(char *), duumbi_compare_names);
+
+    void *array = duumbi_array_new(8);
+    for (size_t i = 0; i < count; i++) {
+        void *name = duumbi_string_new(names[i], (uint64_t)strlen(names[i]));
+        array = duumbi_array_push(array, (int64_t)(intptr_t)name);
+        free(names[i]);
+    }
+    free(names);
+    return duumbi_result_new_ok((int64_t)(intptr_t)array);
+}
+
+void *duumbi_path_join(void *left_ptr, void *right_ptr) {
+    char left[DUUMBI_PATH_BUFFER_LEN];
+    char right[DUUMBI_PATH_BUFFER_LEN];
+    char joined[DUUMBI_PATH_BUFFER_LEN];
+    char normalized[DUUMBI_PATH_BUFFER_LEN];
+
+    if (duumbi_string_to_cstr(left_ptr, left, sizeof(left)) != 0 ||
+        duumbi_string_to_cstr(right_ptr, right, sizeof(right)) != 0) {
+        return duumbi_err_cstr("path_join components must be non-empty");
+    }
+    int written = snprintf(joined, sizeof(joined), "%s/%s", left, right);
+    if (written < 0 || (size_t)written >= sizeof(joined) ||
+        duumbi_normalize_relative_path(joined, normalized, sizeof(normalized)) != 0) {
+        return duumbi_err_cstr("path_join produced an invalid path");
+    }
+    return duumbi_ok_string(normalized, (uint64_t)strlen(normalized));
 }

--- a/runtime/duumbi_runtime.c
+++ b/runtime/duumbi_runtime.c
@@ -10,16 +10,19 @@
 #if defined(_WIN32)
 #include <direct.h>
 #include <io.h>
+#include <process.h>
 #include <windows.h>
 #define DUUMBI_MKDIR(path) _mkdir(path)
 #define DUUMBI_PATH_SEP '\\'
 #define DUUMBI_REALPATH(path, resolved) _fullpath((resolved), (path), DUUMBI_PATH_BUFFER_LEN)
+#define DUUMBI_PROCESS_ID() _getpid()
 #else
 #include <dirent.h>
 #include <unistd.h>
 #define DUUMBI_MKDIR(path) mkdir(path, 0777)
 #define DUUMBI_PATH_SEP '/'
 #define DUUMBI_REALPATH(path, resolved) realpath((path), (resolved))
+#define DUUMBI_PROCESS_ID() getpid()
 #endif
 
 #ifndef S_IFMT
@@ -49,6 +52,7 @@
 #define DUUMBI_TRACE_SCHEMA_VERSION "duumbi.telemetry.trace.v1"
 #define DUUMBI_CRASH_SCHEMA_VERSION "duumbi.telemetry.crash.v1"
 #define DUUMBI_PATH_BUFFER_LEN 4096
+#define DUUMBI_STDIN_LINE_MAX 65536
 #define DUUMBI_TRACE_STACK_LIMIT 1024
 #define DUUMBI_WORKSPACE_ROOT_ENV "DUUMBI_WORKSPACE_ROOT"
 
@@ -1003,26 +1007,45 @@ static int duumbi_resolve_write_workspace_path(void *path_ptr, char *out, size_t
         return -1;
     }
 
+    char *target_name = strrchr(joined, DUUMBI_PATH_SEP);
+    if (target_name == NULL || target_name[1] == '\0') {
+        return -1;
+    }
+    target_name++;
+
     char parent[DUUMBI_PATH_BUFFER_LEN];
-    size_t joined_len = strlen(joined);
-    if (joined_len >= sizeof(parent)) {
+    size_t parent_len = (size_t)((target_name - 1) - joined);
+    if (parent_len == 0 || parent_len >= sizeof(parent)) {
         return -1;
     }
-    memcpy(parent, joined, joined_len + 1);
-    char *slash = strrchr(parent, DUUMBI_PATH_SEP);
-    if (slash == NULL) {
-        return -1;
-    }
-    *slash = '\0';
+    memcpy(parent, joined, parent_len);
+    parent[parent_len] = '\0';
+
     if (DUUMBI_REALPATH(parent, resolved) == NULL || !duumbi_path_inside_root(root, resolved)) {
         return -1;
     }
 
-    if (joined_len >= out_len) {
+    int written = snprintf(out, out_len, "%s%c%s", resolved, DUUMBI_PATH_SEP, target_name);
+    if (written < 0 || (size_t)written >= out_len) {
         return -1;
     }
-    memcpy(out, joined, joined_len + 1);
     return 0;
+}
+
+static int duumbi_temp_write_path(const char *path, char *out, size_t out_len) {
+    int written = snprintf(out, out_len, "%s.tmp.%ld", path, (long)DUUMBI_PROCESS_ID());
+    if (written < 0 || (size_t)written >= out_len) {
+        return -1;
+    }
+    return 0;
+}
+
+static int duumbi_replace_file(const char *tmp_path, const char *target_path) {
+#if defined(_WIN32)
+    return MoveFileExA(tmp_path, target_path, MOVEFILE_REPLACE_EXISTING) ? 0 : -1;
+#else
+    return rename(tmp_path, target_path) == 0 ? 0 : -1;
+#endif
 }
 
 void *duumbi_read_line(void) {
@@ -1035,13 +1058,26 @@ void *duumbi_read_line(void) {
 
     int ch;
     while ((ch = fgetc(stdin)) != EOF) {
+        if (len >= DUUMBI_STDIN_LINE_MAX) {
+            free(buffer);
+            return duumbi_err_cstr("stdin_line_too_long: stdin line exceeds 65536 bytes");
+        }
         if (len + 1 >= capacity) {
-            capacity *= 2;
-            char *grown = (char *)realloc(buffer, capacity);
+            size_t max_capacity = DUUMBI_STDIN_LINE_MAX + 1;
+            size_t next_capacity = capacity * 2;
+            if (next_capacity < capacity || next_capacity > max_capacity) {
+                next_capacity = max_capacity;
+            }
+            if (next_capacity <= capacity) {
+                free(buffer);
+                return duumbi_err_cstr("stdin_line_too_long: stdin line exceeds 65536 bytes");
+            }
+            char *grown = (char *)realloc(buffer, next_capacity);
             if (grown == NULL) {
                 free(buffer);
                 return duumbi_err_cstr("io_error: out of memory");
             }
+            capacity = next_capacity;
             buffer = grown;
         }
         buffer[len++] = (char)ch;
@@ -1164,14 +1200,31 @@ void *duumbi_file_write(void *path_ptr, void *contents_ptr) {
         return duumbi_err_cstr("path_policy: path is outside the workspace");
     }
 
-    FILE *file = fopen(path, "wb");
+    char tmp_path[DUUMBI_PATH_BUFFER_LEN];
+    if (duumbi_temp_write_path(path, tmp_path, sizeof(tmp_path)) != 0) {
+        return duumbi_err_cstr("path_policy: temporary file path is too long");
+    }
+
+    remove(tmp_path);
+    FILE *file = fopen(tmp_path, "wbx");
     if (file == NULL) {
         return duumbi_err_cstr("io_error: failed to open file for writing");
     }
+    if ((uint64_t)(size_t)contents->len != contents->len) {
+        fclose(file);
+        remove(tmp_path);
+        return duumbi_err_cstr("io_error: file contents are too large to write");
+    }
     size_t written = fwrite(contents->data, 1, (size_t)contents->len, file);
+    int write_error = ferror(file);
     int close_error = fclose(file);
-    if (written != contents->len || close_error != 0) {
+    if (written != (size_t)contents->len || write_error || close_error != 0) {
+        remove(tmp_path);
         return duumbi_err_cstr("io_error: failed to write file");
+    }
+    if (duumbi_replace_file(tmp_path, path) != 0) {
+        remove(tmp_path);
+        return duumbi_err_cstr("io_error: failed to replace file");
     }
     return duumbi_ok_i64(0);
 }

--- a/runtime/duumbi_runtime.c
+++ b/runtime/duumbi_runtime.c
@@ -1254,6 +1254,10 @@ void *duumbi_file_exists(void *path_ptr) {
     if (!duumbi_path_inside_root(root, resolved)) {
         return duumbi_err_cstr("path_policy: path is outside the workspace");
     }
+    struct stat st;
+    if (stat(resolved, &st) != 0) {
+        return duumbi_ok_bool(0);
+    }
     return duumbi_ok_bool(1);
 }
 

--- a/runtime/duumbi_runtime.c
+++ b/runtime/duumbi_runtime.c
@@ -22,6 +22,22 @@
 #define DUUMBI_REALPATH(path, resolved) realpath((path), (resolved))
 #endif
 
+#ifndef S_IFMT
+#define S_IFMT _S_IFMT
+#endif
+#ifndef S_IFREG
+#define S_IFREG _S_IFREG
+#endif
+#ifndef S_IFDIR
+#define S_IFDIR _S_IFDIR
+#endif
+#ifndef S_ISREG
+#define S_ISREG(mode) (((mode) & S_IFMT) == S_IFREG)
+#endif
+#ifndef S_ISDIR
+#define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
+#endif
+
 #if defined(_MSC_VER)
 #define DUUMBI_THREAD_LOCAL __declspec(thread)
 #else
@@ -814,6 +830,11 @@ static int duumbi_string_to_cstr(void *ptr, char *out, size_t out_len) {
     if (s == NULL || s->len == 0 || s->len >= out_len) {
         return -1;
     }
+    for (uint64_t i = 0; i < s->len; i++) {
+        if (s->data[i] == '\0') {
+            return -1;
+        }
+    }
     memcpy(out, s->data, (size_t)s->len);
     out[s->len] = '\0';
     return 0;
@@ -881,6 +902,11 @@ static int duumbi_join_workspace_path(const char *normalized, char *out, size_t 
     return 0;
 }
 
+static int duumbi_workspace_root_available(void) {
+    const char *root = getenv(DUUMBI_WORKSPACE_ROOT_ENV);
+    return root != NULL && root[0] != '\0';
+}
+
 static int duumbi_canonical_workspace_root(char *out, size_t out_len) {
     const char *root = getenv(DUUMBI_WORKSPACE_ROOT_ENV);
     if (root == NULL || root[0] == '\0') {
@@ -904,6 +930,35 @@ static int duumbi_path_inside_root(const char *root, const char *path) {
         return 0;
     }
     return path[root_len] == '\0' || path[root_len] == '/' || path[root_len] == '\\';
+}
+
+static int duumbi_nearest_existing_parent_inside_root(const char *joined, const char *root) {
+    char probe[DUUMBI_PATH_BUFFER_LEN];
+    char resolved[DUUMBI_PATH_BUFFER_LEN];
+    size_t joined_len = strlen(joined);
+    if (joined_len == 0 || joined_len >= sizeof(probe)) {
+        return 0;
+    }
+    memcpy(probe, joined, joined_len + 1);
+
+    while (1) {
+        char *slash = strrchr(probe, DUUMBI_PATH_SEP);
+        if (slash == NULL) {
+            return 0;
+        }
+        if (slash == probe) {
+            probe[1] = '\0';
+        } else {
+            *slash = '\0';
+        }
+
+        if (DUUMBI_REALPATH(probe, resolved) != NULL) {
+            return duumbi_path_inside_root(root, resolved);
+        }
+        if (slash == probe) {
+            return 0;
+        }
+    }
 }
 
 static int duumbi_resolve_existing_workspace_path(void *path_ptr, char *out, size_t out_len) {
@@ -975,7 +1030,7 @@ void *duumbi_read_line(void) {
     size_t len = 0;
     char *buffer = (char *)malloc(capacity);
     if (buffer == NULL) {
-        return duumbi_err_cstr("out of memory");
+        return duumbi_err_cstr("io_error: out of memory");
     }
 
     int ch;
@@ -985,7 +1040,7 @@ void *duumbi_read_line(void) {
             char *grown = (char *)realloc(buffer, capacity);
             if (grown == NULL) {
                 free(buffer);
-                return duumbi_err_cstr("out of memory");
+                return duumbi_err_cstr("io_error: out of memory");
             }
             buffer = grown;
         }
@@ -997,11 +1052,11 @@ void *duumbi_read_line(void) {
 
     if (ferror(stdin)) {
         free(buffer);
-        return duumbi_err_cstr("failed to read stdin");
+        return duumbi_err_cstr("io_error: failed to read stdin");
     }
     if (len == 0 && ch == EOF) {
         free(buffer);
-        return duumbi_err_cstr("end of input");
+        return duumbi_err_cstr("stdin_eof: end of input");
     }
     if (len > 0 && buffer[len - 1] == '\n') {
         len--;
@@ -1011,7 +1066,7 @@ void *duumbi_read_line(void) {
     }
     if (!duumbi_utf8_valid(buffer, (uint64_t)len)) {
         free(buffer);
-        return duumbi_err_cstr("stdin line is not valid UTF-8");
+        return duumbi_err_cstr("stdin_invalid_utf8: stdin line is not valid UTF-8");
     }
 
     void *result = duumbi_ok_string(buffer, (uint64_t)len);
@@ -1022,59 +1077,69 @@ void *duumbi_read_line(void) {
 void *duumbi_print_ln(void *ptr) {
     DuumbiString *s = (DuumbiString *)ptr;
     if (s == NULL) {
-        return duumbi_err_cstr("print_ln received null string");
+        return duumbi_err_cstr("io_error: print_ln received null string");
     }
     if ((s->len > 0 && fwrite(s->data, 1, (size_t)s->len, stdout) != s->len) ||
         fputc('\n', stdout) == EOF || fflush(stdout) != 0) {
-        return duumbi_err_cstr("failed to write stdout");
+        return duumbi_err_cstr("stdout_write_failed: failed to write stdout");
     }
     return duumbi_ok_i64(0);
 }
 
 void *duumbi_file_read(void *path_ptr, int64_t max_bytes) {
     if (max_bytes < 0) {
-        return duumbi_err_cstr("max_bytes must be non-negative");
+        return duumbi_err_cstr("byte_limit: max_bytes must be non-negative");
+    }
+    if (!duumbi_workspace_root_available()) {
+        return duumbi_err_cstr("workspace_root_unavailable: DUUMBI_WORKSPACE_ROOT is not set");
     }
 
     char path[DUUMBI_PATH_BUFFER_LEN];
     if (duumbi_resolve_existing_workspace_path(path_ptr, path, sizeof(path)) != 0) {
-        return duumbi_err_cstr("path is outside the workspace or does not exist");
+        return duumbi_err_cstr("path_policy: path is outside the workspace or does not exist");
+    }
+    struct stat st;
+    if (stat(path, &st) != 0) {
+        return duumbi_err_cstr("io_error: failed to inspect file");
+    }
+    if (!S_ISREG(st.st_mode)) {
+        return duumbi_err_cstr("not_file: path is not a file");
     }
 
     FILE *file = fopen(path, "rb");
     if (file == NULL) {
-        return duumbi_err_cstr("failed to open file");
+        return duumbi_err_cstr("io_error: failed to open file");
     }
     if (fseek(file, 0, SEEK_END) != 0) {
         fclose(file);
-        return duumbi_err_cstr("failed to inspect file");
+        return duumbi_err_cstr("io_error: failed to inspect file");
     }
     long size = ftell(file);
     if (size < 0) {
         fclose(file);
-        return duumbi_err_cstr("failed to inspect file");
+        return duumbi_err_cstr("io_error: failed to inspect file");
     }
     if ((int64_t)size > max_bytes) {
         fclose(file);
-        return duumbi_err_cstr("file exceeds max_bytes");
+        return duumbi_err_cstr("byte_limit: file exceeds max_bytes");
     }
     rewind(file);
 
     char *buffer = (char *)malloc((size_t)size + 1);
     if (buffer == NULL) {
         fclose(file);
-        return duumbi_err_cstr("out of memory");
+        return duumbi_err_cstr("io_error: out of memory");
     }
     size_t read = fread(buffer, 1, (size_t)size, file);
     int read_error = ferror(file);
     fclose(file);
     if (read_error || read != (size_t)size) {
         free(buffer);
-        return duumbi_err_cstr("failed to read file");
+        return duumbi_err_cstr("io_error: failed to read file");
     }
     if (!duumbi_utf8_valid(buffer, (uint64_t)size)) {
         free(buffer);
-        return duumbi_err_cstr("file is not valid UTF-8");
+        return duumbi_err_cstr("invalid_utf8: file is not valid UTF-8");
     }
 
     void *result = duumbi_ok_string(buffer, (uint64_t)size);
@@ -1085,22 +1150,28 @@ void *duumbi_file_read(void *path_ptr, int64_t max_bytes) {
 void *duumbi_file_write(void *path_ptr, void *contents_ptr) {
     DuumbiString *contents = (DuumbiString *)contents_ptr;
     if (contents == NULL) {
-        return duumbi_err_cstr("write_file received null contents");
+        return duumbi_err_cstr("io_error: write_file received null contents");
+    }
+    if (!duumbi_utf8_valid(contents->data, contents->len)) {
+        return duumbi_err_cstr("invalid_utf8: write_file contents are not valid UTF-8");
+    }
+    if (!duumbi_workspace_root_available()) {
+        return duumbi_err_cstr("workspace_root_unavailable: DUUMBI_WORKSPACE_ROOT is not set");
     }
 
     char path[DUUMBI_PATH_BUFFER_LEN];
     if (duumbi_resolve_write_workspace_path(path_ptr, path, sizeof(path)) != 0) {
-        return duumbi_err_cstr("path is outside the workspace");
+        return duumbi_err_cstr("path_policy: path is outside the workspace");
     }
 
     FILE *file = fopen(path, "wb");
     if (file == NULL) {
-        return duumbi_err_cstr("failed to open file for writing");
+        return duumbi_err_cstr("io_error: failed to open file for writing");
     }
     size_t written = fwrite(contents->data, 1, (size_t)contents->len, file);
     int close_error = fclose(file);
     if (written != contents->len || close_error != 0) {
-        return duumbi_err_cstr("failed to write file");
+        return duumbi_err_cstr("io_error: failed to write file");
     }
     return duumbi_ok_i64(0);
 }
@@ -1112,17 +1183,23 @@ void *duumbi_file_exists(void *path_ptr) {
     char root[DUUMBI_PATH_BUFFER_LEN];
     char resolved[DUUMBI_PATH_BUFFER_LEN];
 
+    if (!duumbi_workspace_root_available()) {
+        return duumbi_err_cstr("workspace_root_unavailable: DUUMBI_WORKSPACE_ROOT is not set");
+    }
     if (duumbi_string_to_cstr(path_ptr, raw, sizeof(raw)) != 0 ||
         duumbi_normalize_relative_path(raw, normalized, sizeof(normalized)) != 0 ||
         duumbi_join_workspace_path(normalized, joined, sizeof(joined)) != 0 ||
         duumbi_canonical_workspace_root(root, sizeof(root)) != 0) {
-        return duumbi_err_cstr("path is outside the workspace");
+        return duumbi_err_cstr("path_policy: path is outside the workspace");
     }
     if (DUUMBI_REALPATH(joined, resolved) == NULL) {
+        if (!duumbi_nearest_existing_parent_inside_root(joined, root)) {
+            return duumbi_err_cstr("path_policy: path is outside the workspace");
+        }
         return duumbi_ok_bool(0);
     }
     if (!duumbi_path_inside_root(root, resolved)) {
-        return duumbi_err_cstr("path is outside the workspace");
+        return duumbi_err_cstr("path_policy: path is outside the workspace");
     }
     return duumbi_ok_bool(1);
 }
@@ -1169,16 +1246,27 @@ static void duumbi_free_dir_names(char **names, size_t count) {
 }
 
 void *duumbi_list_dir(void *path_ptr) {
+    if (!duumbi_workspace_root_available()) {
+        return duumbi_err_cstr("workspace_root_unavailable: DUUMBI_WORKSPACE_ROOT is not set");
+    }
+
     char path[DUUMBI_PATH_BUFFER_LEN];
     if (duumbi_resolve_existing_workspace_path(path_ptr, path, sizeof(path)) != 0) {
-        return duumbi_err_cstr("path is outside the workspace or does not exist");
+        return duumbi_err_cstr("path_policy: path is outside the workspace or does not exist");
+    }
+    struct stat st;
+    if (stat(path, &st) != 0) {
+        return duumbi_err_cstr("io_error: failed to inspect directory");
+    }
+    if (!S_ISDIR(st.st_mode)) {
+        return duumbi_err_cstr("not_directory: path is not a directory");
     }
 
     size_t count = 0;
     size_t capacity = 8;
     char **names = (char **)calloc(capacity, sizeof(char *));
     if (names == NULL) {
-        return duumbi_err_cstr("out of memory");
+        return duumbi_err_cstr("io_error: out of memory");
     }
 
 #if defined(_WIN32)
@@ -1186,20 +1274,20 @@ void *duumbi_list_dir(void *path_ptr) {
     int written = snprintf(pattern, sizeof(pattern), "%s\\*", path);
     if (written < 0 || (size_t)written >= sizeof(pattern)) {
         free(names);
-        return duumbi_err_cstr("directory path is too long");
+        return duumbi_err_cstr("path_policy: directory path is too long");
     }
 
     WIN32_FIND_DATAA data;
     HANDLE handle = FindFirstFileA(pattern, &data);
     if (handle == INVALID_HANDLE_VALUE) {
         free(names);
-        return duumbi_err_cstr("failed to open directory");
+        return duumbi_err_cstr("io_error: failed to open directory");
     }
     do {
         if (duumbi_collect_dir_name(&names, &count, &capacity, data.cFileName) != 0) {
             FindClose(handle);
             duumbi_free_dir_names(names, count);
-            return duumbi_err_cstr("failed to read directory entry");
+            return duumbi_err_cstr("invalid_utf8: failed to read directory entry");
         }
     } while (FindNextFileA(handle, &data) != 0);
     FindClose(handle);
@@ -1207,7 +1295,7 @@ void *duumbi_list_dir(void *path_ptr) {
     DIR *dir = opendir(path);
     if (dir == NULL) {
         free(names);
-        return duumbi_err_cstr("failed to open directory");
+        return duumbi_err_cstr("io_error: failed to open directory");
     }
 
     struct dirent *entry;
@@ -1215,7 +1303,7 @@ void *duumbi_list_dir(void *path_ptr) {
         if (duumbi_collect_dir_name(&names, &count, &capacity, entry->d_name) != 0) {
             closedir(dir);
             duumbi_free_dir_names(names, count);
-            return duumbi_err_cstr("failed to read directory entry");
+            return duumbi_err_cstr("invalid_utf8: failed to read directory entry");
         }
     }
     closedir(dir);
@@ -1239,12 +1327,12 @@ void *duumbi_path_join(void *left_ptr, void *right_ptr) {
 
     if (duumbi_string_to_cstr(left_ptr, left, sizeof(left)) != 0 ||
         duumbi_string_to_cstr(right_ptr, right, sizeof(right)) != 0) {
-        return duumbi_err_cstr("path_join components must be non-empty");
+        return duumbi_err_cstr("path_policy: path_join components must be non-empty");
     }
     int written = snprintf(joined, sizeof(joined), "%s/%s", left, right);
     if (written < 0 || (size_t)written >= sizeof(joined) ||
         duumbi_normalize_relative_path(joined, normalized, sizeof(normalized)) != 0) {
-        return duumbi_err_cstr("path_join produced an invalid path");
+        return duumbi_err_cstr("path_policy: path_join produced an invalid path");
     }
     return duumbi_ok_string(normalized, (uint64_t)strlen(normalized));
 }

--- a/runtime/duumbi_runtime.c
+++ b/runtime/duumbi_runtime.c
@@ -10,6 +10,7 @@
 #if defined(_WIN32)
 #include <direct.h>
 #include <io.h>
+#include <windows.h>
 #define DUUMBI_MKDIR(path) _mkdir(path)
 #define DUUMBI_PATH_SEP '\\'
 #define DUUMBI_REALPATH(path, resolved) _fullpath((resolved), (path), DUUMBI_PATH_BUFFER_LEN)
@@ -1132,68 +1133,101 @@ static int duumbi_compare_names(const void *a, const void *b) {
     return strcmp(*sa, *sb);
 }
 
+static int duumbi_collect_dir_name(char ***names,
+                                   size_t *count,
+                                   size_t *capacity,
+                                   const char *name) {
+    if (strcmp(name, ".") == 0 || strcmp(name, "..") == 0) {
+        return 0;
+    }
+    size_t len = strlen(name);
+    if (!duumbi_utf8_valid(name, (uint64_t)len)) {
+        return -1;
+    }
+    if (*count == *capacity) {
+        *capacity *= 2;
+        char **grown = (char **)realloc(*names, *capacity * sizeof(char *));
+        if (grown == NULL) {
+            return -1;
+        }
+        *names = grown;
+    }
+    (*names)[*count] = (char *)malloc(len + 1);
+    if ((*names)[*count] == NULL) {
+        return -1;
+    }
+    memcpy((*names)[*count], name, len + 1);
+    (*count)++;
+    return 0;
+}
+
+static void duumbi_free_dir_names(char **names, size_t count) {
+    for (size_t i = 0; i < count; i++) {
+        free(names[i]);
+    }
+    free(names);
+}
+
 void *duumbi_list_dir(void *path_ptr) {
     char path[DUUMBI_PATH_BUFFER_LEN];
     if (duumbi_resolve_existing_workspace_path(path_ptr, path, sizeof(path)) != 0) {
         return duumbi_err_cstr("path is outside the workspace or does not exist");
     }
 
-    DIR *dir = opendir(path);
-    if (dir == NULL) {
-        return duumbi_err_cstr("failed to open directory");
-    }
-
     size_t count = 0;
     size_t capacity = 8;
     char **names = (char **)calloc(capacity, sizeof(char *));
     if (names == NULL) {
-        closedir(dir);
         return duumbi_err_cstr("out of memory");
+    }
+
+#if defined(_WIN32)
+    char pattern[DUUMBI_PATH_BUFFER_LEN];
+    int written = snprintf(pattern, sizeof(pattern), "%s\\*", path);
+    if (written < 0 || (size_t)written >= sizeof(pattern)) {
+        free(names);
+        return duumbi_err_cstr("directory path is too long");
+    }
+
+    WIN32_FIND_DATAA data;
+    HANDLE handle = FindFirstFileA(pattern, &data);
+    if (handle == INVALID_HANDLE_VALUE) {
+        free(names);
+        return duumbi_err_cstr("failed to open directory");
+    }
+    do {
+        if (duumbi_collect_dir_name(&names, &count, &capacity, data.cFileName) != 0) {
+            FindClose(handle);
+            duumbi_free_dir_names(names, count);
+            return duumbi_err_cstr("failed to read directory entry");
+        }
+    } while (FindNextFileA(handle, &data) != 0);
+    FindClose(handle);
+#else
+    DIR *dir = opendir(path);
+    if (dir == NULL) {
+        free(names);
+        return duumbi_err_cstr("failed to open directory");
     }
 
     struct dirent *entry;
     while ((entry = readdir(dir)) != NULL) {
-        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
-            continue;
-        }
-        size_t len = strlen(entry->d_name);
-        if (!duumbi_utf8_valid(entry->d_name, (uint64_t)len)) {
+        if (duumbi_collect_dir_name(&names, &count, &capacity, entry->d_name) != 0) {
             closedir(dir);
-            for (size_t i = 0; i < count; i++) free(names[i]);
-            free(names);
-            return duumbi_err_cstr("directory entry is not valid UTF-8");
+            duumbi_free_dir_names(names, count);
+            return duumbi_err_cstr("failed to read directory entry");
         }
-        if (count == capacity) {
-            capacity *= 2;
-            char **grown = (char **)realloc(names, capacity * sizeof(char *));
-            if (grown == NULL) {
-                closedir(dir);
-                for (size_t i = 0; i < count; i++) free(names[i]);
-                free(names);
-                return duumbi_err_cstr("out of memory");
-            }
-            names = grown;
-        }
-        names[count] = (char *)malloc(len + 1);
-        if (names[count] == NULL) {
-            closedir(dir);
-            for (size_t i = 0; i < count; i++) free(names[i]);
-            free(names);
-            return duumbi_err_cstr("out of memory");
-        }
-        memcpy(names[count], entry->d_name, len + 1);
-        count++;
     }
     closedir(dir);
+#endif
     qsort(names, count, sizeof(char *), duumbi_compare_names);
 
     void *array = duumbi_array_new(8);
     for (size_t i = 0; i < count; i++) {
         void *name = duumbi_string_new(names[i], (uint64_t)strlen(names[i]));
         array = duumbi_array_push(array, (int64_t)(intptr_t)name);
-        free(names[i]);
     }
-    free(names);
+    duumbi_free_dir_names(names, count);
     return duumbi_result_new_ok((int64_t)(intptr_t)array);
 }
 

--- a/runtime/duumbi_runtime.h
+++ b/runtime/duumbi_runtime.h
@@ -23,6 +23,13 @@ void duumbi_print_i64(int64_t val);
 void duumbi_print_f64(double val);
 void duumbi_print_bool(int8_t val);
 void duumbi_print_string(void *ptr);
+void *duumbi_read_line(void);
+void *duumbi_print_ln(void *ptr);
+void *duumbi_file_read(void *path_ptr, int64_t max_bytes);
+void *duumbi_file_write(void *path_ptr, void *contents_ptr);
+void *duumbi_file_exists(void *path_ptr);
+void *duumbi_list_dir(void *path_ptr);
+void *duumbi_path_join(void *left_ptr, void *right_ptr);
 
 /* ── Heap allocation ───────────────────────────────────────────────── */
 

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -509,6 +509,23 @@ mod tests {
     }
 
     #[test]
+    fn init_does_not_install_stdlib_file_by_default() {
+        let tmp = TempDir::new().expect("tempdir");
+        run_init(tmp.path()).expect("init must succeed");
+
+        let d = tmp.path().join(".duumbi");
+        let config = crate::config::load_config(tmp.path()).expect("config must parse");
+        assert!(
+            !config.dependencies.contains_key("@duumbi/stdlib-file"),
+            "stdlib-file must be added explicitly, not by init"
+        );
+        assert!(
+            !d.join("cache/@duumbi/stdlib-file@1.0.0").exists(),
+            "init must not seed stdlib-file cache by default"
+        );
+    }
+
+    #[test]
     fn workspace_name_validation_trims_and_limits_length() {
         assert_eq!(
             validate_workspace_name("  My App  ").expect("valid"),

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -14,7 +14,7 @@ use crate::manifest::ModuleManifest;
 /// Embedded `stdlib/math.jsonld` — abs, max, min, sqrt, pow, mod, clamp, sign.
 const STDLIB_MATH: &str = include_str!("../../stdlib/math.jsonld");
 
-/// Embedded `stdlib/io.jsonld` — print wrappers for i64, f64, bool, string.
+/// Embedded `stdlib/io.jsonld` — print wrappers plus line-oriented Result I/O.
 const STDLIB_IO: &str = include_str!("../../stdlib/io.jsonld");
 
 /// Embedded `stdlib/lang.jsonld` — language utilities (assert_true).
@@ -296,12 +296,14 @@ pub fn run_init_with_options(base: &Path, options: &InitOptions) -> Result<InitS
         ModuleManifest::new(
             "@duumbi/stdlib-io",
             STDLIB_VERSION,
-            "I/O utility functions (print wrappers for i64, f64, bool, string)",
+            "I/O utility functions (print wrappers, read_line, print_ln)",
             vec![
                 "print_i64".to_string(),
                 "print_f64".to_string(),
                 "print_bool".to_string(),
                 "print_string".to_string(),
+                "read_line".to_string(),
+                "print_ln".to_string(),
             ],
         ),
     )

--- a/src/compiler/lowering.rs
+++ b/src/compiler/lowering.rs
@@ -38,6 +38,13 @@ struct RuntimeFuncs {
     print_f64: FuncId,
     print_bool: FuncId,
     print_string: FuncId,
+    read_line: FuncId,
+    print_ln: FuncId,
+    file_read: FuncId,
+    file_write: FuncId,
+    file_exists: FuncId,
+    list_dir: FuncId,
+    path_join: FuncId,
     string_new: FuncId,
     string_free: FuncId,
     string_len: FuncId,
@@ -196,6 +203,13 @@ fn declare_all_runtime_fns(
         print_f64: declare_runtime_fn(module, "duumbi_print_f64", &[f64t], &[])?,
         print_bool: declare_runtime_fn(module, "duumbi_print_bool", &[i8t], &[])?,
         print_string: declare_runtime_fn(module, "duumbi_print_string", &[i64t], &[])?,
+        read_line: declare_runtime_fn(module, "duumbi_read_line", &[], &[i64t])?,
+        print_ln: declare_runtime_fn(module, "duumbi_print_ln", &[i64t], &[i64t])?,
+        file_read: declare_runtime_fn(module, "duumbi_file_read", &[i64t, i64t], &[i64t])?,
+        file_write: declare_runtime_fn(module, "duumbi_file_write", &[i64t, i64t], &[i64t])?,
+        file_exists: declare_runtime_fn(module, "duumbi_file_exists", &[i64t], &[i64t])?,
+        list_dir: declare_runtime_fn(module, "duumbi_list_dir", &[i64t], &[i64t])?,
+        path_join: declare_runtime_fn(module, "duumbi_path_join", &[i64t, i64t], &[i64t])?,
 
         // String functions (ptr = i64)
         string_new: declare_runtime_fn(module, "duumbi_string_new", &[i64t, i64t], &[i64t])?,
@@ -748,6 +762,13 @@ fn compile_function(
     let print_f64_ref = obj_module.declare_func_in_func(runtime.print_f64, builder.func);
     let print_bool_ref = obj_module.declare_func_in_func(runtime.print_bool, builder.func);
     let print_string_ref = obj_module.declare_func_in_func(runtime.print_string, builder.func);
+    let read_line_ref = obj_module.declare_func_in_func(runtime.read_line, builder.func);
+    let print_ln_ref = obj_module.declare_func_in_func(runtime.print_ln, builder.func);
+    let file_read_ref = obj_module.declare_func_in_func(runtime.file_read, builder.func);
+    let file_write_ref = obj_module.declare_func_in_func(runtime.file_write, builder.func);
+    let file_exists_ref = obj_module.declare_func_in_func(runtime.file_exists, builder.func);
+    let list_dir_ref = obj_module.declare_func_in_func(runtime.list_dir, builder.func);
+    let path_join_ref = obj_module.declare_func_in_func(runtime.path_join, builder.func);
     let string_new_ref = obj_module.declare_func_in_func(runtime.string_new, builder.func);
     let string_free_ref = obj_module.declare_func_in_func(runtime.string_free, builder.func);
     let string_len_ref = obj_module.declare_func_in_func(runtime.string_len, builder.func);
@@ -1123,16 +1144,52 @@ fn compile_function(
                     let operand_val = get_unary_operand(graph, node_idx, &value_map)?;
                     builder.ins().call(print_string_ref, &[operand_val]);
                 }
-                Op::ReadLine
-                | Op::PrintLn
-                | Op::ReadFile
-                | Op::WriteFile
-                | Op::FileExists
-                | Op::ListDir
-                | Op::PathJoin => {
-                    return Err(CompileError::Cranelift {
-                        message: format!("{} lowering is not implemented yet", node.op),
-                    });
+                Op::ReadLine => {
+                    let call = builder.ins().call(read_line_ref, &[]);
+                    let result = builder.inst_results(call)[0];
+                    value_map.insert(node.id.clone(), result);
+                }
+                Op::PrintLn => {
+                    let operand_val = get_unary_operand(graph, node_idx, &value_map)?;
+                    let call = builder.ins().call(print_ln_ref, &[operand_val]);
+                    let result = builder.inst_results(call)[0];
+                    value_map.insert(node.id.clone(), result);
+                }
+                Op::ReadFile => {
+                    let (path_val, max_bytes_val) =
+                        get_binary_operands(graph, node_idx, &value_map)?;
+                    let call = builder
+                        .ins()
+                        .call(file_read_ref, &[path_val, max_bytes_val]);
+                    let result = builder.inst_results(call)[0];
+                    value_map.insert(node.id.clone(), result);
+                }
+                Op::WriteFile => {
+                    let (path_val, contents_val) =
+                        get_binary_operands(graph, node_idx, &value_map)?;
+                    let call = builder
+                        .ins()
+                        .call(file_write_ref, &[path_val, contents_val]);
+                    let result = builder.inst_results(call)[0];
+                    value_map.insert(node.id.clone(), result);
+                }
+                Op::FileExists => {
+                    let path_val = get_unary_operand(graph, node_idx, &value_map)?;
+                    let call = builder.ins().call(file_exists_ref, &[path_val]);
+                    let result = builder.inst_results(call)[0];
+                    value_map.insert(node.id.clone(), result);
+                }
+                Op::ListDir => {
+                    let path_val = get_unary_operand(graph, node_idx, &value_map)?;
+                    let call = builder.ins().call(list_dir_ref, &[path_val]);
+                    let result = builder.inst_results(call)[0];
+                    value_map.insert(node.id.clone(), result);
+                }
+                Op::PathJoin => {
+                    let (left_val, right_val) = get_binary_operands(graph, node_idx, &value_map)?;
+                    let call = builder.ins().call(path_join_ref, &[left_val, right_val]);
+                    let result = builder.inst_results(call)[0];
+                    value_map.insert(node.id.clone(), result);
                 }
                 Op::StringConcat => {
                     let (left_val, right_val) = get_binary_operands(graph, node_idx, &value_map)?;

--- a/src/compiler/lowering.rs
+++ b/src/compiler/lowering.rs
@@ -1123,6 +1123,17 @@ fn compile_function(
                     let operand_val = get_unary_operand(graph, node_idx, &value_map)?;
                     builder.ins().call(print_string_ref, &[operand_val]);
                 }
+                Op::ReadLine
+                | Op::PrintLn
+                | Op::ReadFile
+                | Op::WriteFile
+                | Op::FileExists
+                | Op::ListDir
+                | Op::PathJoin => {
+                    return Err(CompileError::Cranelift {
+                        message: format!("{} lowering is not implemented yet", node.op),
+                    });
+                }
                 Op::StringConcat => {
                     let (left_val, right_val) = get_binary_operands(graph, node_idx, &value_map)?;
                     let left_type = get_left_operand_type(graph, node_idx);

--- a/src/compiler/lowering.rs
+++ b/src/compiler/lowering.rs
@@ -1536,13 +1536,23 @@ fn compile_function(
                 Op::ResultUnwrap => {
                     let operand_val = get_unary_operand(graph, node_idx, &value_map)?;
                     let call = builder.ins().call(result_unwrap_ref, &[operand_val]);
-                    let result = builder.inst_results(call)[0];
+                    let payload = builder.inst_results(call)[0];
+                    let result = if node.result_type == Some(DuumbiType::Bool) {
+                        builder.ins().ireduce(types::I8, payload)
+                    } else {
+                        payload
+                    };
                     value_map.insert(node.id.clone(), result);
                 }
                 Op::ResultUnwrapErr => {
                     let operand_val = get_unary_operand(graph, node_idx, &value_map)?;
                     let call = builder.ins().call(result_unwrap_err_ref, &[operand_val]);
-                    let result = builder.inst_results(call)[0];
+                    let payload = builder.inst_results(call)[0];
+                    let result = if node.result_type == Some(DuumbiType::Bool) {
+                        builder.ins().ireduce(types::I8, payload)
+                    } else {
+                        payload
+                    };
                     value_map.insert(node.id.clone(), result);
                 }
 
@@ -1568,7 +1578,12 @@ fn compile_function(
                 Op::OptionUnwrap => {
                     let operand_val = get_unary_operand(graph, node_idx, &value_map)?;
                     let call = builder.ins().call(option_unwrap_ref, &[operand_val]);
-                    let result = builder.inst_results(call)[0];
+                    let payload = builder.inst_results(call)[0];
+                    let result = if node.result_type == Some(DuumbiType::Bool) {
+                        builder.ins().ireduce(types::I8, payload)
+                    } else {
+                        payload
+                    };
                     value_map.insert(node.id.clone(), result);
                 }
 

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -84,7 +84,7 @@ pub struct GraphNode {
 }
 
 /// Edge label in the semantic graph.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[allow(dead_code)] // Phase 1 variants used once compiler handles them
 pub enum GraphEdge {
     /// Left operand of a binary operation.

--- a/src/graph/result_safety.rs
+++ b/src/graph/result_safety.rs
@@ -31,6 +31,13 @@ pub fn has_result_option_ops(graph: &SemanticGraph) -> bool {
                 | Op::OptionIsSome
                 | Op::OptionUnwrap
                 | Op::Match { .. }
+                | Op::ReadLine
+                | Op::PrintLn
+                | Op::ReadFile
+                | Op::WriteFile
+                | Op::FileExists
+                | Op::ListDir
+                | Op::PathJoin
         )
     })
 }
@@ -64,10 +71,7 @@ fn check_unhandled_result_option(
 
     for &node_idx in &block_info.nodes {
         let node = &graph.graph[node_idx];
-        if !matches!(&node.op, Op::Call { .. }) {
-            continue;
-        }
-        let Some(ref result_ty) = node.result_type else {
+        let Some(ref result_ty) = direct_result_or_option_type(node) else {
             continue;
         };
 
@@ -76,7 +80,7 @@ fn check_unhandled_result_option(
                 Diagnostic::error(
                     codes::E030_UNHANDLED_RESULT,
                     format!(
-                        "Unhandled Result: Call '{}' returns '{}' but no Match, \
+                        "Unhandled Result: '{}' returns '{}' but no Match, \
                          ResultIsOk, or ResultUnwrap follows in the same block",
                         node.id, result_ty
                     ),
@@ -88,7 +92,7 @@ fn check_unhandled_result_option(
                 Diagnostic::error(
                     codes::E031_UNHANDLED_OPTION,
                     format!(
-                        "Unhandled Option: Call '{}' returns '{}' but no Match, \
+                        "Unhandled Option: '{}' returns '{}' but no Match, \
                          OptionIsSome, or OptionUnwrap follows in the same block",
                         node.id, result_ty
                     ),
@@ -97,6 +101,26 @@ fn check_unhandled_result_option(
             );
         }
     }
+}
+
+fn direct_result_or_option_type(node: &GraphNode) -> Option<&DuumbiType> {
+    if !matches!(
+        &node.op,
+        Op::Call { .. }
+            | Op::ReadLine
+            | Op::PrintLn
+            | Op::ReadFile
+            | Op::WriteFile
+            | Op::FileExists
+            | Op::ListDir
+            | Op::PathJoin
+    ) {
+        return None;
+    }
+
+    node.result_type
+        .as_ref()
+        .filter(|ty| ty.is_result() || ty.is_option())
 }
 
 /// E034 (WARNING) — Checks that ResultUnwrap/OptionUnwrap are preceded by a guard check.
@@ -346,7 +370,7 @@ fn check_payload_matches(
 /// Collects node IDs that are referenced as operands by handler ops in the block.
 ///
 /// Handler ops are: `ResultIsOk`, `OptionIsSome`, `Match`, `ResultUnwrap`,
-/// `ResultUnwrapErr`, `OptionUnwrap`.
+/// `ResultUnwrapErr`, `OptionUnwrap`, and `Return` for explicit propagation.
 fn collect_handled_ids(
     graph: &SemanticGraph,
     block_info: &BlockInfo,
@@ -363,6 +387,7 @@ fn collect_handled_ids(
                 | Op::ResultUnwrap
                 | Op::ResultUnwrapErr
                 | Op::OptionUnwrap
+                | Op::Return
         );
         if !is_handler {
             continue;

--- a/src/graph/validator.rs
+++ b/src/graph/validator.rs
@@ -193,8 +193,227 @@ fn check_types(graph: &SemanticGraph, diagnostics: &mut Vec<Diagnostic>) {
                     );
                 }
             }
+            Op::ReadLine => {
+                check_exact_result_type(
+                    node,
+                    &result_string_string(),
+                    "ReadLine must return result<string,string>",
+                    diagnostics,
+                );
+            }
+            Op::PrintLn => {
+                check_operand_type(
+                    graph,
+                    node_idx,
+                    node,
+                    GraphEdge::Operand,
+                    &DuumbiType::String,
+                    "PrintLn operand must be string",
+                    diagnostics,
+                );
+                check_exact_result_type(
+                    node,
+                    &result_i64_string(),
+                    "PrintLn must return result<i64,string>",
+                    diagnostics,
+                );
+            }
+            Op::ReadFile => {
+                check_operand_type(
+                    graph,
+                    node_idx,
+                    node,
+                    GraphEdge::Left,
+                    &DuumbiType::String,
+                    "ReadFile path must be string",
+                    diagnostics,
+                );
+                check_operand_type(
+                    graph,
+                    node_idx,
+                    node,
+                    GraphEdge::Right,
+                    &DuumbiType::I64,
+                    "ReadFile maxBytes must be i64",
+                    diagnostics,
+                );
+                check_exact_result_type(
+                    node,
+                    &result_string_string(),
+                    "ReadFile must return result<string,string>",
+                    diagnostics,
+                );
+            }
+            Op::WriteFile => {
+                check_operand_type(
+                    graph,
+                    node_idx,
+                    node,
+                    GraphEdge::Left,
+                    &DuumbiType::String,
+                    "WriteFile path must be string",
+                    diagnostics,
+                );
+                check_operand_type(
+                    graph,
+                    node_idx,
+                    node,
+                    GraphEdge::Right,
+                    &DuumbiType::String,
+                    "WriteFile contents must be string",
+                    diagnostics,
+                );
+                check_exact_result_type(
+                    node,
+                    &result_i64_string(),
+                    "WriteFile must return result<i64,string>",
+                    diagnostics,
+                );
+            }
+            Op::FileExists => {
+                check_operand_type(
+                    graph,
+                    node_idx,
+                    node,
+                    GraphEdge::Operand,
+                    &DuumbiType::String,
+                    "FileExists path must be string",
+                    diagnostics,
+                );
+                check_exact_result_type(
+                    node,
+                    &DuumbiType::Result(Box::new(DuumbiType::Bool), Box::new(DuumbiType::String)),
+                    "FileExists must return result<bool,string>",
+                    diagnostics,
+                );
+            }
+            Op::ListDir => {
+                check_operand_type(
+                    graph,
+                    node_idx,
+                    node,
+                    GraphEdge::Operand,
+                    &DuumbiType::String,
+                    "ListDir path must be string",
+                    diagnostics,
+                );
+                check_exact_result_type(
+                    node,
+                    &DuumbiType::Result(
+                        Box::new(DuumbiType::Array(Box::new(DuumbiType::String))),
+                        Box::new(DuumbiType::String),
+                    ),
+                    "ListDir must return result<array<string>,string>",
+                    diagnostics,
+                );
+            }
+            Op::PathJoin => {
+                check_operand_type(
+                    graph,
+                    node_idx,
+                    node,
+                    GraphEdge::Left,
+                    &DuumbiType::String,
+                    "PathJoin left must be string",
+                    diagnostics,
+                );
+                check_operand_type(
+                    graph,
+                    node_idx,
+                    node,
+                    GraphEdge::Right,
+                    &DuumbiType::String,
+                    "PathJoin right must be string",
+                    diagnostics,
+                );
+                check_exact_result_type(
+                    node,
+                    &result_string_string(),
+                    "PathJoin must return result<string,string>",
+                    diagnostics,
+                );
+            }
             _ => {}
         }
+    }
+}
+
+fn result_string_string() -> DuumbiType {
+    DuumbiType::Result(Box::new(DuumbiType::String), Box::new(DuumbiType::String))
+}
+
+fn result_i64_string() -> DuumbiType {
+    DuumbiType::Result(Box::new(DuumbiType::I64), Box::new(DuumbiType::String))
+}
+
+fn check_exact_result_type(
+    node: &super::GraphNode,
+    expected: &DuumbiType,
+    message: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    if node.result_type.as_ref() == Some(expected) {
+        return;
+    }
+
+    let mut details = HashMap::new();
+    details.insert("expected".to_string(), expected.to_string());
+    details.insert(
+        "found".to_string(),
+        node.result_type
+            .as_ref()
+            .map(ToString::to_string)
+            .unwrap_or_else(|| "<missing>".to_string()),
+    );
+    diagnostics.push(
+        Diagnostic::error(codes::E001_TYPE_MISMATCH, message)
+            .with_node(&node.id)
+            .with_details(details),
+    );
+}
+
+fn check_operand_type(
+    graph: &SemanticGraph,
+    node_idx: petgraph::stable_graph::NodeIndex,
+    node: &super::GraphNode,
+    edge: GraphEdge,
+    expected: &DuumbiType,
+    message: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let mut found_edge = false;
+    for edge_ref in graph
+        .graph
+        .edges_directed(node_idx, petgraph::Direction::Incoming)
+    {
+        if edge_ref.weight() != &edge {
+            continue;
+        }
+        found_edge = true;
+        let source_node = &graph.graph[edge_ref.source()];
+        if let Some(actual_type) = resolve_output_type(source_node)
+            && &actual_type != expected
+        {
+            let mut details = HashMap::new();
+            details.insert("expected".to_string(), expected.to_string());
+            details.insert("found".to_string(), actual_type.to_string());
+            diagnostics.push(
+                Diagnostic::error(codes::E001_TYPE_MISMATCH, message)
+                    .with_node(&node.id)
+                    .with_details(details),
+            );
+        }
+    }
+
+    if !found_edge {
+        let mut details = HashMap::new();
+        details.insert("expected".to_string(), expected.to_string());
+        details.insert("found".to_string(), "<missing>".to_string());
+        diagnostics.push(
+            Diagnostic::error(codes::E009_SCHEMA_INVALID, message)
+                .with_node(&node.id)
+                .with_details(details),
+        );
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -370,13 +370,19 @@ async fn run(cli: Cli) -> Result<i32> {
         }
         Commands::Run { args } => {
             let workspace = PathBuf::from(".");
-            if !workspace.join(".duumbi").exists() {
-                anyhow::bail!("`duumbi run` requires an initialized workspace");
+            if workspace.join(".duumbi").exists() {
+                let output = workspace::run_workspace_binary(&workspace, &args)?;
+                print!("{}", output.stdout);
+                eprint!("{}", output.stderr);
+                return Ok(output.exit_code);
             }
-            let output = workspace::run_workspace_binary(&workspace, &args)?;
-            print!("{}", output.stdout);
-            eprint!("{}", output.stderr);
-            Ok(output.exit_code)
+
+            let output_path = resolve_output(None)?;
+            let status = process::Command::new(&output_path)
+                .args(&args)
+                .status()
+                .with_context(|| format!("Failed to run binary '{}'", output_path.display()))?;
+            Ok(status.code().unwrap_or(-1))
         }
         Commands::Check { input } => {
             let input_path = resolve_input(input.as_deref())?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -370,25 +370,13 @@ async fn run(cli: Cli) -> Result<i32> {
         }
         Commands::Run { args } => {
             let workspace = PathBuf::from(".");
-            if workspace.join(".duumbi").exists() {
-                let output = workspace::run_workspace_binary(&workspace, &args)?;
-                print!("{}", output.stdout);
-                eprint!("{}", output.stderr);
-                Ok(output.exit_code)
-            } else {
-                let binary = resolve_output(None)?;
-                if !binary.exists() {
-                    anyhow::bail!(
-                        "Binary not found at '{}'. Run `duumbi build` first.",
-                        binary.display()
-                    );
-                }
-                let status = process::Command::new(&binary)
-                    .args(&args)
-                    .status()
-                    .with_context(|| format!("Failed to execute '{}'", binary.display()))?;
-                Ok(status.code().unwrap_or(EXIT_FAILURE))
+            if !workspace.join(".duumbi").exists() {
+                anyhow::bail!("`duumbi run` requires an initialized workspace");
             }
+            let output = workspace::run_workspace_binary(&workspace, &args)?;
+            print!("{}", output.stdout);
+            eprint!("{}", output.stderr);
+            Ok(output.exit_code)
         }
         Commands::Check { input } => {
             let input_path = resolve_input(input.as_deref())?;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -569,6 +569,52 @@ fn parse_op(value: &serde_json::Value) -> Result<OpAst, ParseError> {
             ast.operand = Some(operand);
             Ok(ast)
         }
+        "duumbi:ReadLine" => Ok(make_op_ast(
+            NodeId(node_id_str.to_string()),
+            Op::ReadLine,
+            result_type,
+        )),
+        "duumbi:PrintLn" => {
+            let operand = parse_node_ref(value, "duumbi:operand", node_id_str)?;
+            let mut ast = make_op_ast(NodeId(node_id_str.to_string()), Op::PrintLn, result_type);
+            ast.operand = Some(operand);
+            Ok(ast)
+        }
+        "duumbi:ReadFile" => {
+            let left = parse_node_ref(value, "duumbi:path", node_id_str)?;
+            let right = parse_node_ref(value, "duumbi:maxBytes", node_id_str)?;
+            let mut ast = make_op_ast(NodeId(node_id_str.to_string()), Op::ReadFile, result_type);
+            ast.left = Some(left);
+            ast.right = Some(right);
+            Ok(ast)
+        }
+        "duumbi:WriteFile" => {
+            let left = parse_node_ref(value, "duumbi:path", node_id_str)?;
+            let right = parse_node_ref(value, "duumbi:contents", node_id_str)?;
+            let mut ast = make_op_ast(NodeId(node_id_str.to_string()), Op::WriteFile, result_type);
+            ast.left = Some(left);
+            ast.right = Some(right);
+            Ok(ast)
+        }
+        "duumbi:FileExists" | "duumbi:ListDir" => {
+            let operand = parse_node_ref(value, "duumbi:path", node_id_str)?;
+            let op = match at_type {
+                "duumbi:FileExists" => Op::FileExists,
+                "duumbi:ListDir" => Op::ListDir,
+                _ => unreachable!(),
+            };
+            let mut ast = make_op_ast(NodeId(node_id_str.to_string()), op, result_type);
+            ast.operand = Some(operand);
+            Ok(ast)
+        }
+        "duumbi:PathJoin" => {
+            let left = parse_node_ref(value, "duumbi:left", node_id_str)?;
+            let right = parse_node_ref(value, "duumbi:right", node_id_str)?;
+            let mut ast = make_op_ast(NodeId(node_id_str.to_string()), Op::PathJoin, result_type);
+            ast.left = Some(left);
+            ast.right = Some(right);
+            Ok(ast)
+        }
         // -- String ops --
         "duumbi:StringConcat"
         | "duumbi:StringEquals"

--- a/src/types.rs
+++ b/src/types.rs
@@ -89,6 +89,8 @@ impl fmt::Display for CompareOp {
 /// Phase 0 ops: Const, Add, Sub, Mul, Div, Print, Return.
 /// Phase 1 ops: ConstF64, ConstBool, Compare, Branch, Call, Load, Store.
 /// Phase 9a-1 ops: ConstString, String*, Array*, Struct*, PrintString.
+/// DUUMBI-378 ops: ReadLine, PrintLn, ReadFile, WriteFile, FileExists,
+/// ListDir, PathJoin.
 #[derive(Debug, Clone, PartialEq)]
 #[allow(dead_code)] // Variants used as parser/compiler are extended
 pub enum Op {
@@ -133,6 +135,20 @@ pub enum Op {
     Print,
     /// Print string to stdout: `duumbi:PrintString`
     PrintString,
+    /// Read one UTF-8 line from stdin: `duumbi:ReadLine`
+    ReadLine,
+    /// Print a string plus exactly one newline: `duumbi:PrintLn`
+    PrintLn,
+    /// Read a UTF-8 file with an explicit byte bound: `duumbi:ReadFile`
+    ReadFile,
+    /// Overwrite a UTF-8 file: `duumbi:WriteFile`
+    WriteFile,
+    /// Check whether a workspace-confined path exists: `duumbi:FileExists`
+    FileExists,
+    /// List directory entry names deterministically: `duumbi:ListDir`
+    ListDir,
+    /// Join two DUUMBI-relative path components: `duumbi:PathJoin`
+    PathJoin,
     /// Return value from function: `duumbi:Return`
     Return,
 
@@ -305,6 +321,13 @@ impl fmt::Display for Op {
             Op::Store { variable } => write!(f, "Store({variable})"),
             Op::Print => f.write_str("Print"),
             Op::PrintString => f.write_str("PrintString"),
+            Op::ReadLine => f.write_str("ReadLine"),
+            Op::PrintLn => f.write_str("PrintLn"),
+            Op::ReadFile => f.write_str("ReadFile"),
+            Op::WriteFile => f.write_str("WriteFile"),
+            Op::FileExists => f.write_str("FileExists"),
+            Op::ListDir => f.write_str("ListDir"),
+            Op::PathJoin => f.write_str("PathJoin"),
             Op::Return => f.write_str("Return"),
             Op::StringConcat => f.write_str("StringConcat"),
             Op::StringEquals => f.write_str("StringEquals"),
@@ -397,7 +420,14 @@ impl Op {
             | Op::FieldGet { .. }
             | Op::Alloc { .. }
             | Op::Move { .. }
-            | Op::Borrow { .. } => result_type.clone(),
+            | Op::Borrow { .. }
+            | Op::ReadLine
+            | Op::PrintLn
+            | Op::ReadFile
+            | Op::WriteFile
+            | Op::FileExists
+            | Op::ListDir
+            | Op::PathJoin => result_type.clone(),
             Op::Compare(_) | Op::StringEquals | Op::StringContains => Some(DuumbiType::Bool),
             Op::StringCompare(_) => Some(DuumbiType::Bool),
             Op::StringConcat

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -4,6 +4,7 @@
 //! browser-facing surfaces do not need to shell out through `cargo run`.
 
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -216,6 +217,16 @@ fn validate_trace_config(
 /// Runs a compiled workspace binary, capturing stdout and stderr.
 #[must_use = "the captured process output should be inspected"]
 pub fn run_workspace_binary(workspace_root: &Path, args: &[String]) -> Result<BinaryRunOutput> {
+    run_workspace_binary_with_stdin(workspace_root, args, "")
+}
+
+/// Runs a compiled workspace binary with supplied stdin, capturing stdout and stderr.
+#[must_use = "the captured process output should be inspected"]
+pub fn run_workspace_binary_with_stdin(
+    workspace_root: &Path,
+    args: &[String],
+    stdin: &str,
+) -> Result<BinaryRunOutput> {
     let output_path = workspace_output_path(workspace_root);
     if !output_path.exists() {
         anyhow::bail!(
@@ -224,11 +235,27 @@ pub fn run_workspace_binary(workspace_root: &Path, args: &[String]) -> Result<Bi
         );
     }
 
-    let output = std::process::Command::new(&output_path)
+    let mut child = std::process::Command::new(&output_path)
         .args(args)
         .current_dir(workspace_root)
-        .output()
+        .env("DUUMBI_WORKSPACE_ROOT", workspace_root)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
         .with_context(|| format!("Failed to execute '{}'", output_path.display()))?;
+
+    if !stdin.is_empty() {
+        let child_stdin = child.stdin.as_mut().context("Failed to open child stdin")?;
+        child_stdin
+            .write_all(stdin.as_bytes())
+            .context("Failed to write child stdin")?;
+    }
+    drop(child.stdin.take());
+
+    let output = child
+        .wait_with_output()
+        .with_context(|| format!("Failed to wait for '{}'", output_path.display()))?;
 
     Ok(BinaryRunOutput {
         exit_code: output.status.code().unwrap_or(-1),
@@ -257,4 +284,38 @@ fn find_runtime_c() -> Result<PathBuf> {
     let runtime_path = tmp_dir.join("duumbi_runtime.c");
     fs::write(&runtime_path, RUNTIME_C_SOURCE).context("Failed to write embedded runtime")?;
     Ok(runtime_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[cfg(unix)]
+    #[test]
+    fn run_workspace_binary_sets_workspace_root_and_writes_stdin() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().expect("tempdir");
+        let output_path = workspace_output_path(tmp.path());
+        fs::create_dir_all(output_path.parent().expect("output parent")).expect("build dir");
+        fs::write(
+            &output_path,
+            b"#!/bin/sh\nread line\nprintf '%s|%s' \"$DUUMBI_WORKSPACE_ROOT\" \"$line\"\n",
+        )
+        .expect("write script");
+        let mut permissions = fs::metadata(&output_path).expect("metadata").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&output_path, permissions).expect("chmod");
+
+        let output =
+            run_workspace_binary_with_stdin(tmp.path(), &[], "hello\n").expect("run binary");
+
+        assert_eq!(output.exit_code, 0);
+        assert_eq!(
+            output.stdout,
+            format!("{}|hello", tmp.path().display()),
+            "runner must set DUUMBI_WORKSPACE_ROOT and pass stdin"
+        );
+    }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -217,15 +217,30 @@ fn validate_trace_config(
 /// Runs a compiled workspace binary, capturing stdout and stderr.
 #[must_use = "the captured process output should be inspected"]
 pub fn run_workspace_binary(workspace_root: &Path, args: &[String]) -> Result<BinaryRunOutput> {
-    run_workspace_binary_with_stdin(workspace_root, args, "")
+    run_workspace_binary_inner(workspace_root, args, BinaryStdin::Inherit)
 }
 
 /// Runs a compiled workspace binary with supplied stdin, capturing stdout and stderr.
+#[allow(dead_code)] // Public lib API used by integration tests; binary target uses inherited stdin.
 #[must_use = "the captured process output should be inspected"]
 pub fn run_workspace_binary_with_stdin(
     workspace_root: &Path,
     args: &[String],
     stdin: &str,
+) -> Result<BinaryRunOutput> {
+    run_workspace_binary_inner(workspace_root, args, BinaryStdin::Bytes(stdin))
+}
+
+#[allow(dead_code)] // The binary target only constructs inherited stdin.
+enum BinaryStdin<'a> {
+    Inherit,
+    Bytes(&'a str),
+}
+
+fn run_workspace_binary_inner(
+    workspace_root: &Path,
+    args: &[String],
+    stdin: BinaryStdin<'_>,
 ) -> Result<BinaryRunOutput> {
     let output_path = workspace_output_path(workspace_root);
     if !output_path.exists() {
@@ -235,23 +250,36 @@ pub fn run_workspace_binary_with_stdin(
         );
     }
 
-    let mut child = std::process::Command::new(&output_path)
+    let mut command = std::process::Command::new(&output_path);
+    command
         .args(args)
         .current_dir(workspace_root)
         .env("DUUMBI_WORKSPACE_ROOT", workspace_root)
-        .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    match stdin {
+        BinaryStdin::Inherit => {
+            command.stdin(std::process::Stdio::inherit());
+        }
+        BinaryStdin::Bytes(_) => {
+            command.stdin(std::process::Stdio::piped());
+        }
+    }
+
+    let mut child = command
         .spawn()
         .with_context(|| format!("Failed to execute '{}'", output_path.display()))?;
 
-    if !stdin.is_empty() {
-        let child_stdin = child.stdin.as_mut().context("Failed to open child stdin")?;
-        child_stdin
-            .write_all(stdin.as_bytes())
-            .context("Failed to write child stdin")?;
+    if let BinaryStdin::Bytes(input) = stdin {
+        if !input.is_empty() {
+            let child_stdin = child.stdin.as_mut().context("Failed to open child stdin")?;
+            child_stdin
+                .write_all(input.as_bytes())
+                .context("Failed to write child stdin")?;
+        }
+        drop(child.stdin.take());
     }
-    drop(child.stdin.take());
 
     let output = child
         .wait_with_output()
@@ -286,12 +314,11 @@ fn find_runtime_c() -> Result<PathBuf> {
     Ok(runtime_path)
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    #[cfg(unix)]
     #[test]
     fn run_workspace_binary_sets_workspace_root_and_writes_stdin() {
         use std::os::unix::fs::PermissionsExt;

--- a/stdlib/file.jsonld
+++ b/stdlib/file.jsonld
@@ -1,0 +1,142 @@
+{
+  "@context": {"duumbi": "https://duumbi.dev/ns/core#"},
+  "@type": "duumbi:Module",
+  "@id": "duumbi:file",
+  "duumbi:name": "file",
+  "duumbi:exports": ["read_file", "write_file", "file_exists", "list_dir", "path_join"],
+  "duumbi:functions": [
+    {
+      "@type": "duumbi:Function",
+      "@id": "duumbi:file/read_file",
+      "duumbi:name": "read_file",
+      "duumbi:returnType": "result<string,string>",
+      "duumbi:params": [
+        {"duumbi:name": "path", "duumbi:paramType": "string"},
+        {"duumbi:name": "max_bytes", "duumbi:paramType": "i64"}
+      ],
+      "duumbi:blocks": [
+        {
+          "@type": "duumbi:Block",
+          "@id": "duumbi:file/read_file/entry",
+          "duumbi:label": "entry",
+          "duumbi:ops": [
+            {"@type": "duumbi:Load", "@id": "duumbi:file/read_file/entry/0",
+              "duumbi:variable": "path", "duumbi:resultType": "string"},
+            {"@type": "duumbi:Load", "@id": "duumbi:file/read_file/entry/1",
+              "duumbi:variable": "max_bytes", "duumbi:resultType": "i64"},
+            {"@type": "duumbi:ReadFile", "@id": "duumbi:file/read_file/entry/2",
+              "duumbi:path": {"@id": "duumbi:file/read_file/entry/0"},
+              "duumbi:maxBytes": {"@id": "duumbi:file/read_file/entry/1"},
+              "duumbi:resultType": "result<string,string>"},
+            {"@type": "duumbi:Return", "@id": "duumbi:file/read_file/entry/3",
+              "duumbi:operand": {"@id": "duumbi:file/read_file/entry/2"}}
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "duumbi:Function",
+      "@id": "duumbi:file/write_file",
+      "duumbi:name": "write_file",
+      "duumbi:returnType": "result<i64,string>",
+      "duumbi:params": [
+        {"duumbi:name": "path", "duumbi:paramType": "string"},
+        {"duumbi:name": "contents", "duumbi:paramType": "string"}
+      ],
+      "duumbi:blocks": [
+        {
+          "@type": "duumbi:Block",
+          "@id": "duumbi:file/write_file/entry",
+          "duumbi:label": "entry",
+          "duumbi:ops": [
+            {"@type": "duumbi:Load", "@id": "duumbi:file/write_file/entry/0",
+              "duumbi:variable": "path", "duumbi:resultType": "string"},
+            {"@type": "duumbi:Load", "@id": "duumbi:file/write_file/entry/1",
+              "duumbi:variable": "contents", "duumbi:resultType": "string"},
+            {"@type": "duumbi:WriteFile", "@id": "duumbi:file/write_file/entry/2",
+              "duumbi:path": {"@id": "duumbi:file/write_file/entry/0"},
+              "duumbi:contents": {"@id": "duumbi:file/write_file/entry/1"},
+              "duumbi:resultType": "result<i64,string>"},
+            {"@type": "duumbi:Return", "@id": "duumbi:file/write_file/entry/3",
+              "duumbi:operand": {"@id": "duumbi:file/write_file/entry/2"}}
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "duumbi:Function",
+      "@id": "duumbi:file/file_exists",
+      "duumbi:name": "file_exists",
+      "duumbi:returnType": "result<bool,string>",
+      "duumbi:params": [{"duumbi:name": "path", "duumbi:paramType": "string"}],
+      "duumbi:blocks": [
+        {
+          "@type": "duumbi:Block",
+          "@id": "duumbi:file/file_exists/entry",
+          "duumbi:label": "entry",
+          "duumbi:ops": [
+            {"@type": "duumbi:Load", "@id": "duumbi:file/file_exists/entry/0",
+              "duumbi:variable": "path", "duumbi:resultType": "string"},
+            {"@type": "duumbi:FileExists", "@id": "duumbi:file/file_exists/entry/1",
+              "duumbi:path": {"@id": "duumbi:file/file_exists/entry/0"},
+              "duumbi:resultType": "result<bool,string>"},
+            {"@type": "duumbi:Return", "@id": "duumbi:file/file_exists/entry/2",
+              "duumbi:operand": {"@id": "duumbi:file/file_exists/entry/1"}}
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "duumbi:Function",
+      "@id": "duumbi:file/list_dir",
+      "duumbi:name": "list_dir",
+      "duumbi:returnType": "result<array<string>,string>",
+      "duumbi:params": [{"duumbi:name": "path", "duumbi:paramType": "string"}],
+      "duumbi:blocks": [
+        {
+          "@type": "duumbi:Block",
+          "@id": "duumbi:file/list_dir/entry",
+          "duumbi:label": "entry",
+          "duumbi:ops": [
+            {"@type": "duumbi:Load", "@id": "duumbi:file/list_dir/entry/0",
+              "duumbi:variable": "path", "duumbi:resultType": "string"},
+            {"@type": "duumbi:ListDir", "@id": "duumbi:file/list_dir/entry/1",
+              "duumbi:path": {"@id": "duumbi:file/list_dir/entry/0"},
+              "duumbi:resultType": "result<array<string>,string>"},
+            {"@type": "duumbi:Return", "@id": "duumbi:file/list_dir/entry/2",
+              "duumbi:operand": {"@id": "duumbi:file/list_dir/entry/1"}}
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "duumbi:Function",
+      "@id": "duumbi:file/path_join",
+      "duumbi:name": "path_join",
+      "duumbi:returnType": "result<string,string>",
+      "duumbi:params": [
+        {"duumbi:name": "left", "duumbi:paramType": "string"},
+        {"duumbi:name": "right", "duumbi:paramType": "string"}
+      ],
+      "duumbi:blocks": [
+        {
+          "@type": "duumbi:Block",
+          "@id": "duumbi:file/path_join/entry",
+          "duumbi:label": "entry",
+          "duumbi:ops": [
+            {"@type": "duumbi:Load", "@id": "duumbi:file/path_join/entry/0",
+              "duumbi:variable": "left", "duumbi:resultType": "string"},
+            {"@type": "duumbi:Load", "@id": "duumbi:file/path_join/entry/1",
+              "duumbi:variable": "right", "duumbi:resultType": "string"},
+            {"@type": "duumbi:PathJoin", "@id": "duumbi:file/path_join/entry/2",
+              "duumbi:left": {"@id": "duumbi:file/path_join/entry/0"},
+              "duumbi:right": {"@id": "duumbi:file/path_join/entry/1"},
+              "duumbi:resultType": "result<string,string>"},
+            {"@type": "duumbi:Return", "@id": "duumbi:file/path_join/entry/3",
+              "duumbi:operand": {"@id": "duumbi:file/path_join/entry/2"}}
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/stdlib/file.manifest.toml
+++ b/stdlib/file.manifest.toml
@@ -1,0 +1,8 @@
+[module]
+name = "@duumbi/stdlib-file"
+version = "1.0.0"
+description = "Workspace-confined UTF-8 file and path utility functions"
+license = "MPL-2.0"
+
+[exports]
+functions = ["read_file", "write_file", "file_exists", "list_dir", "path_join"]

--- a/stdlib/io.jsonld
+++ b/stdlib/io.jsonld
@@ -3,7 +3,7 @@
   "@type": "duumbi:Module",
   "@id": "duumbi:io",
   "duumbi:name": "io",
-  "duumbi:exports": ["print_i64", "print_f64", "print_bool", "print_string"],
+  "duumbi:exports": ["print_i64", "print_f64", "print_bool", "print_string", "read_line", "print_ln"],
   "duumbi:functions": [
     {
       "@type": "duumbi:Function",
@@ -97,6 +97,48 @@
               "duumbi:value": 0, "duumbi:resultType": "i64"},
             {"@type": "duumbi:Return", "@id": "duumbi:io/print_string/entry/3",
               "duumbi:operand": {"@id": "duumbi:io/print_string/entry/2"}}
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "duumbi:Function",
+      "@id": "duumbi:io/read_line",
+      "duumbi:name": "read_line",
+      "duumbi:returnType": "result<string,string>",
+      "duumbi:blocks": [
+        {
+          "@type": "duumbi:Block",
+          "@id": "duumbi:io/read_line/entry",
+          "duumbi:label": "entry",
+          "duumbi:ops": [
+            {"@type": "duumbi:ReadLine", "@id": "duumbi:io/read_line/entry/0",
+              "duumbi:resultType": "result<string,string>"},
+            {"@type": "duumbi:Return", "@id": "duumbi:io/read_line/entry/1",
+              "duumbi:operand": {"@id": "duumbi:io/read_line/entry/0"}}
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "duumbi:Function",
+      "@id": "duumbi:io/print_ln",
+      "duumbi:name": "print_ln",
+      "duumbi:returnType": "result<i64,string>",
+      "duumbi:params": [{"duumbi:name": "value", "duumbi:paramType": "string"}],
+      "duumbi:blocks": [
+        {
+          "@type": "duumbi:Block",
+          "@id": "duumbi:io/print_ln/entry",
+          "duumbi:label": "entry",
+          "duumbi:ops": [
+            {"@type": "duumbi:Load", "@id": "duumbi:io/print_ln/entry/0",
+              "duumbi:variable": "value", "duumbi:resultType": "string"},
+            {"@type": "duumbi:PrintLn", "@id": "duumbi:io/print_ln/entry/1",
+              "duumbi:operand": {"@id": "duumbi:io/print_ln/entry/0"},
+              "duumbi:resultType": "result<i64,string>"},
+            {"@type": "duumbi:Return", "@id": "duumbi:io/print_ln/entry/2",
+              "duumbi:operand": {"@id": "duumbi:io/print_ln/entry/1"}}
           ]
         }
       ]

--- a/tests/integration_duumbi_378_cycle1.rs
+++ b/tests/integration_duumbi_378_cycle1.rs
@@ -1,0 +1,188 @@
+//! DUUMBI-378 Cycle 1 acceptance coverage:
+//! parser, validator, result-safety, and stdlib metadata.
+
+use duumbi::errors::codes;
+use duumbi::graph::builder::{build_graph, build_graph_no_call_check};
+use duumbi::graph::validator::validate;
+use duumbi::parser::parse_jsonld;
+use duumbi::types::Op;
+
+fn diagnostics_for(jsonld: &str) -> Vec<duumbi::errors::Diagnostic> {
+    let module = parse_jsonld(jsonld).expect("fixture must parse");
+    let graph = build_graph(&module).expect("fixture must build");
+    validate(&graph)
+}
+
+#[test]
+fn stdlib_io_metadata_includes_line_result_apis() {
+    let module = parse_jsonld(include_str!("../stdlib/io.jsonld")).expect("stdlib io must parse");
+    assert!(module.exports.contains(&"read_line".to_string()));
+    assert!(module.exports.contains(&"print_ln".to_string()));
+
+    let graph = build_graph_no_call_check(&module).expect("stdlib io must build");
+    let diagnostics = validate(&graph);
+    assert!(
+        diagnostics.is_empty(),
+        "stdlib io must validate cleanly, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn stdlib_file_metadata_validates() {
+    let module =
+        parse_jsonld(include_str!("../stdlib/file.jsonld")).expect("stdlib file must parse");
+    assert_eq!(
+        module.exports,
+        vec![
+            "read_file".to_string(),
+            "write_file".to_string(),
+            "file_exists".to_string(),
+            "list_dir".to_string(),
+            "path_join".to_string()
+        ]
+    );
+
+    let graph = build_graph_no_call_check(&module).expect("stdlib file must build");
+    let diagnostics = validate(&graph);
+    assert!(
+        diagnostics.is_empty(),
+        "stdlib file must validate cleanly, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn read_file_parses_path_and_max_bytes_fields() {
+    let module =
+        parse_jsonld(include_str!("../stdlib/file.jsonld")).expect("stdlib file must parse");
+    let read_file = module
+        .functions
+        .iter()
+        .find(|function| function.name.0 == "read_file")
+        .expect("read_file function must exist");
+    let op = &read_file.blocks[0].ops[2];
+
+    assert!(matches!(op.op, Op::ReadFile));
+    assert_eq!(
+        op.left.as_ref().expect("path ref").id.0,
+        "duumbi:file/read_file/entry/0"
+    );
+    assert_eq!(
+        op.right.as_ref().expect("maxBytes ref").id.0,
+        "duumbi:file/read_file/entry/1"
+    );
+}
+
+#[test]
+fn read_file_rejects_non_i64_max_bytes() {
+    let diagnostics = diagnostics_for(
+        r#"{
+          "@context": {"duumbi": "https://duumbi.dev/ns/core#"},
+          "@type": "duumbi:Module",
+          "@id": "duumbi:test",
+          "duumbi:name": "test",
+          "duumbi:functions": [{
+            "@type": "duumbi:Function",
+            "@id": "duumbi:test/main",
+            "duumbi:name": "main",
+            "duumbi:returnType": "result<string,string>",
+            "duumbi:blocks": [{
+              "@type": "duumbi:Block",
+              "@id": "duumbi:test/main/entry",
+              "duumbi:label": "entry",
+              "duumbi:ops": [
+                {"@type": "duumbi:Const", "@id": "duumbi:test/main/entry/0",
+                  "duumbi:value": "notes.txt", "duumbi:resultType": "string"},
+                {"@type": "duumbi:Const", "@id": "duumbi:test/main/entry/1",
+                  "duumbi:value": "bad", "duumbi:resultType": "string"},
+                {"@type": "duumbi:ReadFile", "@id": "duumbi:test/main/entry/2",
+                  "duumbi:path": {"@id": "duumbi:test/main/entry/0"},
+                  "duumbi:maxBytes": {"@id": "duumbi:test/main/entry/1"},
+                  "duumbi:resultType": "result<string,string>"},
+                {"@type": "duumbi:Return", "@id": "duumbi:test/main/entry/3",
+                  "duumbi:operand": {"@id": "duumbi:test/main/entry/2"}}
+              ]
+            }]
+          }]
+        }"#,
+    );
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == codes::E001_TYPE_MISMATCH
+                && diagnostic.message.contains("maxBytes")),
+        "ReadFile maxBytes must reject non-i64 input, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn ignored_direct_result_producer_is_rejected() {
+    let diagnostics = diagnostics_for(
+        r#"{
+          "@context": {"duumbi": "https://duumbi.dev/ns/core#"},
+          "@type": "duumbi:Module",
+          "@id": "duumbi:test",
+          "duumbi:name": "test",
+          "duumbi:functions": [{
+            "@type": "duumbi:Function",
+            "@id": "duumbi:test/main",
+            "duumbi:name": "main",
+            "duumbi:returnType": "i64",
+            "duumbi:blocks": [{
+              "@type": "duumbi:Block",
+              "@id": "duumbi:test/main/entry",
+              "duumbi:label": "entry",
+              "duumbi:ops": [
+                {"@type": "duumbi:ReadLine", "@id": "duumbi:test/main/entry/0",
+                  "duumbi:resultType": "result<string,string>"},
+                {"@type": "duumbi:Const", "@id": "duumbi:test/main/entry/1",
+                  "duumbi:value": 0, "duumbi:resultType": "i64"},
+                {"@type": "duumbi:Return", "@id": "duumbi:test/main/entry/2",
+                  "duumbi:operand": {"@id": "duumbi:test/main/entry/1"}}
+              ]
+            }]
+          }]
+        }"#,
+    );
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == codes::E030_UNHANDLED_RESULT),
+        "ignored ReadLine Result must be rejected, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn returned_direct_result_producer_is_accepted() {
+    let diagnostics = diagnostics_for(
+        r#"{
+          "@context": {"duumbi": "https://duumbi.dev/ns/core#"},
+          "@type": "duumbi:Module",
+          "@id": "duumbi:test",
+          "duumbi:name": "test",
+          "duumbi:functions": [{
+            "@type": "duumbi:Function",
+            "@id": "duumbi:test/main",
+            "duumbi:name": "main",
+            "duumbi:returnType": "result<string,string>",
+            "duumbi:blocks": [{
+              "@type": "duumbi:Block",
+              "@id": "duumbi:test/main/entry",
+              "duumbi:label": "entry",
+              "duumbi:ops": [
+                {"@type": "duumbi:ReadLine", "@id": "duumbi:test/main/entry/0",
+                  "duumbi:resultType": "result<string,string>"},
+                {"@type": "duumbi:Return", "@id": "duumbi:test/main/entry/1",
+                  "duumbi:operand": {"@id": "duumbi:test/main/entry/0"}}
+              ]
+            }]
+          }]
+        }"#,
+    );
+
+    assert!(
+        diagnostics.is_empty(),
+        "returned ReadLine Result should be accepted, got {diagnostics:?}"
+    );
+}

--- a/tests/integration_duumbi_378_cycle2.rs
+++ b/tests/integration_duumbi_378_cycle2.rs
@@ -1,0 +1,85 @@
+//! DUUMBI-378 Cycle 2 acceptance coverage:
+//! runtime-op lowering for stdin/stdout and workspace file APIs.
+
+use duumbi::compiler::lowering;
+use duumbi::graph::builder::build_graph;
+use duumbi::parser::parse_jsonld;
+
+#[test]
+fn new_io_and_file_ops_lower_to_native_object() {
+    let module = parse_jsonld(
+        r#"{
+          "@context": {"duumbi": "https://duumbi.dev/ns/core#"},
+          "@type": "duumbi:Module",
+          "@id": "duumbi:test",
+          "duumbi:name": "test",
+          "duumbi:functions": [{
+            "@type": "duumbi:Function",
+            "@id": "duumbi:test/main",
+            "duumbi:name": "main",
+            "duumbi:returnType": "result<array<string>,string>",
+            "duumbi:blocks": [{
+              "@type": "duumbi:Block",
+              "@id": "duumbi:test/main/entry",
+              "duumbi:label": "entry",
+              "duumbi:ops": [
+                {"@type": "duumbi:Const", "@id": "duumbi:test/main/entry/0",
+                  "duumbi:value": "data", "duumbi:resultType": "string"},
+                {"@type": "duumbi:Const", "@id": "duumbi:test/main/entry/1",
+                  "duumbi:value": "notes.txt", "duumbi:resultType": "string"},
+                {"@type": "duumbi:PathJoin", "@id": "duumbi:test/main/entry/2",
+                  "duumbi:left": {"@id": "duumbi:test/main/entry/0"},
+                  "duumbi:right": {"@id": "duumbi:test/main/entry/1"},
+                  "duumbi:resultType": "result<string,string>"},
+                {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:test/main/entry/3",
+                  "duumbi:operand": {"@id": "duumbi:test/main/entry/2"},
+                  "duumbi:resultType": "string"},
+                {"@type": "duumbi:ReadLine", "@id": "duumbi:test/main/entry/4",
+                  "duumbi:resultType": "result<string,string>"},
+                {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:test/main/entry/5",
+                  "duumbi:operand": {"@id": "duumbi:test/main/entry/4"},
+                  "duumbi:resultType": "string"},
+                {"@type": "duumbi:PrintLn", "@id": "duumbi:test/main/entry/6",
+                  "duumbi:operand": {"@id": "duumbi:test/main/entry/5"},
+                  "duumbi:resultType": "result<i64,string>"},
+                {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:test/main/entry/7",
+                  "duumbi:operand": {"@id": "duumbi:test/main/entry/6"},
+                  "duumbi:resultType": "i64"},
+                {"@type": "duumbi:WriteFile", "@id": "duumbi:test/main/entry/8",
+                  "duumbi:path": {"@id": "duumbi:test/main/entry/3"},
+                  "duumbi:contents": {"@id": "duumbi:test/main/entry/5"},
+                  "duumbi:resultType": "result<i64,string>"},
+                {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:test/main/entry/9",
+                  "duumbi:operand": {"@id": "duumbi:test/main/entry/8"},
+                  "duumbi:resultType": "i64"},
+                {"@type": "duumbi:Const", "@id": "duumbi:test/main/entry/10",
+                  "duumbi:value": 1024, "duumbi:resultType": "i64"},
+                {"@type": "duumbi:ReadFile", "@id": "duumbi:test/main/entry/11",
+                  "duumbi:path": {"@id": "duumbi:test/main/entry/3"},
+                  "duumbi:maxBytes": {"@id": "duumbi:test/main/entry/10"},
+                  "duumbi:resultType": "result<string,string>"},
+                {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:test/main/entry/12",
+                  "duumbi:operand": {"@id": "duumbi:test/main/entry/11"},
+                  "duumbi:resultType": "string"},
+                {"@type": "duumbi:FileExists", "@id": "duumbi:test/main/entry/13",
+                  "duumbi:path": {"@id": "duumbi:test/main/entry/3"},
+                  "duumbi:resultType": "result<bool,string>"},
+                {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:test/main/entry/14",
+                  "duumbi:operand": {"@id": "duumbi:test/main/entry/13"},
+                  "duumbi:resultType": "bool"},
+                {"@type": "duumbi:ListDir", "@id": "duumbi:test/main/entry/15",
+                  "duumbi:path": {"@id": "duumbi:test/main/entry/0"},
+                  "duumbi:resultType": "result<array<string>,string>"},
+                {"@type": "duumbi:Return", "@id": "duumbi:test/main/entry/16",
+                  "duumbi:operand": {"@id": "duumbi:test/main/entry/15"}}
+              ]
+            }]
+          }]
+        }"#,
+    )
+    .expect("fixture must parse");
+
+    let graph = build_graph(&module).expect("fixture must build");
+    let object = lowering::compile_to_object(&graph).expect("new runtime ops must lower");
+    assert!(!object.is_empty(), "compiled object must not be empty");
+}

--- a/tests/integration_duumbi_378_cycle3.rs
+++ b/tests/integration_duumbi_378_cycle3.rs
@@ -71,7 +71,7 @@ functions = ["print_i64", "print_f64", "print_bool", "print_string", "read_line"
 
     assert_eq!(run.exit_code, 0);
     assert_eq!(run.stderr, "");
-    assert_eq!(run.stdout, "hello duumbi\n1\nfalse\n");
+    assert_eq!(run.stdout.replace("\r\n", "\n"), "hello duumbi\n1\nfalse\n");
     assert_eq!(
         fs::read_to_string(tmp.path().join("data/out.txt")).expect("read output"),
         "hello duumbi"

--- a/tests/integration_duumbi_378_cycle3.rs
+++ b/tests/integration_duumbi_378_cycle3.rs
@@ -2,6 +2,9 @@
 //! public stdlib calls, stdin, workspace-confined file APIs, and path rejection.
 
 use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
 use duumbi::workspace::{build_workspace, run_workspace_binary_with_stdin, workspace_output_path};
 
@@ -82,6 +85,204 @@ functions = ["print_i64", "print_f64", "print_bool", "print_string", "read_line"
         !config_after.contains("@duumbi/stdlib-file-new"),
         "test must not introduce any non-spec file stdlib dependency"
     );
+}
+
+#[test]
+fn read_line_empty_and_eof_inputs_are_deterministic() {
+    let (tmp, output_path) = build_duumbi_378_workspace(read_line_echo_jsonld());
+
+    let empty = run_workspace_binary_with_stdin(tmp.path(), &[], "\n").expect("empty stdin run");
+    assert_eq!(empty.exit_code, 0);
+    assert_eq!(empty.stderr, "");
+    assert_eq!(normalize_stdout(&empty.stdout), "\n");
+
+    let eof_after_bytes =
+        run_workspace_binary_with_stdin(tmp.path(), &[], "hello").expect("eof stdin run");
+    assert_eq!(eof_after_bytes.exit_code, 0);
+    assert_eq!(eof_after_bytes.stderr, "");
+    assert_eq!(normalize_stdout(&eof_after_bytes.stdout), "hello\n");
+
+    assert!(
+        output_path.exists(),
+        "workspace build must produce a binary"
+    );
+}
+
+#[test]
+fn invalid_utf8_stdin_returns_error_class() {
+    let (tmp, output_path) = build_duumbi_378_workspace(read_line_invalid_utf8_jsonld());
+    let run = run_binary_with_stdin_bytes(&output_path, tmp.path(), Some(tmp.path()), &[0xff]);
+
+    assert_eq!(run.exit_code, 0);
+    assert_eq!(run.stderr, "");
+    assert_eq!(normalize_stdout(&run.stdout), "true\n");
+}
+
+#[test]
+fn file_api_error_classes_cover_path_byte_limit_utf8_and_join_policy() {
+    let (tmp, output_path) = build_duumbi_378_workspace(file_error_classes_jsonld());
+    fs::create_dir_all(tmp.path().join("data")).expect("data dir");
+    fs::write(tmp.path().join("data/input.txt"), "hello").expect("write input");
+    fs::write(tmp.path().join("data/bad.bin"), [0xff, b'\n']).expect("write invalid utf8");
+
+    let run = run_workspace_binary_with_stdin(tmp.path(), &[], "").expect("file errors run");
+
+    assert_eq!(run.exit_code, 0);
+    assert_eq!(run.stderr, "");
+    assert_eq!(
+        normalize_stdout(&run.stdout),
+        "true\ntrue\ntrue\ntrue\ntrue\ntrue\n"
+    );
+    assert!(
+        output_path.exists(),
+        "workspace build must produce a binary"
+    );
+}
+
+#[test]
+fn file_exists_overwrite_and_sorted_list_are_deterministic() {
+    let (tmp, output_path) = build_duumbi_378_workspace(file_state_and_sorted_list_jsonld());
+    fs::create_dir_all(tmp.path().join("data")).expect("data dir");
+    fs::create_dir_all(tmp.path().join("listed")).expect("listed dir");
+    fs::write(tmp.path().join("data/input.txt"), "hello").expect("write input");
+    fs::write(tmp.path().join("data/out.txt"), "old").expect("write old output");
+    fs::write(tmp.path().join("listed/b.txt"), "b").expect("write b");
+    fs::write(tmp.path().join("listed/a.txt"), "a").expect("write a");
+
+    let run = run_workspace_binary_with_stdin(tmp.path(), &[], "").expect("file state run");
+
+    assert_eq!(run.exit_code, 0);
+    assert_eq!(run.stderr, "");
+    assert_eq!(
+        normalize_stdout(&run.stdout),
+        "true\nfalse\n2\na.txt\nb.txt\n"
+    );
+    assert_eq!(
+        fs::read_to_string(tmp.path().join("data/out.txt")).expect("read overwritten output"),
+        "new"
+    );
+    assert!(
+        output_path.exists(),
+        "workspace build must produce a binary"
+    );
+}
+
+#[test]
+fn file_apis_fail_without_workspace_root_env() {
+    let (tmp, output_path) = build_duumbi_378_workspace(workspace_root_missing_jsonld());
+    fs::create_dir_all(tmp.path().join("data")).expect("data dir");
+    fs::write(tmp.path().join("data/input.txt"), "hello").expect("write input");
+
+    let run = run_binary_with_stdin_bytes(&output_path, tmp.path(), None, &[]);
+
+    assert_eq!(run.exit_code, 0);
+    assert_eq!(run.stderr, "");
+    assert_eq!(normalize_stdout(&run.stdout), "true\n");
+}
+
+struct BinaryRun {
+    exit_code: i32,
+    stdout: String,
+    stderr: String,
+}
+
+fn build_duumbi_378_workspace(main_jsonld: &str) -> (tempfile::TempDir, PathBuf) {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    fs::create_dir_all(tmp.path().join(".duumbi/graph")).expect("graph dir");
+    fs::create_dir_all(tmp.path().join(".duumbi/build")).expect("build dir");
+    fs::write(
+        tmp.path().join(".duumbi/config.toml"),
+        r#"[workspace]
+name = "duumbi-378-focused"
+namespace = "duumbi-378-focused"
+default-registry = "duumbi"
+
+[registries]
+duumbi = "https://registry.duumbi.dev"
+
+[dependencies]
+"@duumbi/stdlib-io" = "1.0.0"
+"@duumbi/stdlib-file" = "1.0.0"
+"#,
+    )
+    .expect("write config");
+
+    let io_cache = tmp.path().join(".duumbi/cache/@duumbi/stdlib-io@1.0.0");
+    fs::create_dir_all(io_cache.join("graph")).expect("create io cache");
+    fs::write(
+        io_cache.join("graph/io.jsonld"),
+        include_str!("../stdlib/io.jsonld"),
+    )
+    .expect("write io module");
+    fs::write(
+        io_cache.join("manifest.toml"),
+        r#"[module]
+name = "@duumbi/stdlib-io"
+version = "1.0.0"
+description = "I/O utility functions (print wrappers, read_line, print_ln)"
+license = "MPL-2.0"
+
+[exports]
+functions = ["print_i64", "print_f64", "print_bool", "print_string", "read_line", "print_ln"]
+"#,
+    )
+    .expect("write io manifest");
+
+    let file_cache = tmp.path().join(".duumbi/cache/@duumbi/stdlib-file@1.0.0");
+    fs::create_dir_all(file_cache.join("graph")).expect("create file cache");
+    fs::write(
+        file_cache.join("graph/file.jsonld"),
+        include_str!("../stdlib/file.jsonld"),
+    )
+    .expect("write file module");
+    fs::write(
+        file_cache.join("manifest.toml"),
+        include_str!("../stdlib/file.manifest.toml"),
+    )
+    .expect("write file manifest");
+
+    fs::write(tmp.path().join(".duumbi/graph/main.jsonld"), main_jsonld).expect("write main");
+    let output_path = workspace_output_path(tmp.path());
+    build_workspace(tmp.path(), &output_path, false).expect("workspace build");
+    (tmp, output_path)
+}
+
+fn run_binary_with_stdin_bytes(
+    output_path: &Path,
+    current_dir: &Path,
+    workspace_root: Option<&Path>,
+    stdin: &[u8],
+) -> BinaryRun {
+    let mut command = Command::new(output_path);
+    command
+        .current_dir(current_dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let Some(root) = workspace_root {
+        command.env("DUUMBI_WORKSPACE_ROOT", root);
+    } else {
+        command.env_remove("DUUMBI_WORKSPACE_ROOT");
+    }
+
+    let mut child = command.spawn().expect("spawn compiled binary");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin pipe")
+        .write_all(stdin)
+        .expect("write stdin");
+    let output = child.wait_with_output().expect("wait for binary");
+
+    BinaryRun {
+        exit_code: output.status.code().unwrap_or(-1),
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    }
+}
+
+fn normalize_stdout(stdout: &str) -> String {
+    stdout.replace("\r\n", "\n")
 }
 
 fn main_jsonld() -> &'static str {
@@ -177,6 +378,373 @@ fn main_jsonld() -> &'static str {
               "duumbi:value": 0, "duumbi:resultType": "i64"},
             {"@type": "duumbi:Return", "@id": "duumbi:main/main/entry/22",
               "duumbi:operand": {"@id": "duumbi:main/main/entry/21"}}
+          ]
+        }]
+      }]
+    }"#
+}
+
+fn read_line_echo_jsonld() -> &'static str {
+    r#"{
+      "@context": {"duumbi": "https://duumbi.dev/ns/core#"},
+      "@type": "duumbi:Module",
+      "@id": "duumbi:main",
+      "duumbi:name": "main",
+      "duumbi:functions": [{
+        "@type": "duumbi:Function",
+        "@id": "duumbi:main/main",
+        "duumbi:name": "main",
+        "duumbi:returnType": "i64",
+        "duumbi:blocks": [{
+          "@type": "duumbi:Block",
+          "@id": "duumbi:main/main/entry",
+          "duumbi:label": "entry",
+          "duumbi:ops": [
+            {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/0",
+              "duumbi:function": "read_line", "duumbi:module": "io",
+              "duumbi:args": [], "duumbi:resultType": "result<string,string>"},
+            {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/1",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/0"},
+              "duumbi:resultType": "string"},
+            {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/2",
+              "duumbi:function": "print_ln", "duumbi:module": "io",
+              "duumbi:args": [{"@id": "duumbi:main/main/entry/1"}],
+              "duumbi:resultType": "result<i64,string>"},
+            {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/3",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/2"},
+              "duumbi:resultType": "i64"},
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/4",
+              "duumbi:value": 0, "duumbi:resultType": "i64"},
+            {"@type": "duumbi:Return", "@id": "duumbi:main/main/entry/5",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/4"}}
+          ]
+        }]
+      }]
+    }"#
+}
+
+fn read_line_invalid_utf8_jsonld() -> &'static str {
+    r#"{
+      "@context": {"duumbi": "https://duumbi.dev/ns/core#"},
+      "@type": "duumbi:Module",
+      "@id": "duumbi:main",
+      "duumbi:name": "main",
+      "duumbi:functions": [{
+        "@type": "duumbi:Function",
+        "@id": "duumbi:main/main",
+        "duumbi:name": "main",
+        "duumbi:returnType": "i64",
+        "duumbi:blocks": [{
+          "@type": "duumbi:Block",
+          "@id": "duumbi:main/main/entry",
+          "duumbi:label": "entry",
+          "duumbi:ops": [
+            {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/0",
+              "duumbi:function": "read_line", "duumbi:module": "io",
+              "duumbi:args": [], "duumbi:resultType": "result<string,string>"},
+            {"@type": "duumbi:ResultUnwrapErr", "@id": "duumbi:main/main/entry/1",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/0"},
+              "duumbi:resultType": "string"},
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/2",
+              "duumbi:value": "stdin_invalid_utf8", "duumbi:resultType": "string"},
+            {"@type": "duumbi:StringContains", "@id": "duumbi:main/main/entry/3",
+              "duumbi:left": {"@id": "duumbi:main/main/entry/1"},
+              "duumbi:right": {"@id": "duumbi:main/main/entry/2"},
+              "duumbi:resultType": "bool"},
+            {"@type": "duumbi:Print", "@id": "duumbi:main/main/entry/4",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/3"}},
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/5",
+              "duumbi:value": 0, "duumbi:resultType": "i64"},
+            {"@type": "duumbi:Return", "@id": "duumbi:main/main/entry/6",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/5"}}
+          ]
+        }]
+      }]
+    }"#
+}
+
+fn file_error_classes_jsonld() -> &'static str {
+    r#"{
+      "@context": {"duumbi": "https://duumbi.dev/ns/core#"},
+      "@type": "duumbi:Module",
+      "@id": "duumbi:main",
+      "duumbi:name": "main",
+      "duumbi:functions": [{
+        "@type": "duumbi:Function",
+        "@id": "duumbi:main/main",
+        "duumbi:name": "main",
+        "duumbi:returnType": "i64",
+        "duumbi:blocks": [{
+          "@type": "duumbi:Block",
+          "@id": "duumbi:main/main/entry",
+          "duumbi:label": "entry",
+          "duumbi:ops": [
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/0",
+              "duumbi:value": "/tmp/duumbi.txt", "duumbi:resultType": "string"},
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/1",
+              "duumbi:value": 16, "duumbi:resultType": "i64"},
+            {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/2",
+              "duumbi:function": "read_file", "duumbi:module": "file",
+              "duumbi:args": [
+                {"@id": "duumbi:main/main/entry/0"},
+                {"@id": "duumbi:main/main/entry/1"}],
+              "duumbi:resultType": "result<string,string>"},
+            {"@type": "duumbi:ResultUnwrapErr", "@id": "duumbi:main/main/entry/3",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/2"},
+              "duumbi:resultType": "string"},
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/4",
+              "duumbi:value": "path_policy", "duumbi:resultType": "string"},
+            {"@type": "duumbi:StringContains", "@id": "duumbi:main/main/entry/5",
+              "duumbi:left": {"@id": "duumbi:main/main/entry/3"},
+              "duumbi:right": {"@id": "duumbi:main/main/entry/4"},
+              "duumbi:resultType": "bool"},
+            {"@type": "duumbi:Print", "@id": "duumbi:main/main/entry/6",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/5"}},
+
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/7",
+              "duumbi:value": "../escape.txt", "duumbi:resultType": "string"},
+            {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/8",
+              "duumbi:function": "file_exists", "duumbi:module": "file",
+              "duumbi:args": [{"@id": "duumbi:main/main/entry/7"}],
+              "duumbi:resultType": "result<bool,string>"},
+            {"@type": "duumbi:ResultUnwrapErr", "@id": "duumbi:main/main/entry/9",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/8"},
+              "duumbi:resultType": "string"},
+            {"@type": "duumbi:StringContains", "@id": "duumbi:main/main/entry/10",
+              "duumbi:left": {"@id": "duumbi:main/main/entry/9"},
+              "duumbi:right": {"@id": "duumbi:main/main/entry/4"},
+              "duumbi:resultType": "bool"},
+            {"@type": "duumbi:Print", "@id": "duumbi:main/main/entry/11",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/10"}},
+
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/12",
+              "duumbi:value": "data/input.txt", "duumbi:resultType": "string"},
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/13",
+              "duumbi:value": 4, "duumbi:resultType": "i64"},
+            {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/14",
+              "duumbi:function": "read_file", "duumbi:module": "file",
+              "duumbi:args": [
+                {"@id": "duumbi:main/main/entry/12"},
+                {"@id": "duumbi:main/main/entry/13"}],
+              "duumbi:resultType": "result<string,string>"},
+            {"@type": "duumbi:ResultUnwrapErr", "@id": "duumbi:main/main/entry/15",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/14"},
+              "duumbi:resultType": "string"},
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/16",
+              "duumbi:value": "byte_limit", "duumbi:resultType": "string"},
+            {"@type": "duumbi:StringContains", "@id": "duumbi:main/main/entry/17",
+              "duumbi:left": {"@id": "duumbi:main/main/entry/15"},
+              "duumbi:right": {"@id": "duumbi:main/main/entry/16"},
+              "duumbi:resultType": "bool"},
+            {"@type": "duumbi:Print", "@id": "duumbi:main/main/entry/18",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/17"}},
+
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/19",
+              "duumbi:value": "data/bad.bin", "duumbi:resultType": "string"},
+            {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/20",
+              "duumbi:function": "read_file", "duumbi:module": "file",
+              "duumbi:args": [
+                {"@id": "duumbi:main/main/entry/19"},
+                {"@id": "duumbi:main/main/entry/1"}],
+              "duumbi:resultType": "result<string,string>"},
+            {"@type": "duumbi:ResultUnwrapErr", "@id": "duumbi:main/main/entry/21",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/20"},
+              "duumbi:resultType": "string"},
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/22",
+              "duumbi:value": "invalid_utf8", "duumbi:resultType": "string"},
+            {"@type": "duumbi:StringContains", "@id": "duumbi:main/main/entry/23",
+              "duumbi:left": {"@id": "duumbi:main/main/entry/21"},
+              "duumbi:right": {"@id": "duumbi:main/main/entry/22"},
+              "duumbi:resultType": "bool"},
+            {"@type": "duumbi:Print", "@id": "duumbi:main/main/entry/24",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/23"}},
+
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/25",
+              "duumbi:value": "", "duumbi:resultType": "string"},
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/26",
+              "duumbi:value": "file.txt", "duumbi:resultType": "string"},
+            {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/27",
+              "duumbi:function": "path_join", "duumbi:module": "file",
+              "duumbi:args": [
+                {"@id": "duumbi:main/main/entry/25"},
+                {"@id": "duumbi:main/main/entry/26"}],
+              "duumbi:resultType": "result<string,string>"},
+            {"@type": "duumbi:ResultUnwrapErr", "@id": "duumbi:main/main/entry/28",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/27"},
+              "duumbi:resultType": "string"},
+            {"@type": "duumbi:StringContains", "@id": "duumbi:main/main/entry/29",
+              "duumbi:left": {"@id": "duumbi:main/main/entry/28"},
+              "duumbi:right": {"@id": "duumbi:main/main/entry/4"},
+              "duumbi:resultType": "bool"},
+            {"@type": "duumbi:Print", "@id": "duumbi:main/main/entry/30",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/29"}},
+
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/31",
+              "duumbi:value": "dir", "duumbi:resultType": "string"},
+            {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/32",
+              "duumbi:function": "path_join", "duumbi:module": "file",
+              "duumbi:args": [
+                {"@id": "duumbi:main/main/entry/31"},
+                {"@id": "duumbi:main/main/entry/25"}],
+              "duumbi:resultType": "result<string,string>"},
+            {"@type": "duumbi:ResultUnwrapErr", "@id": "duumbi:main/main/entry/33",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/32"},
+              "duumbi:resultType": "string"},
+            {"@type": "duumbi:StringContains", "@id": "duumbi:main/main/entry/34",
+              "duumbi:left": {"@id": "duumbi:main/main/entry/33"},
+              "duumbi:right": {"@id": "duumbi:main/main/entry/4"},
+              "duumbi:resultType": "bool"},
+            {"@type": "duumbi:Print", "@id": "duumbi:main/main/entry/35",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/34"}},
+
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/36",
+              "duumbi:value": 0, "duumbi:resultType": "i64"},
+            {"@type": "duumbi:Return", "@id": "duumbi:main/main/entry/37",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/36"}}
+          ]
+        }]
+      }]
+    }"#
+}
+
+fn file_state_and_sorted_list_jsonld() -> &'static str {
+    r#"{
+      "@context": {"duumbi": "https://duumbi.dev/ns/core#"},
+      "@type": "duumbi:Module",
+      "@id": "duumbi:main",
+      "duumbi:name": "main",
+      "duumbi:functions": [{
+        "@type": "duumbi:Function",
+        "@id": "duumbi:main/main",
+        "duumbi:name": "main",
+        "duumbi:returnType": "i64",
+        "duumbi:blocks": [{
+          "@type": "duumbi:Block",
+          "@id": "duumbi:main/main/entry",
+          "duumbi:label": "entry",
+          "duumbi:ops": [
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/0",
+              "duumbi:value": "data/out.txt", "duumbi:resultType": "string"},
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/1",
+              "duumbi:value": "new", "duumbi:resultType": "string"},
+            {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/2",
+              "duumbi:function": "write_file", "duumbi:module": "file",
+              "duumbi:args": [
+                {"@id": "duumbi:main/main/entry/0"},
+                {"@id": "duumbi:main/main/entry/1"}],
+              "duumbi:resultType": "result<i64,string>"},
+            {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/3",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/2"},
+              "duumbi:resultType": "i64"},
+
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/4",
+              "duumbi:value": "data/input.txt", "duumbi:resultType": "string"},
+            {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/5",
+              "duumbi:function": "file_exists", "duumbi:module": "file",
+              "duumbi:args": [{"@id": "duumbi:main/main/entry/4"}],
+              "duumbi:resultType": "result<bool,string>"},
+            {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/6",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/5"},
+              "duumbi:resultType": "bool"},
+            {"@type": "duumbi:Print", "@id": "duumbi:main/main/entry/7",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/6"}},
+
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/8",
+              "duumbi:value": "data/missing.txt", "duumbi:resultType": "string"},
+            {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/9",
+              "duumbi:function": "file_exists", "duumbi:module": "file",
+              "duumbi:args": [{"@id": "duumbi:main/main/entry/8"}],
+              "duumbi:resultType": "result<bool,string>"},
+            {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/10",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/9"},
+              "duumbi:resultType": "bool"},
+            {"@type": "duumbi:Print", "@id": "duumbi:main/main/entry/11",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/10"}},
+
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/12",
+              "duumbi:value": "listed", "duumbi:resultType": "string"},
+            {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/13",
+              "duumbi:function": "list_dir", "duumbi:module": "file",
+              "duumbi:args": [{"@id": "duumbi:main/main/entry/12"}],
+              "duumbi:resultType": "result<array<string>,string>"},
+            {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/14",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/13"},
+              "duumbi:resultType": "array<string>"},
+            {"@type": "duumbi:ArrayLength", "@id": "duumbi:main/main/entry/15",
+              "duumbi:array": {"@id": "duumbi:main/main/entry/14"},
+              "duumbi:resultType": "i64"},
+            {"@type": "duumbi:Print", "@id": "duumbi:main/main/entry/16",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/15"}},
+
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/17",
+              "duumbi:value": 0, "duumbi:resultType": "i64"},
+            {"@type": "duumbi:ArrayGet", "@id": "duumbi:main/main/entry/18",
+              "duumbi:array": {"@id": "duumbi:main/main/entry/14"},
+              "duumbi:index": {"@id": "duumbi:main/main/entry/17"},
+              "duumbi:resultType": "string"},
+            {"@type": "duumbi:PrintString", "@id": "duumbi:main/main/entry/19",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/18"}},
+
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/21",
+              "duumbi:value": 1, "duumbi:resultType": "i64"},
+            {"@type": "duumbi:ArrayGet", "@id": "duumbi:main/main/entry/22",
+              "duumbi:array": {"@id": "duumbi:main/main/entry/14"},
+              "duumbi:index": {"@id": "duumbi:main/main/entry/21"},
+              "duumbi:resultType": "string"},
+            {"@type": "duumbi:PrintString", "@id": "duumbi:main/main/entry/23",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/22"}},
+
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/25",
+              "duumbi:value": 0, "duumbi:resultType": "i64"},
+            {"@type": "duumbi:Return", "@id": "duumbi:main/main/entry/26",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/25"}}
+          ]
+        }]
+      }]
+    }"#
+}
+
+fn workspace_root_missing_jsonld() -> &'static str {
+    r#"{
+      "@context": {"duumbi": "https://duumbi.dev/ns/core#"},
+      "@type": "duumbi:Module",
+      "@id": "duumbi:main",
+      "duumbi:name": "main",
+      "duumbi:functions": [{
+        "@type": "duumbi:Function",
+        "@id": "duumbi:main/main",
+        "duumbi:name": "main",
+        "duumbi:returnType": "i64",
+        "duumbi:blocks": [{
+          "@type": "duumbi:Block",
+          "@id": "duumbi:main/main/entry",
+          "duumbi:label": "entry",
+          "duumbi:ops": [
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/0",
+              "duumbi:value": "data/input.txt", "duumbi:resultType": "string"},
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/1",
+              "duumbi:value": 64, "duumbi:resultType": "i64"},
+            {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/2",
+              "duumbi:function": "read_file", "duumbi:module": "file",
+              "duumbi:args": [
+                {"@id": "duumbi:main/main/entry/0"},
+                {"@id": "duumbi:main/main/entry/1"}],
+              "duumbi:resultType": "result<string,string>"},
+            {"@type": "duumbi:ResultUnwrapErr", "@id": "duumbi:main/main/entry/3",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/2"},
+              "duumbi:resultType": "string"},
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/4",
+              "duumbi:value": "workspace_root_unavailable", "duumbi:resultType": "string"},
+            {"@type": "duumbi:StringContains", "@id": "duumbi:main/main/entry/5",
+              "duumbi:left": {"@id": "duumbi:main/main/entry/3"},
+              "duumbi:right": {"@id": "duumbi:main/main/entry/4"},
+              "duumbi:resultType": "bool"},
+            {"@type": "duumbi:Print", "@id": "duumbi:main/main/entry/6",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/5"}},
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/7",
+              "duumbi:value": 0, "duumbi:resultType": "i64"},
+            {"@type": "duumbi:Return", "@id": "duumbi:main/main/entry/8",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/7"}}
           ]
         }]
       }]

--- a/tests/integration_duumbi_378_cycle3.rs
+++ b/tests/integration_duumbi_378_cycle3.rs
@@ -1,0 +1,184 @@
+//! DUUMBI-378 Cycle 3 deterministic E2E coverage:
+//! public stdlib calls, stdin, workspace-confined file APIs, and path rejection.
+
+use std::fs;
+
+use duumbi::workspace::{build_workspace, run_workspace_binary_with_stdin, workspace_output_path};
+
+#[test]
+fn stdlib_io_and_file_live_workspace_e2e() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    fs::create_dir_all(tmp.path().join(".duumbi/graph")).expect("graph dir");
+    fs::create_dir_all(tmp.path().join(".duumbi/build")).expect("build dir");
+    fs::write(
+        tmp.path().join(".duumbi/config.toml"),
+        r#"[workspace]
+name = "duumbi-378-e2e"
+namespace = "duumbi-378-e2e"
+default-registry = "duumbi"
+
+[registries]
+duumbi = "https://registry.duumbi.dev"
+
+[dependencies]
+"@duumbi/stdlib-io" = "1.0.0"
+"@duumbi/stdlib-file" = "1.0.0"
+"#,
+    )
+    .expect("write config");
+
+    let io_cache = tmp.path().join(".duumbi/cache/@duumbi/stdlib-io@1.0.0");
+    fs::create_dir_all(io_cache.join("graph")).expect("create io cache");
+    fs::write(
+        io_cache.join("graph/io.jsonld"),
+        include_str!("../stdlib/io.jsonld"),
+    )
+    .expect("write io module");
+    fs::write(
+        io_cache.join("manifest.toml"),
+        r#"[module]
+name = "@duumbi/stdlib-io"
+version = "1.0.0"
+description = "I/O utility functions (print wrappers, read_line, print_ln)"
+license = "MPL-2.0"
+
+[exports]
+functions = ["print_i64", "print_f64", "print_bool", "print_string", "read_line", "print_ln"]
+"#,
+    )
+    .expect("write io manifest");
+
+    let file_cache = tmp.path().join(".duumbi/cache/@duumbi/stdlib-file@1.0.0");
+    fs::create_dir_all(file_cache.join("graph")).expect("create file cache");
+    fs::write(
+        file_cache.join("graph/file.jsonld"),
+        include_str!("../stdlib/file.jsonld"),
+    )
+    .expect("write file module");
+    fs::write(
+        file_cache.join("manifest.toml"),
+        include_str!("../stdlib/file.manifest.toml"),
+    )
+    .expect("write file manifest");
+
+    fs::create_dir_all(tmp.path().join("data")).expect("create data dir");
+    fs::write(tmp.path().join(".duumbi/graph/main.jsonld"), main_jsonld()).expect("write main");
+
+    let output_path = workspace_output_path(tmp.path());
+    build_workspace(tmp.path(), &output_path, false).expect("workspace build");
+    let run =
+        run_workspace_binary_with_stdin(tmp.path(), &[], "hello duumbi\n").expect("workspace run");
+
+    assert_eq!(run.exit_code, 0);
+    assert_eq!(run.stderr, "");
+    assert_eq!(run.stdout, "hello duumbi\n1\nfalse\n");
+    assert_eq!(
+        fs::read_to_string(tmp.path().join("data/out.txt")).expect("read output"),
+        "hello duumbi"
+    );
+
+    let config_after = fs::read_to_string(tmp.path().join(".duumbi/config.toml")).expect("config");
+    assert!(
+        !config_after.contains("@duumbi/stdlib-file-new"),
+        "test must not introduce any non-spec file stdlib dependency"
+    );
+}
+
+fn main_jsonld() -> &'static str {
+    r#"{
+      "@context": {"duumbi": "https://duumbi.dev/ns/core#"},
+      "@type": "duumbi:Module",
+      "@id": "duumbi:main",
+      "duumbi:name": "main",
+      "duumbi:functions": [{
+        "@type": "duumbi:Function",
+        "@id": "duumbi:main/main",
+        "duumbi:name": "main",
+        "duumbi:returnType": "i64",
+        "duumbi:blocks": [{
+          "@type": "duumbi:Block",
+          "@id": "duumbi:main/main/entry",
+          "duumbi:label": "entry",
+          "duumbi:ops": [
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/0",
+              "duumbi:value": "data", "duumbi:resultType": "string"},
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/1",
+              "duumbi:value": "out.txt", "duumbi:resultType": "string"},
+            {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/2",
+              "duumbi:function": "path_join", "duumbi:module": "file",
+              "duumbi:args": [
+                {"@id": "duumbi:main/main/entry/0"},
+                {"@id": "duumbi:main/main/entry/1"}
+              ],
+              "duumbi:resultType": "result<string,string>"},
+            {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/3",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/2"},
+              "duumbi:resultType": "string"},
+            {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/4",
+              "duumbi:function": "read_line", "duumbi:module": "io",
+              "duumbi:args": [],
+              "duumbi:resultType": "result<string,string>"},
+            {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/5",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/4"},
+              "duumbi:resultType": "string"},
+            {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/6",
+              "duumbi:function": "write_file", "duumbi:module": "file",
+              "duumbi:args": [
+                {"@id": "duumbi:main/main/entry/3"},
+                {"@id": "duumbi:main/main/entry/5"}
+              ],
+              "duumbi:resultType": "result<i64,string>"},
+            {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/7",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/6"},
+              "duumbi:resultType": "i64"},
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/8",
+              "duumbi:value": 128, "duumbi:resultType": "i64"},
+            {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/9",
+              "duumbi:function": "read_file", "duumbi:module": "file",
+              "duumbi:args": [
+                {"@id": "duumbi:main/main/entry/3"},
+                {"@id": "duumbi:main/main/entry/8"}
+              ],
+              "duumbi:resultType": "result<string,string>"},
+            {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/10",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/9"},
+              "duumbi:resultType": "string"},
+            {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/11",
+              "duumbi:function": "print_ln", "duumbi:module": "io",
+              "duumbi:args": [{"@id": "duumbi:main/main/entry/10"}],
+              "duumbi:resultType": "result<i64,string>"},
+            {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/12",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/11"},
+              "duumbi:resultType": "i64"},
+            {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/13",
+              "duumbi:function": "list_dir", "duumbi:module": "file",
+              "duumbi:args": [{"@id": "duumbi:main/main/entry/0"}],
+              "duumbi:resultType": "result<array<string>,string>"},
+            {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/14",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/13"},
+              "duumbi:resultType": "array<string>"},
+            {"@type": "duumbi:ArrayLength", "@id": "duumbi:main/main/entry/15",
+              "duumbi:array": {"@id": "duumbi:main/main/entry/14"},
+              "duumbi:resultType": "i64"},
+            {"@type": "duumbi:Print", "@id": "duumbi:main/main/entry/16",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/15"}},
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/17",
+              "duumbi:value": "../escape.txt", "duumbi:resultType": "string"},
+            {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/18",
+              "duumbi:function": "file_exists", "duumbi:module": "file",
+              "duumbi:args": [{"@id": "duumbi:main/main/entry/17"}],
+              "duumbi:resultType": "result<bool,string>"},
+            {"@type": "duumbi:ResultIsOk", "@id": "duumbi:main/main/entry/19",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/18"},
+              "duumbi:resultType": "bool"},
+            {"@type": "duumbi:Print", "@id": "duumbi:main/main/entry/20",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/19"}},
+            {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/21",
+              "duumbi:value": 0, "duumbi:resultType": "i64"},
+            {"@type": "duumbi:Return", "@id": "duumbi:main/main/entry/22",
+              "duumbi:operand": {"@id": "duumbi:main/main/entry/21"}}
+          ]
+        }]
+      }]
+    }"#
+}


### PR DESCRIPTION
## Summary

Related to #378.

Implements the approved DUUMBI-378 product and technical specs:
- keeps legacy stdlib IO print wrappers compatible
- adds Result-returning `read_line` and `print_ln` to `@duumbi/stdlib-io`
- adds explicit-dependency `@duumbi/stdlib-file` with `read_file`, `write_file`, `file_exists`, `list_dir`, and `path_join`
- adds parser, IR, validator, result-safety, lowering, runtime, and workspace-runner support
- keeps `@duumbi/stdlib-file` out of default `duumbi init` dependencies/cache

Workflow note: this implementation PR must leave the execution issue open for Stage 11 review and closure handling.

## BDD-to-test mapping

- Legacy print compatibility: existing broad runtime/stdout suites plus `cargo test --all` passed.
- `read_line`, `print_ln`, and stdlib IO metadata: `tests/integration_duumbi_378_cycle1.rs`, `tests/integration_duumbi_378_cycle3.rs`.
- File APIs and explicit stdlib-file metadata: `tests/integration_duumbi_378_cycle1.rs`, `tests/integration_duumbi_378_cycle3.rs`.
- Parser and validator contracts for new ops: `tests/integration_duumbi_378_cycle1.rs`.
- Direct Result producer handling/rejection: `tests/integration_duumbi_378_cycle1.rs`.
- Lowering/runtime wiring for all new ops: `tests/integration_duumbi_378_cycle2.rs`.
- Workspace root and stdin runner contract: `workspace::tests::run_workspace_binary_sets_workspace_root_and_writes_stdin`.
- `@duumbi/stdlib-file` not default-installed: `cli::init::tests::init_does_not_install_stdlib_file_by_default`.
- Live deterministic E2E: `tests/integration_duumbi_378_cycle3.rs` builds a temp workspace, seeds `@duumbi/stdlib-file@1.0.0`, runs with stdin, verifies stdout, file content, list_dir, and path escape rejection.

## Verification

- `cargo fmt --check`
- `cargo test --test integration_duumbi_378_cycle1 --test integration_duumbi_378_cycle2 --test integration_duumbi_378_cycle3`
- `cargo test init_does_not_install_stdlib_file_by_default`
- `cargo test workspace::tests::run_workspace_binary_sets_workspace_root_and_writes_stdin`
- `cc -c runtime/duumbi_runtime.c -o /tmp/duumbi_runtime_378.o`
- `cargo test --all`
- `cargo clippy --all-targets -- -D warnings`

## Ralph Cycle Resource Policy

- Autonomous batch used: 3 low-budget cycles plus Codex self-review cleanup.
- External LLM calls: 0.
- Estimated external cost: USD 0.
- No Greptile invoked.
- No risky dependencies, migrations, security-sensitive behavior, or product/architecture scope expansion introduced.
