### PR TITLE
[codex] Fix Stage 12 closure dispatch for spec PRs

### DIFF
--- a/.github/workflows/stage-approval.yml
+++ b/.github/workflows/stage-approval.yml
@@ -508,7 +508,16 @@ jobs:
                 checkRuns.push(...pageRuns);
                 if (pageRuns.length < 100) break;
               }
-              const badChecks = checkRuns.filter((check) =>
+              const ignoredSpecGateCheckNames = new Set([
+                // These checks are created by the approval/closure automation itself
+                // after a spec PR is merged. They are not pre-merge artifact evidence.
+                'Execute approval',
+                'Dispatch Stage 12 closure prompt',
+              ]);
+              const relevantCheckRuns = checkRuns.filter((check) =>
+                !ignoredSpecGateCheckNames.has(String(check.name || ''))
+              );
+              const badChecks = relevantCheckRuns.filter((check) =>
                 check.status !== 'completed' || !['success', 'neutral', 'skipped'].includes(check.conclusion)
               );
               const { data: combinedStatus } = await github.rest.repos.getCombinedStatusForRef({
@@ -516,7 +525,7 @@ jobs:
               });
               const statuses = combinedStatus.statuses || [];
               const badStatuses = statuses.filter((status) => status.state !== 'success');
-              if (checkRuns.length + statuses.length === 0) {
+              if (relevantCheckRuns.length + statuses.length === 0) {
                 throw new Error(`${policy.kind} PR #${prNumber} has no check runs or status contexts; approval requires verifiable green checks.`);
               }
               if (badChecks.length > 0) {
@@ -550,7 +559,7 @@ jobs:
                   prUrl,
                   mergeSha: pr.merge_commit_sha || '',
                   expectedPath: policy.expectedPath,
-                  checkCount: checkRuns.length + statuses.length,
+                  checkCount: relevantCheckRuns.length + statuses.length,
                   reviewCount: latestReviews.length,
                   requiredReviewers: requiredAutomatedReviewers(),
                   alreadyMerged: true,
@@ -571,7 +580,7 @@ jobs:
                 prUrl,
                 mergeSha: merge.data.sha || '',
                 expectedPath: policy.expectedPath,
-                checkCount: checkRuns.length + statuses.length,
+                checkCount: relevantCheckRuns.length + statuses.length,
                 reviewCount: latestReviews.length,
                 requiredReviewers: requiredAutomatedReviewers(),
               };

--- a/.github/workflows/stage12-closure-dispatch.yml
+++ b/.github/workflows/stage12-closure-dispatch.yml
@@ -49,6 +49,55 @@ jobs:
             const prUrlFor = (prNumber) => `${context.serverUrl}/${owner}/${repo}/pull/${prNumber}`;
             const markerFor = (prNumber, mergeSha) =>
               `<!-- duumbi-stage12-closure-dispatch:v1 pr=${prNumber} merge_sha=${mergeSha || "unknown"} -->`;
+            const writeMetrics = (decision, reason, prNumber, issueNumber = null) => {
+              const now = new Date().toISOString();
+              fs.writeFileSync(process.env.DUUMBI_METRICS_PATH, `${JSON.stringify({
+                schema_version: "duumbi.workflow_metrics.v1",
+                generated_at: now,
+                source: "github_actions",
+                repository: `${owner}/${repo}`,
+                workflow: {
+                  name: context.workflow,
+                  file: ".github/workflows/stage12-closure-dispatch.yml",
+                  run_id: context.runId,
+                  run_attempt: Number(process.env.GITHUB_RUN_ATTEMPT || 1),
+                  event_name: eventName,
+                  actor: context.actor,
+                  ref: context.ref,
+                  sha: context.sha,
+                  conclusion: "success",
+                  started_at: now,
+                  completed_at: now,
+                  duration_ms: null,
+                },
+                correlation: {
+                  issue_number: issueNumber,
+                  pr_number: prNumber,
+                  stage: "12",
+                  decision,
+                  project_status: null,
+                },
+                counts: {
+                  issues_considered: issueNumber ? 1 : 0,
+                  issues_queued: decision === "closure_dispatch" ? 1 : 0,
+                  slack_notifications_attempted: decision === "closure_dispatch" ? 1 : 0,
+                  artifact_links_found: issueNumber ? 2 : 1,
+                  artifact_links_missing: issueNumber ? 0 : 1,
+                },
+                provider_usage: {
+                  available: false,
+                  reason: "agent_dispatch_only",
+                },
+                privacy: {
+                  metadata_only: true,
+                  raw_prompts_included: false,
+                  raw_completions_included: false,
+                  raw_slack_payloads_included: false,
+                  secrets_included: false,
+                },
+                warnings: reason ? [reason] : warnings,
+              }, null, 2)}\n`);
+            };
 
             const extractIssueNumbers = (text) => {
               const value = String(text || "");
@@ -90,6 +139,46 @@ jobs:
             const issueNumber = linkedIssueNumbers[0] || null;
             if (!issueNumber) {
               warnings.push("linked_issue_not_detected");
+            }
+
+            const prFiles = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number: prNumber,
+              per_page: 100,
+            });
+            const specArtifactPattern = /^specs\/DUUMBI-\d+\/(?:PRODUCT|TECHNICAL)\.md$/;
+            const specArtifactOnly = prFiles.length > 0
+              && prFiles.every((file) => specArtifactPattern.test(file.filename || ""));
+            if (specArtifactOnly) {
+              const reason = `skipped_spec_artifact_pr:${prFiles.map((file) => file.filename).join(",")}`;
+              core.info(`Skipping Stage 12 closure dispatch for spec-only PR #${prNumber}.`);
+              writeMetrics("skipped", reason, prNumber, issueNumber);
+              return;
+            }
+
+            if (issueNumber) {
+              const { data: issue } = await github.rest.issues.get({
+                owner,
+                repo,
+                issue_number: issueNumber,
+              });
+              const labels = issue.labels
+                .map((label) => typeof label === "string" ? label : label.name)
+                .filter(Boolean);
+              const closureBlockedLabels = new Set([
+                "needs-spec",
+                "spec-review",
+                "needs-tech-spec",
+                "technical-spec-review",
+              ]);
+              const blockingLabels = labels.filter((label) => closureBlockedLabels.has(label));
+              if (blockingLabels.length > 0) {
+                const reason = `skipped_issue_not_ready_for_closure:${blockingLabels.join(",")}`;
+                core.info(`Skipping Stage 12 closure dispatch for issue #${issueNumber}; blocking labels: ${blockingLabels.join(", ")}.`);
+                writeMetrics("skipped", reason, prNumber, issueNumber);
+                return;
+              }
             }
 
             const prComments = await github.paginate(github.rest.issues.listComments, {
@@ -159,12 +248,19 @@ jobs:
               `Slack timestamp: ${body.ts || "<unavailable>"}`,
               issueNumber ? `Linked issue: ${issueUrlFor(issueNumber)}` : "Linked issue: not detected",
             ].join("\n");
-            const { data: prComment } = await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number: prNumber,
-              body: markerBody,
-            });
+            let prCommentUrl = "";
+            try {
+              const { data: prComment } = await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body: markerBody,
+              });
+              prCommentUrl = prComment.html_url;
+            } catch (error) {
+              warnings.push(`pr_comment_failed:${error.message}`);
+              core.warning(`PR closure-dispatch comment failed: ${error.message}`);
+            }
 
             let issueCommentUrl = "";
             if (issueNumber) {
@@ -188,53 +284,7 @@ jobs:
               }
             }
 
