### PR TITLE
Fix triage refill Inbox archiving

### DIFF
--- a/.github/workflows/triage-queue-refill.yml
+++ b/.github/workflows/triage-queue-refill.yml
@@ -32,8 +32,8 @@ jobs:
         with:
           repository: ${{ github.repository_owner }}/duumbi-vault
           path: duumbi-vault
-          token: ${{ secrets.GH_PROJECT_PAT }}
-          persist-credentials: false
+          token: ${{ secrets.GH_PROJECT_PAT || github.token }}
+          persist-credentials: true
 
       - name: Inspect Project V2 and refill queue
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553

--- a/.github/workflows/triage-queue-refill.yml
+++ b/.github/workflows/triage-queue-refill.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           repository: ${{ github.repository_owner }}/duumbi-vault
           path: duumbi-vault
-          token: ${{ secrets.GH_PROJECT_PAT || github.token }}
+          token: ${{ secrets.GH_PROJECT_PAT }}
           persist-credentials: true
 
       - name: Inspect Project V2 and refill queue

--- a/scripts/github-actions/triage-queue-refill.mjs
+++ b/scripts/github-actions/triage-queue-refill.mjs
@@ -637,13 +637,9 @@ export function commitVaultChanges({
   vaultRoot,
   archivedInboxNotes = [],
   git = defaultGit,
-  env = process.env,
 }) {
   if (!Array.isArray(archivedInboxNotes) || archivedInboxNotes.length === 0) {
     return { committed: false, commitSha: null };
-  }
-  if (!normalizeText(env.GH_PROJECT_PAT)) {
-    throw new Error("GH_PROJECT_PAT is required to commit processed Inbox disposition to duumbi-vault/main.");
   }
 
   const relativePaths = archivedInboxNotes.flatMap((note) => [note.source, note.archived]).filter(Boolean);
@@ -1334,7 +1330,6 @@ export async function runTriageQueueRefill({
       vaultRoot: path.resolve(workspace, "duumbi-vault"),
       archivedInboxNotes,
       git,
-      env,
     });
     const queued = applied.issueNumber ? 1 : 0;
     const lastDeepSeekResponse = deepSeekResponses.at(-1);

--- a/scripts/github-actions/triage-queue-refill.mjs
+++ b/scripts/github-actions/triage-queue-refill.mjs
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import fsModule from "node:fs";
 import pathModule from "node:path";
 
@@ -34,6 +35,14 @@ const DEEPSEEK_PRICING_USD_PER_1M = {
 
 function nowIso() {
   return new Date().toISOString();
+}
+
+function defaultGit(args, { cwd }) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
 }
 
 export function normalizeText(value) {
@@ -511,6 +520,145 @@ export function buildExistingIssueComment(decision) {
     "",
     "**Next stage:** Needs Human Acceptance",
   ].join("\n");
+}
+
+function isPathInside(path, root, target) {
+  const relative = path.relative(root, target);
+  return Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+function sourceLinkToInboxPath({ fs, path, vaultRoot, inboxRoot, sourceLink, warnings }) {
+  const source = normalizeText(sourceLink);
+  if (!source || /^https?:\/\//i.test(source)) return null;
+
+  const normalized = source
+    .replace(/^file:\/\//i, "")
+    .replace(/^\.\//, "")
+    .replace(/^duumbi-vault\//, "");
+  const absolutePath = path.isAbsolute(normalized)
+    ? path.resolve(normalized)
+    : path.resolve(vaultRoot, normalized);
+
+  if (!isPathInside(path, inboxRoot, absolutePath)) return null;
+  if (!fs.existsSync(absolutePath)) {
+    warnings?.push?.(`Inbox source link no longer exists: ${source}`);
+    return null;
+  }
+  if (!fs.statSync(absolutePath).isFile()) {
+    warnings?.push?.(`Inbox source link is not a file: ${source}`);
+    return null;
+  }
+  return absolutePath;
+}
+
+function uniqueArchivePath(fs, path, processedInboxRoot, filename) {
+  const parsed = path.parse(filename);
+  let candidate = path.join(processedInboxRoot, filename);
+  let suffix = 2;
+  while (fs.existsSync(candidate)) {
+    candidate = path.join(processedInboxRoot, `${parsed.name} - ${suffix}${parsed.ext}`);
+    suffix += 1;
+  }
+  return candidate;
+}
+
+function buildInboxTriageResult({ generatedAt, issueNumber, issueUrl, decision }) {
+  const routing = decision.action === "create_issue"
+    ? `Created GitHub issue #${issueNumber} and routed it to ${HUMAN_ACCEPTANCE_STATUS}.`
+    : `Routed existing GitHub issue #${issueNumber} to ${HUMAN_ACCEPTANCE_STATUS}.`;
+
+  return [
+    "## Triage result",
+    `- Date: ${generatedAt}`,
+    "- Classification: execution work",
+    `- Routing: ${routing}`,
+    "- GitHub artifacts:",
+    `  - ${issueUrl || `#${issueNumber}`}`,
+    "- Obsidian artifacts:",
+    "  - none",
+    "- Canonical duplicate:",
+    "  - none",
+    "- Open questions:",
+    "  - See GitHub issue.",
+    "- Assumptions:",
+    `  - Automated triage refill selected this source as actionable. Rationale: ${decision.rationale || "not provided"}`,
+    `- Next stage: ${HUMAN_ACCEPTANCE_STATUS}`,
+  ].join("\n");
+}
+
+export function archiveProcessedInboxNotes({
+  fs = fsModule,
+  path = pathModule,
+  workspace = process.cwd(),
+  vaultPath = "duumbi-vault",
+  sourceLinks = [],
+  generatedAt = nowIso(),
+  issueNumber,
+  issueUrl,
+  decision,
+  warnings = [],
+}) {
+  if (!issueNumber || !Array.isArray(sourceLinks) || sourceLinks.length === 0) {
+    return [];
+  }
+
+  const vaultRoot = path.resolve(workspace, vaultPath);
+  const inboxRoot = path.join(vaultRoot, "Duumbi", "00 Inbox (ToProcess)");
+  const processedInboxRoot = path.join(vaultRoot, "Duumbi", "05 Archive", "Processed Inbox");
+  const inboxPaths = new Set(
+    sourceLinks
+      .map((sourceLink) => sourceLinkToInboxPath({ fs, path, vaultRoot, inboxRoot, sourceLink, warnings }))
+      .filter(Boolean),
+  );
+
+  if (inboxPaths.size === 0) return [];
+
+  fs.mkdirSync(processedInboxRoot, { recursive: true });
+  const archived = [];
+  for (const inboxPath of inboxPaths) {
+    const original = fs.readFileSync(inboxPath, "utf8");
+    const triageResult = buildInboxTriageResult({ generatedAt, issueNumber, issueUrl, decision });
+    const nextText = /^## Triage result$/m.test(original)
+      ? original
+      : `${original.trimEnd()}\n\n${triageResult}\n`;
+    fs.writeFileSync(inboxPath, nextText);
+
+    const archivePath = uniqueArchivePath(fs, path, processedInboxRoot, path.basename(inboxPath));
+    fs.renameSync(inboxPath, archivePath);
+    archived.push({
+      source: path.relative(vaultRoot, inboxPath).split(path.sep).join("/"),
+      archived: path.relative(vaultRoot, archivePath).split(path.sep).join("/"),
+    });
+  }
+  return archived;
+}
+
+export function commitVaultChanges({
+  vaultRoot,
+  archivedInboxNotes = [],
+  git = defaultGit,
+  env = process.env,
+}) {
+  if (!Array.isArray(archivedInboxNotes) || archivedInboxNotes.length === 0) {
+    return { committed: false, commitSha: null };
+  }
+  if (!normalizeText(env.GH_PROJECT_PAT)) {
+    throw new Error("GH_PROJECT_PAT is required to commit processed Inbox disposition to duumbi-vault/main.");
+  }
+
+  const relativePaths = archivedInboxNotes.flatMap((note) => [note.source, note.archived]).filter(Boolean);
+  git(["config", "user.name", "duumbi-triage-refill[bot]"], { cwd: vaultRoot });
+  git(["config", "user.email", "duumbi-triage-refill[bot]@users.noreply.github.com"], { cwd: vaultRoot });
+  git(["add", "-A", "--", ...relativePaths], { cwd: vaultRoot });
+  const status = git(["status", "--porcelain", "--", ...relativePaths], { cwd: vaultRoot });
+  if (!normalizeText(status)) {
+    return { committed: false, commitSha: null };
+  }
+
+  git(["commit", "-m", "chore: archive processed DUUMBI inbox notes"], { cwd: vaultRoot });
+  const commitSha = normalizeText(git(["rev-parse", "HEAD"], { cwd: vaultRoot }));
+  git(["push", "origin", "HEAD:main"], { cwd: vaultRoot });
+  return { committed: true, commitSha };
 }
 
 export function estimateDeepSeekCostUsd(model, usage = {}) {
@@ -1034,6 +1182,8 @@ async function writeSummary(summary, result) {
     ["Refill needed", String(result.refillNeeded)],
     ["Decision", result.decision || "none"],
     ["Issue", result.issueNumber ? `#${result.issueNumber}` : "none"],
+    ["Inbox notes archived", String(result.inboxNotesArchived ?? 0)],
+    ["Vault commit", result.commitSha || "none"],
     ["Direct Slack notification", "not_sent"],
     ["Model", result.model || "not_called"],
   ];
@@ -1052,6 +1202,7 @@ export async function runTriageQueueRefill({
   fs = fsModule,
   path = pathModule,
   workspace = process.cwd(),
+  git = defaultGit,
 } = {}) {
   const warnings = [];
   const metricsPath = env.DUUMBI_METRICS_PATH || "duumbi-workflow-metrics.json";
@@ -1073,6 +1224,8 @@ export async function runTriageQueueRefill({
     issueNumber: null,
     model: null,
     inspectedIssueCount: null,
+    inboxNotesArchived: 0,
+    commitSha: null,
   };
 
   const writeMetrics = (metrics) => {
@@ -1159,6 +1312,30 @@ export async function runTriageQueueRefill({
     });
     const decision = validateTriageDecision(parsedDecision, triageContext);
     const applied = await applyTriageDecision({ api, project, decision });
+    result = {
+      ...result,
+      ok: true,
+      decision: decision.action,
+      issueNumber: applied.issueNumber,
+      issueUrl: applied.issueUrl,
+    };
+    const archivedInboxNotes = archiveProcessedInboxNotes({
+      fs,
+      path,
+      workspace,
+      sourceLinks: decision.source_links,
+      generatedAt: triageContext.generated_at,
+      issueNumber: applied.issueNumber,
+      issueUrl: applied.issueUrl,
+      decision,
+      warnings,
+    });
+    const vaultCommit = commitVaultChanges({
+      vaultRoot: path.resolve(workspace, "duumbi-vault"),
+      archivedInboxNotes,
+      git,
+      env,
+    });
     const queued = applied.issueNumber ? 1 : 0;
     const lastDeepSeekResponse = deepSeekResponses.at(-1);
     const combinedDeepSeekUsage = combineDeepSeekUsage(deepSeekResponses);
@@ -1170,6 +1347,9 @@ export async function runTriageQueueRefill({
       issueNumber: applied.issueNumber,
       issueUrl: applied.issueUrl,
       model: lastDeepSeekResponse.model,
+      inboxNotesArchived: archivedInboxNotes.length,
+      archivedInboxNotes,
+      commitSha: vaultCommit.commitSha,
     };
 
     const metrics = buildWorkflowMetrics({
@@ -1205,7 +1385,7 @@ export async function runTriageQueueRefill({
       issueNumber: result.issueNumber,
       counts: {
         issues_considered: result.inspectedIssueCount,
-        issues_queued: 0,
+        issues_queued: result.issueNumber ? 1 : 0,
         slack_notifications_attempted: 0,
         artifact_links_found: null,
         artifact_links_missing: null,

--- a/scripts/github-actions/triage-queue-refill.test.mjs
+++ b/scripts/github-actions/triage-queue-refill.test.mjs
@@ -120,6 +120,17 @@ function makeSummary() {
   };
 }
 
+function makeGit() {
+  const calls = [];
+  const git = (args, options = {}) => {
+    calls.push({ args, cwd: options.cwd });
+    if (args[0] === "status") return "R  Duumbi/00 Inbox (ToProcess)/candidate.md -> Duumbi/05 Archive/Processed Inbox/candidate.md\n";
+    if (args[0] === "rev-parse") return "vault-commit-sha\n";
+    return "";
+  };
+  return { git, calls };
+}
+
 function makeWorkspace() {
   const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "duumbi-triage-refill-"));
   const inbox = path.join(workspace, "duumbi-vault", "Duumbi", "00 Inbox (ToProcess)");
@@ -488,6 +499,7 @@ test("runTriageQueueRefill routes one eligible Todo issue to human acceptance", 
   const workspace = makeWorkspace();
   const { fetchImpl, calls } = makeFetch({ project, decision });
   const core = makeCore();
+  const { git, calls: gitCalls } = makeGit();
 
   const result = await runTriageQueueRefill({
     env: {
@@ -501,6 +513,7 @@ test("runTriageQueueRefill routes one eligible Todo issue to human acceptance", 
     summary: makeSummary(),
     fetchImpl,
     workspace,
+    git,
   });
 
   assert.equal(core.failed, null);
@@ -522,6 +535,22 @@ test("runTriageQueueRefill routes one eligible Todo issue to human acceptance", 
   assert.equal(metrics.counts.issues_queued, 1);
   assert.equal(metrics.counts.slack_notifications_attempted, 0);
   assert.equal(metrics.provider_usage.provider, "deepseek");
+
+  const inboxPath = path.join(workspace, "duumbi-vault", "Duumbi", "00 Inbox (ToProcess)", "candidate.md");
+  const archivedPath = path.join(workspace, "duumbi-vault", "Duumbi", "05 Archive", "Processed Inbox", "candidate.md");
+  assert.equal(fs.existsSync(inboxPath), false);
+  assert.equal(fs.existsSync(archivedPath), true);
+  const archivedText = fs.readFileSync(archivedPath, "utf8");
+  assert.match(archivedText, /## Triage result/);
+  assert.match(archivedText, /Routed existing GitHub issue #10 to Needs Human Acceptance/);
+  assert.equal(result.inboxNotesArchived, 1);
+  assert.equal(result.commitSha, "vault-commit-sha");
+  assert.equal(gitCalls.some((call) => call.args[0] === "commit"), true);
+  assert.equal(gitCalls.some((call) => call.args[0] === "push"), true);
+  assert.deepEqual(result.archivedInboxNotes, [{
+    source: "Duumbi/00 Inbox (ToProcess)/candidate.md",
+    archived: "Duumbi/05 Archive/Processed Inbox/candidate.md",
+  }]);
 });
 
 test("runTriageQueueRefill retries once when DeepSeek returns malformed JSON", async () => {
@@ -562,6 +591,7 @@ test("runTriageQueueRefill retries once when DeepSeek returns malformed JSON", a
     ],
   });
   const core = makeCore();
+  const { git } = makeGit();
 
   const result = await runTriageQueueRefill({
     env: {
@@ -575,6 +605,7 @@ test("runTriageQueueRefill retries once when DeepSeek returns malformed JSON", a
     summary: makeSummary(),
     fetchImpl,
     workspace,
+    git,
   });
 
   assert.equal(core.failed, null);
@@ -627,9 +658,66 @@ test("runTriageQueueRefill blocks before status update when existing issue label
   assert.equal(result.ok, false);
   assert.match(core.failed, /GitHub REST POST/);
   assert.equal(calls.some((call) => call.body.query?.includes("updateProjectV2ItemFieldValue")), false);
+  assert.equal(
+    fs.existsSync(path.join(workspace, "duumbi-vault", "Duumbi", "00 Inbox (ToProcess)", "candidate.md")),
+    true,
+  );
+  assert.equal(
+    fs.existsSync(path.join(workspace, "duumbi-vault", "Duumbi", "05 Archive", "Processed Inbox", "candidate.md")),
+    false,
+  );
   const metrics = JSON.parse(fs.readFileSync(path.join(workspace, "metrics.json"), "utf8"));
   assert.equal(metrics.counts.issues_considered, 2);
   assert.equal(metrics.provider_usage.request_count, null);
+});
+
+test("runTriageQueueRefill archives Inbox notes after creating a queued issue", async () => {
+  const project = projectWithItems([
+    issueItem({ number: 1, status: HUMAN_ACCEPTANCE_STATUS }),
+    issueItem({ number: 2, status: HUMAN_ACCEPTANCE_STATUS }),
+  ]);
+  const decision = {
+    action: "create_issue",
+    source_links: [
+      "Duumbi/00 Inbox (ToProcess)/candidate.md",
+      "https://github.com/hgahub/duumbi/discussions/1",
+    ],
+    rationale: "No existing Todo issue represents the candidate.",
+    issue: {
+      title: "New triage candidate",
+      body: "Create a new triage candidate.",
+    },
+  };
+  const workspace = makeWorkspace();
+  const { fetchImpl } = makeFetch({ project, decision });
+  const core = makeCore();
+  const { git, calls: gitCalls } = makeGit();
+
+  const result = await runTriageQueueRefill({
+    env: {
+      GH_PROJECT_PAT: "pat",
+      DEEPSEEK_API_KEY: "deepseek-key",
+      DUUMBI_PROJECT_NUMBER: "1",
+      DUUMBI_METRICS_PATH: "metrics.json",
+    },
+    context: makeContext(),
+    core,
+    summary: makeSummary(),
+    fetchImpl,
+    workspace,
+    git,
+  });
+
+  assert.equal(core.failed, null);
+  assert.equal(result.decision, "create_issue");
+  assert.equal(result.issueNumber, 99);
+  assert.equal(result.inboxNotesArchived, 1);
+  assert.equal(result.commitSha, "vault-commit-sha");
+  assert.equal(gitCalls.some((call) => call.args[0] === "push"), true);
+  const archivedPath = path.join(workspace, "duumbi-vault", "Duumbi", "05 Archive", "Processed Inbox", "candidate.md");
+  assert.equal(fs.existsSync(path.join(workspace, "duumbi-vault", "Duumbi", "00 Inbox (ToProcess)", "candidate.md")), false);
+  assert.equal(fs.existsSync(archivedPath), true);
+  assert.match(fs.readFileSync(archivedPath, "utf8"), /Created GitHub issue #99 and routed it to Needs Human Acceptance/);
 });
 
 test("runTriageQueueRefill closes a created issue when Project insertion fails", async () => {


### PR DESCRIPTION
## Summary
- archive cited Obsidian Inbox notes after successful triage refill queueing
- commit and push processed Inbox disposition back to duumbi-vault/main
- update the workflow vault checkout credentials and add regression coverage

## Tests
- node --test scripts/github-actions/triage-queue-refill.test.mjs
- git diff --check