-            const now = new Date().toISOString();
-            fs.writeFileSync(process.env.DUUMBI_METRICS_PATH, `${JSON.stringify({
-              schema_version: "duumbi.workflow_metrics.v1",
-              generated_at: now,
-              source: "github_actions",
-              repository: `${owner}/${repo}`,
-              workflow: {
-                name: context.workflow,
-                file: ".github/workflows/stage12-closure-dispatch.yml",
-                run_id: context.runId,
-                run_attempt: Number(process.env.GITHUB_RUN_ATTEMPT || 1),
-                event_name: eventName,
-                actor: context.actor,
-                ref: context.ref,
-                sha: context.sha,
-                conclusion: "success",
-                started_at: now,
-                completed_at: now,
-                duration_ms: null,
-              },
-              correlation: {
-                issue_number: issueNumber,
-                pr_number: prNumber,
-                stage: "12",
-                decision: "closure_dispatch",
-                project_status: null,
-              },
-              counts: {
-                issues_considered: issueNumber ? 1 : 0,
-                issues_queued: 1,
-                slack_notifications_attempted: 1,
-                artifact_links_found: issueNumber ? 2 : 1,
-                artifact_links_missing: issueNumber ? 0 : 1,
-              },
-              provider_usage: {
-                available: false,
-                reason: "agent_dispatch_only",
-              },
-              privacy: {
-                metadata_only: true,
-                raw_prompts_included: false,
-                raw_completions_included: false,
-                raw_slack_payloads_included: false,
-                secrets_included: false,
-              },
-              warnings,
-            }, null, 2)}\n`);
+            writeMetrics("closure_dispatch", null, prNumber, issueNumber);
 
             await core.summary
               .addHeading("DUUMBI Stage 12 Closure Dispatch", 2)
@@ -242,7 +292,7 @@ jobs:
                 [{ data: "Field", header: true }, { data: "Value", header: true }],
                 ["PR", `#${prNumber}`],
                 ["Linked issue", issueNumber ? `#${issueNumber}` : "not detected"],
-                ["PR marker comment", prComment.html_url],
+                ["PR marker comment", prCommentUrl || "not written"],
                 ["Issue marker comment", issueCommentUrl || "not applicable"],
                 ["Slack dispatch", "posted"],
               ])


### PR DESCRIPTION
## Summary

Fixes the workflow loop where merging a spec-only PR could trigger Stage 12 closure dispatch and then cause Stage Approval to fail on the closure/approval checks it just created.

## Root Cause

`stage12-closure-dispatch.yml` ran on every merged PR and only checked whether the PR was merged. Spec-only PRs such as `specs/DUUMBI-*/PRODUCT.md` and `specs/DUUMBI-*/TECHNICAL.md` were therefore treated like implementation completion evidence.

`stage-approval.yml` then listed all check runs for the spec PR head SHA and treated the post-merge Stage Approval / Stage 12 jobs as required green pre-merge evidence, creating a failure loop.

## Changes

- Skip Stage 12 closure dispatch before Slack posting when the merged PR is spec-only.
- Skip Stage 12 closure dispatch when the linked issue still has spec-stage labels: `needs-spec`, `spec-review`, `needs-tech-spec`, or `technical-spec-review`.
- Keep Stage 12 marker comments best-effort after Slack dispatch so a comment permission failure does not turn a sent dispatch into a failed workflow.
- Ignore the approval/closure automation checks when validating spec PR green-check evidence.

## Validation

- `git diff --check`
- YAML load check for the changed workflow files
- Parsed both embedded `github-script` bodies inside an async JavaScript wrapper