### PR TITLE
feat(stdlib): publish DUUMBI-381 server evidence

### DIFF
--- a/runtime/duumbi_runtime.c
+++ b/runtime/duumbi_runtime.c
@@ -2108,7 +2108,14 @@ static DuumbiHttpRoute *duumbi_http_find_route(DuumbiHttpServer *server, const c
     return NULL;
 }
 
-static int duumbi_http_handle_client(DuumbiHttpServer *server, DuumbiSocketHandle client) {
+static int duumbi_http_handle_client(
+    DuumbiHttpServer *server,
+    DuumbiSocketHandle client,
+    int64_t timeout_ms
+) {
+    int ready = duumbi_tcp_wait(client, 0, timeout_ms);
+    if (ready <= 0) return 0;
+
     char request[DUUMBI_HTTP_MAX_REQUEST_BYTES + 1];
 #if defined(_WIN32)
     int n = recv(client, request, DUUMBI_HTTP_MAX_REQUEST_BYTES, 0);
@@ -2155,7 +2162,9 @@ void *duumbi_server_start(void *server_ptr, int64_t max_requests, int64_t timeou
         if (ready < 0) return duumbi_server_err("server_start failed");
         DuumbiSocketHandle client = accept(server->handle, NULL, NULL);
         if (client == DUUMBI_INVALID_SOCKET) return duumbi_server_err("server_start failed: accept");
-        (void)duumbi_http_handle_client(server, client);
+        int64_t read_timeout = duumbi_tcp_remaining_timeout(start_ms, timeout_ms);
+        if (read_timeout <= 0) read_timeout = 1;
+        (void)duumbi_http_handle_client(server, client, read_timeout);
         duumbi_socket_close_handle(client);
         handled++;
     }

--- a/runtime/duumbi_runtime.c
+++ b/runtime/duumbi_runtime.c
@@ -1793,6 +1793,396 @@ void *duumbi_tcp_listener_close(void *listener_ptr) {
     return duumbi_tcp_ok_i64(0);
 }
 
+/* ── HTTP server (DUUMBI-381) ─────────────────────────────────────── */
+
+#define DUUMBI_HTTP_MAX_REQUEST_BYTES 8192
+
+typedef struct {
+    char *key;
+    char *value;
+} DuumbiHttpHeader;
+
+typedef struct {
+    char *method;
+    char *path;
+    int64_t status;
+    DuumbiHttpHeader *headers;
+    uint64_t header_len;
+    char *body;
+    uint64_t body_len;
+} DuumbiHttpRoute;
+
+typedef struct {
+    DuumbiSocketHandle handle;
+    int closed;
+    int started;
+    DuumbiHttpRoute *routes;
+    uint64_t route_len;
+    uint64_t route_cap;
+} DuumbiHttpServer;
+
+static void *duumbi_server_err(const char *message) {
+    void *err = duumbi_string_new(message, (uint64_t)strlen(message));
+    return duumbi_result_new_err((int64_t)(intptr_t)err);
+}
+
+static char *duumbi_server_string_to_c(void *ptr) {
+    return duumbi_tcp_string_to_c(ptr);
+}
+
+static int duumbi_http_method_valid(const char *method) {
+    if (method == NULL || method[0] == '\0') return 0;
+    for (const unsigned char *p = (const unsigned char *)method; *p != '\0'; p++) {
+        if (!isalnum(*p) && *p != '!' && *p != '#' && *p != '$' && *p != '%' &&
+            *p != '&' && *p != '\'' && *p != '*' && *p != '+' && *p != '-' &&
+            *p != '.' && *p != '^' && *p != '_' && *p != '`' && *p != '|' &&
+            *p != '~') {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int duumbi_http_header_text_valid(const char *text) {
+    if (text == NULL || text[0] == '\0') return 0;
+    for (const unsigned char *p = (const unsigned char *)text; *p != '\0'; p++) {
+        if (*p == '\r' || *p == '\n') return 0;
+    }
+    return 1;
+}
+
+static void duumbi_http_route_free(DuumbiHttpRoute *route) {
+    if (route == NULL) return;
+    duumbi_dealloc(route->method);
+    duumbi_dealloc(route->path);
+    duumbi_dealloc(route->body);
+    for (uint64_t i = 0; i < route->header_len; i++) {
+        duumbi_dealloc(route->headers[i].key);
+        duumbi_dealloc(route->headers[i].value);
+    }
+    duumbi_dealloc(route->headers);
+    memset(route, 0, sizeof(*route));
+}
+
+static int duumbi_http_copy_headers(void *headers_ptr, DuumbiHttpHeader **out, uint64_t *out_len) {
+    DuumbiJson *headers = (DuumbiJson *)headers_ptr;
+    if (headers == NULL || headers->kind != DUUMBI_JSON_OBJECT) return 0;
+    *out = NULL;
+    *out_len = headers->object_len;
+    if (headers->object_len == 0) return 1;
+
+    DuumbiHttpHeader *copied =
+        (DuumbiHttpHeader *)duumbi_alloc(sizeof(DuumbiHttpHeader) * headers->object_len);
+    memset(copied, 0, sizeof(DuumbiHttpHeader) * headers->object_len);
+    for (uint64_t i = 0; i < headers->object_len; i++) {
+        DuumbiJsonObjectEntry *entry = &headers->object_entries[i];
+        if (entry->value == NULL || entry->value->kind != DUUMBI_JSON_STRING) {
+            for (uint64_t j = 0; j < i; j++) {
+                duumbi_dealloc(copied[j].key);
+                duumbi_dealloc(copied[j].value);
+            }
+            duumbi_dealloc(copied);
+            return 0;
+        }
+        copied[i].key = duumbi_json_strndup(entry->key, entry->key_len);
+        copied[i].value = duumbi_json_strndup(entry->value->string_value, entry->value->string_len);
+        if (!duumbi_http_header_text_valid(copied[i].key) ||
+            !duumbi_http_header_text_valid(copied[i].value)) {
+            for (uint64_t j = 0; j <= i; j++) {
+                duumbi_dealloc(copied[j].key);
+                duumbi_dealloc(copied[j].value);
+            }
+            duumbi_dealloc(copied);
+            return 0;
+        }
+    }
+    *out = copied;
+    return 1;
+}
+
+void *duumbi_server_new(void *host_ptr, int64_t port, int64_t timeout_ms) {
+    if (!duumbi_socket_init()) return duumbi_server_err("server_new failed: socket init failed");
+    if (!duumbi_tcp_validate_port(port)) return duumbi_server_err("server_new failed: invalid port");
+    if (!duumbi_tcp_validate_common(timeout_ms)) {
+        return duumbi_server_err("server_new failed: invalid timeout_ms");
+    }
+    char *host = duumbi_server_string_to_c(host_ptr);
+    if (host == NULL) return duumbi_server_err("server_new failed: host is null");
+    uint64_t start_ms = duumbi_tcp_now_ms();
+
+    char port_buf[16];
+    snprintf(port_buf, sizeof(port_buf), "%lld", (long long)port);
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_flags = AI_PASSIVE | AI_NUMERICHOST;
+    struct addrinfo *res = NULL;
+    if (getaddrinfo(host, port_buf, &hints, &res) != 0) {
+        duumbi_dealloc(host);
+        return duumbi_server_err("server_new failed: address resolution failed");
+    }
+
+    DuumbiSocketHandle bound = DUUMBI_INVALID_SOCKET;
+    int timed_out = 0;
+    for (struct addrinfo *ai = res; ai != NULL; ai = ai->ai_next) {
+        if (duumbi_tcp_remaining_timeout(start_ms, timeout_ms) <= 0) {
+            timed_out = 1;
+            break;
+        }
+        DuumbiSocketHandle handle = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+        if (handle == DUUMBI_INVALID_SOCKET) continue;
+        int yes = 1;
+        setsockopt(handle, SOL_SOCKET, SO_REUSEADDR, (const char *)&yes, sizeof(yes));
+        if (bind(handle, ai->ai_addr, (int)ai->ai_addrlen) == 0 &&
+            listen(handle, 16) == 0 &&
+            duumbi_socket_set_nonblocking(handle)) {
+            bound = handle;
+            break;
+        }
+        duumbi_socket_close_handle(handle);
+    }
+    freeaddrinfo(res);
+    duumbi_dealloc(host);
+
+    if (bound == DUUMBI_INVALID_SOCKET) {
+        return duumbi_server_err(timed_out ? "server_new failed: timeout" : "server_new failed");
+    }
+    DuumbiHttpServer *server = (DuumbiHttpServer *)duumbi_alloc(sizeof(DuumbiHttpServer));
+    memset(server, 0, sizeof(*server));
+    server->handle = bound;
+    return duumbi_tcp_ok_ptr(server);
+}
+
+void *duumbi_route_add_static(
+    void *server_ptr,
+    void *method_ptr,
+    void *path_ptr,
+    int64_t status,
+    void *headers_ptr,
+    void *body_ptr
+) {
+    DuumbiHttpServer *server = (DuumbiHttpServer *)server_ptr;
+    if (server == NULL || server->closed) {
+        return duumbi_server_err("route_add_static failed: server is closed");
+    }
+    if (server->started) return duumbi_server_err("route_add_static failed: server already started");
+    if (status < 100 || status > 599) return duumbi_server_err("route_add_static failed: invalid status");
+
+    char *method = duumbi_server_string_to_c(method_ptr);
+    char *path = duumbi_server_string_to_c(path_ptr);
+    char *body = duumbi_server_string_to_c(body_ptr);
+    if (method == NULL || path == NULL || body == NULL) {
+        duumbi_dealloc(method);
+        duumbi_dealloc(path);
+        duumbi_dealloc(body);
+        return duumbi_server_err("route_add_static failed: null string");
+    }
+    if (!duumbi_http_method_valid(method) || path[0] != '/') {
+        duumbi_dealloc(method);
+        duumbi_dealloc(path);
+        duumbi_dealloc(body);
+        return duumbi_server_err("route_add_static failed: invalid route");
+    }
+    for (uint64_t i = 0; i < server->route_len; i++) {
+        if (strcmp(server->routes[i].method, method) == 0 &&
+            strcmp(server->routes[i].path, path) == 0) {
+            duumbi_dealloc(method);
+            duumbi_dealloc(path);
+            duumbi_dealloc(body);
+            return duumbi_server_err("route_add_static failed: duplicate route");
+        }
+    }
+
+    DuumbiHttpHeader *headers = NULL;
+    uint64_t header_len = 0;
+    if (!duumbi_http_copy_headers(headers_ptr, &headers, &header_len)) {
+        duumbi_dealloc(method);
+        duumbi_dealloc(path);
+        duumbi_dealloc(body);
+        return duumbi_server_err("route_add_static failed: invalid headers");
+    }
+
+    if (server->route_len == server->route_cap) {
+        uint64_t new_cap = server->route_cap == 0 ? 4 : server->route_cap * 2;
+        DuumbiHttpRoute *new_routes =
+            (DuumbiHttpRoute *)realloc(server->routes, sizeof(DuumbiHttpRoute) * new_cap);
+        if (new_routes == NULL) {
+            duumbi_dealloc(method);
+            duumbi_dealloc(path);
+            duumbi_dealloc(body);
+            for (uint64_t i = 0; i < header_len; i++) {
+                duumbi_dealloc(headers[i].key);
+                duumbi_dealloc(headers[i].value);
+            }
+            duumbi_dealloc(headers);
+            return duumbi_server_err("route_add_static failed: out of memory");
+        }
+        server->routes = new_routes;
+        server->route_cap = new_cap;
+    }
+
+    DuumbiHttpRoute *route = &server->routes[server->route_len++];
+    memset(route, 0, sizeof(*route));
+    route->method = method;
+    route->path = path;
+    route->status = status;
+    route->headers = headers;
+    route->header_len = header_len;
+    route->body = body;
+    route->body_len = strlen(body);
+    return duumbi_tcp_ok_i64(0);
+}
+
+static const char *duumbi_http_status_text(int64_t status) {
+    switch (status) {
+    case 200: return "OK";
+    case 201: return "Created";
+    case 204: return "No Content";
+    case 400: return "Bad Request";
+    case 404: return "Not Found";
+    case 500: return "Internal Server Error";
+    default: return "OK";
+    }
+}
+
+static int duumbi_http_send_all(DuumbiSocketHandle handle, const char *data, size_t len) {
+    size_t sent = 0;
+    while (sent < len) {
+#if defined(_WIN32)
+        int n = send(handle, data + sent, (int)(len - sent), 0);
+#else
+        ssize_t n = send(handle, data + sent, len - sent, 0);
+#endif
+        if (n <= 0) return 0;
+        sent += (size_t)n;
+    }
+    return 1;
+}
+
+static int duumbi_http_write_response(DuumbiSocketHandle client, DuumbiHttpRoute *route) {
+    char head[2048];
+    size_t len = 0;
+    if (route == NULL) {
+        len = (size_t)snprintf(
+            head,
+            sizeof(head),
+            "HTTP/1.1 404 Not Found\r\nContent-Length: 9\r\nConnection: close\r\n\r\nnot found"
+        );
+        return len < sizeof(head) && duumbi_http_send_all(client, head, len);
+    }
+    len = (size_t)snprintf(
+        head,
+        sizeof(head),
+        "HTTP/1.1 %lld %s\r\nContent-Length: %llu\r\nConnection: close\r\n",
+        (long long)route->status,
+        duumbi_http_status_text(route->status),
+        (unsigned long long)route->body_len
+    );
+    if (len >= sizeof(head)) return 0;
+    for (uint64_t i = 0; i < route->header_len; i++) {
+        int written = snprintf(
+            head + len,
+            sizeof(head) - len,
+            "%s: %s\r\n",
+            route->headers[i].key,
+            route->headers[i].value
+        );
+        if (written < 0 || (size_t)written >= sizeof(head) - len) return 0;
+        len += (size_t)written;
+    }
+    if (len + 2 >= sizeof(head)) return 0;
+    memcpy(head + len, "\r\n", 3);
+    len += 2;
+    return duumbi_http_send_all(client, head, len) &&
+           duumbi_http_send_all(client, route->body, (size_t)route->body_len);
+}
+
+static DuumbiHttpRoute *duumbi_http_find_route(DuumbiHttpServer *server, const char *method, const char *path) {
+    for (uint64_t i = 0; i < server->route_len; i++) {
+        if (strcmp(server->routes[i].method, method) == 0 &&
+            strcmp(server->routes[i].path, path) == 0) {
+            return &server->routes[i];
+        }
+    }
+    return NULL;
+}
+
+static int duumbi_http_handle_client(DuumbiHttpServer *server, DuumbiSocketHandle client) {
+    char request[DUUMBI_HTTP_MAX_REQUEST_BYTES + 1];
+#if defined(_WIN32)
+    int n = recv(client, request, DUUMBI_HTTP_MAX_REQUEST_BYTES, 0);
+#else
+    ssize_t n = recv(client, request, DUUMBI_HTTP_MAX_REQUEST_BYTES, 0);
+#endif
+    if (n <= 0) return 0;
+    request[n] = '\0';
+    char method[32];
+    char path[1024];
+    if (sscanf(request, "%31s %1023s", method, path) != 2) {
+        DuumbiHttpRoute *missing = NULL;
+        return duumbi_http_write_response(client, missing);
+    }
+    return duumbi_http_write_response(client, duumbi_http_find_route(server, method, path));
+}
+
+void *duumbi_server_start(void *server_ptr, int64_t max_requests, int64_t timeout_ms) {
+    DuumbiHttpServer *server = (DuumbiHttpServer *)server_ptr;
+    if (server == NULL || server->closed) {
+        return duumbi_server_err("server_start failed: server is closed");
+    }
+    if (max_requests <= 0) return duumbi_server_err("server_start failed: invalid max_requests");
+    if (!duumbi_tcp_validate_common(timeout_ms)) {
+        return duumbi_server_err("server_start failed: invalid timeout_ms");
+    }
+    server->started = 1;
+    uint64_t start_ms = duumbi_tcp_now_ms();
+    int64_t handled = 0;
+
+    while (handled < max_requests) {
+        int64_t remaining = duumbi_tcp_remaining_timeout(start_ms, timeout_ms);
+        if (remaining <= 0) {
+            return handled > 0
+                ? duumbi_tcp_ok_i64(handled)
+                : duumbi_server_err("server_start failed: timeout");
+        }
+        int ready = duumbi_tcp_wait(server->handle, 0, remaining);
+        if (ready == 0) {
+            return handled > 0
+                ? duumbi_tcp_ok_i64(handled)
+                : duumbi_server_err("server_start failed: timeout");
+        }
+        if (ready < 0) return duumbi_server_err("server_start failed");
+        DuumbiSocketHandle client = accept(server->handle, NULL, NULL);
+        if (client == DUUMBI_INVALID_SOCKET) return duumbi_server_err("server_start failed: accept");
+        (void)duumbi_http_handle_client(server, client);
+        duumbi_socket_close_handle(client);
+        handled++;
+    }
+    return duumbi_tcp_ok_i64(handled);
+}
+
+void *duumbi_server_close(void *server_ptr) {
+    DuumbiHttpServer *server = (DuumbiHttpServer *)server_ptr;
+    if (server == NULL) return duumbi_tcp_ok_i64(0);
+    if (!server->closed && server->handle != DUUMBI_INVALID_SOCKET) {
+        duumbi_socket_close_handle(server->handle);
+        server->closed = 1;
+    }
+    return duumbi_tcp_ok_i64(0);
+}
+
+void duumbi_server_free(void *server_ptr) {
+    DuumbiHttpServer *server = (DuumbiHttpServer *)server_ptr;
+    if (server == NULL) return;
+    (void)duumbi_server_close(server);
+    for (uint64_t i = 0; i < server->route_len; i++) {
+        duumbi_http_route_free(&server->routes[i]);
+    }
+    duumbi_dealloc(server->routes);
+    duumbi_dealloc(server);
+}
+
 /* ── Option (tagged union: {i8 discriminant, i64 payload}) ────────── */
 /*
  * Layout: DuumbiOption = { int8_t tag, int64_t payload }

--- a/runtime/duumbi_runtime.h
+++ b/runtime/duumbi_runtime.h
@@ -114,4 +114,13 @@ void    *duumbi_tcp_listener_close(void *listener);
 void     duumbi_tcp_socket_free(void *socket);
 void     duumbi_tcp_listener_free(void *listener);
 
+/* ── HTTP server ─────────────────────────────────────────────────── */
+
+void    *duumbi_server_new(void *host, int64_t port, int64_t timeout_ms);
+void    *duumbi_route_add_static(void *server, void *method, void *path,
+                                 int64_t status, void *headers, void *body);
+void    *duumbi_server_start(void *server, int64_t max_requests, int64_t timeout_ms);
+void    *duumbi_server_close(void *server);
+void     duumbi_server_free(void *server);
+
 #endif /* DUUMBI_RUNTIME_H */

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -29,6 +29,9 @@ const STDLIB_JSON: &str = include_str!("../../stdlib/json.jsonld");
 /// Embedded `stdlib/net.jsonld` — bounded TCP socket and listener helpers.
 const STDLIB_NET: &str = include_str!("../../stdlib/net.jsonld");
 
+/// Embedded `stdlib/server.jsonld` — bounded local static-route HTTP server helpers.
+const STDLIB_SERVER: &str = include_str!("../../stdlib/server.jsonld");
+
 /// Stdlib module versions pinned at init time.
 const STDLIB_VERSION: &str = "1.0.0";
 
@@ -411,6 +414,29 @@ pub fn run_init_with_options(base: &Path, options: &InitOptions) -> Result<InitS
     )
     .context("Failed to write stdlib net module")?;
 
+    // Write stdlib server module to cache. It remains opt-in and is not added
+    // to default dependencies by this issue.
+    write_cache_module(
+        &duumbi_dir,
+        "@duumbi",
+        "stdlib-server",
+        STDLIB_VERSION,
+        "server.jsonld",
+        STDLIB_SERVER,
+        ModuleManifest::new(
+            "@duumbi/stdlib-server",
+            STDLIB_VERSION,
+            "Bounded local static-route HTTP server functions",
+            vec![
+                "server_new".to_string(),
+                "route_add_static".to_string(),
+                "server_start".to_string(),
+                "server_close".to_string(),
+            ],
+        ),
+    )
+    .context("Failed to write stdlib server module")?;
+
     // Write config (includes stdlib deps by default).
     //
     // The `[workspace]` block is built via formatting (not chained string
@@ -554,6 +580,16 @@ mod tests {
                 .exists(),
             "stdlib-net manifest must exist"
         );
+        assert!(
+            d.join("cache/@duumbi/stdlib-server@1.0.0/graph/server.jsonld")
+                .exists(),
+            "stdlib-server jsonld must exist"
+        );
+        assert!(
+            d.join("cache/@duumbi/stdlib-server@1.0.0/manifest.toml")
+                .exists(),
+            "stdlib-server manifest must exist"
+        );
     }
 
     #[test]
@@ -610,10 +646,25 @@ mod tests {
                 "tcp_listener_close"
             ]
         );
+
+        let server_manifest = crate::manifest::parse_manifest(
+            &d.join("cache/@duumbi/stdlib-server@1.0.0/manifest.toml"),
+        )
+        .expect("server manifest must parse");
+        assert_eq!(server_manifest.module.name, "@duumbi/stdlib-server");
+        assert_eq!(
+            server_manifest.exports.functions,
+            vec![
+                "server_new",
+                "route_add_static",
+                "server_start",
+                "server_close"
+            ]
+        );
     }
 
     #[test]
-    fn init_keeps_json_net_out_of_default_dependencies() {
+    fn init_keeps_integration_modules_out_of_default_dependencies() {
         let tmp = TempDir::new().expect("tempdir");
         run_init(tmp.path()).expect("init must succeed");
 
@@ -625,6 +676,9 @@ mod tests {
         assert!(config.contains("\"@duumbi/stdlib-string\" = \"1.0.0\""));
         assert!(!config.contains("@duumbi/stdlib-json"));
         assert!(!config.contains("@duumbi/stdlib-net"));
+        assert!(!config.contains("@duumbi/stdlib-server"));
+        assert!(!config.contains("@duumbi/stdlib-http"));
+        assert!(!config.contains("@duumbi/stdlib-db"));
     }
 
     #[test]

--- a/src/cli/publish.rs
+++ b/src/cli/publish.rs
@@ -4,8 +4,9 @@
 //! registry. Validates the manifest and graph before packaging.
 
 use std::fmt::Write as _;
+use std::fs;
 use std::io::{self, Write as IoWrite};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
@@ -50,17 +51,17 @@ pub async fn run_publish(
         })?
         .clone();
 
-    // 2. Validate graph files pass `duumbi check`
-    let graph_path = workspace.join(".duumbi/graph/main.jsonld");
-    if !graph_path.exists() {
-        anyhow::bail!(
-            "No graph file found at .duumbi/graph/main.jsonld.\n\
-             A publishable module must have at least a main.jsonld."
-        );
+    // 2. Validate graph files
+    let graph_files = collect_publish_graph_files(workspace)?;
+    eprintln!("Validating graph files...");
+    for graph_path in &graph_files {
+        super::commands::parse_and_validate(graph_path).with_context(|| {
+            format!(
+                "Graph validation failed for '{}'. Fix errors before publishing.",
+                graph_path.display()
+            )
+        })?;
     }
-    eprintln!("Validating graph...");
-    super::commands::check(&graph_path)
-        .context("Graph validation failed. Fix errors before publishing.")?;
 
     // 3. Package module
     eprintln!("Packaging module...");
@@ -181,6 +182,39 @@ fn resolve_target_registry(cfg: &config::DuumbiConfig, explicit: Option<&str>) -
         "No target registry specified.\n\
          Use `--registry <name>` or set a default with `duumbi registry default <name>`."
     )
+}
+
+/// Collects all publishable `.jsonld` graph files from a workspace.
+fn collect_publish_graph_files(workspace: &Path) -> Result<Vec<PathBuf>> {
+    let graph_dir = workspace.join(".duumbi/graph");
+    if !graph_dir.exists() {
+        anyhow::bail!(
+            "No graph directory found at .duumbi/graph.\n\
+             A publishable module must have at least one .jsonld graph file."
+        );
+    }
+
+    let mut graph_files = Vec::new();
+    for entry in fs::read_dir(&graph_dir)
+        .with_context(|| format!("Failed to read graph directory '{}'", graph_dir.display()))?
+    {
+        let entry =
+            entry.with_context(|| format!("Failed to read entry in '{}'", graph_dir.display()))?;
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) == Some("jsonld") {
+            graph_files.push(path);
+        }
+    }
+    graph_files.sort();
+
+    if graph_files.is_empty() {
+        anyhow::bail!(
+            "No .jsonld graph files found in .duumbi/graph.\n\
+             A publishable module must have at least one .jsonld graph file."
+        );
+    }
+
+    Ok(graph_files)
 }
 
 /// Formats a byte count as a human-readable size string.
@@ -308,6 +342,14 @@ mod tests {
         fs::write(graph.join("main.jsonld"), VALID_GRAPH).expect("invariant: write graph");
     }
 
+    fn rename_main_graph(dir: &std::path::Path, new_name: &str) {
+        use std::fs;
+
+        let graph = dir.join(".duumbi/graph");
+        fs::rename(graph.join("main.jsonld"), graph.join(new_name))
+            .expect("invariant: rename graph");
+    }
+
     #[test]
     fn resolve_explicit_registry() {
         let cfg = make_config(vec![("duumbi", "https://r.dev")], None);
@@ -348,6 +390,43 @@ mod tests {
 
         let tarball = package::pack_module(tmp.path()).expect("pack must succeed");
         assert!(!tarball.is_empty());
+    }
+
+    #[test]
+    fn collect_publish_graph_files_returns_sorted_jsonld_files() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().expect("invariant: tempdir");
+        let graph = tmp.path().join(".duumbi/graph");
+        fs::create_dir_all(&graph).expect("invariant: create dirs");
+        fs::write(graph.join("z.jsonld"), VALID_GRAPH).expect("write z");
+        fs::write(graph.join("a.jsonld"), VALID_GRAPH).expect("write a");
+        fs::write(graph.join("README.md"), "ignored").expect("write ignored");
+
+        let files = collect_publish_graph_files(tmp.path()).expect("must collect");
+        let names: Vec<String> = files
+            .iter()
+            .map(|path| path.file_name().unwrap().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(names, vec!["a.jsonld", "z.jsonld"]);
+    }
+
+    #[test]
+    fn collect_publish_graph_files_requires_jsonld_files() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().expect("invariant: tempdir");
+        let graph = tmp.path().join(".duumbi/graph");
+        fs::create_dir_all(&graph).expect("invariant: create dirs");
+        fs::write(graph.join("README.md"), "ignored").expect("write ignored");
+
+        let err = collect_publish_graph_files(tmp.path()).expect_err("must fail without jsonld");
+        assert!(
+            err.to_string().contains("No .jsonld graph files found"),
+            "expected missing graph file error, got: {err}"
+        );
     }
 
     #[test]
@@ -424,6 +503,48 @@ mod tests {
         run_publish(tmp.path(), Some("test"), true, false)
             .await
             .expect("dry-run must succeed without auth");
+    }
+
+    #[tokio::test]
+    async fn publish_dry_run_accepts_non_main_graph_file() {
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().expect("invariant: tempdir");
+        make_publishable_workspace(tmp.path(), "@test/non-main", "1.0.0");
+        rename_main_graph(tmp.path(), "stdlib-test.jsonld");
+
+        run_publish(tmp.path(), Some("test"), true, false)
+            .await
+            .expect("dry-run must validate and package non-main graph");
+    }
+
+    #[tokio::test]
+    async fn publish_dry_run_requires_release_manifest_metadata() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().expect("invariant: tempdir");
+        make_publishable_workspace(tmp.path(), "@test/missing-metadata", "1.0.0");
+
+        let duumbi = tmp.path().join(".duumbi");
+        let mut manifest = crate::manifest::ModuleManifest::new(
+            "@test/missing-metadata",
+            "1.0.0",
+            "",
+            vec!["main".into()],
+        );
+        manifest.module.license.clear();
+        fs::write(duumbi.join("manifest.toml"), manifest.to_toml())
+            .expect("invariant: write manifest");
+
+        let err = run_publish(tmp.path(), Some("test"), true, false)
+            .await
+            .expect_err("dry-run must fail without required release metadata");
+        assert!(
+            err.to_string().contains("module.description")
+                || err.to_string().contains("module.license"),
+            "expected release metadata error, got: {err}"
+        );
     }
 
     #[tokio::test]
@@ -534,12 +655,12 @@ mod tests {
         fs::write(duumbi.join("manifest.toml"), manifest.to_toml())
             .expect("invariant: write manifest");
 
-        // No main.jsonld — should fail
+        // No .jsonld file — should fail
         let err = run_publish(tmp.path(), Some("test"), true, false)
             .await
-            .expect_err("must fail without main.jsonld");
+            .expect_err("must fail without graph jsonld");
         assert!(
-            err.to_string().contains("No graph file found"),
+            err.to_string().contains("No .jsonld graph files found"),
             "expected missing graph error, got: {err}"
         );
     }

--- a/src/compiler/lowering.rs
+++ b/src/compiler/lowering.rs
@@ -112,6 +112,13 @@ struct RuntimeFuncs {
     tcp_socket_free: FuncId,
     tcp_listener_free: FuncId,
 
+    // HTTP server functions (DUUMBI-381)
+    server_new: FuncId,
+    route_add_static: FuncId,
+    server_start: FuncId,
+    server_close: FuncId,
+    server_free: FuncId,
+
     trace: Option<RuntimeTraceFuncs>,
 }
 
@@ -353,6 +360,21 @@ fn declare_all_runtime_fns(
         )?,
         tcp_socket_free: declare_runtime_fn(module, "duumbi_tcp_socket_free", &[i64t], &[])?,
         tcp_listener_free: declare_runtime_fn(module, "duumbi_tcp_listener_free", &[i64t], &[])?,
+        server_new: declare_runtime_fn(module, "duumbi_server_new", &[i64t, i64t, i64t], &[i64t])?,
+        route_add_static: declare_runtime_fn(
+            module,
+            "duumbi_route_add_static",
+            &[i64t, i64t, i64t, i64t, i64t, i64t],
+            &[i64t],
+        )?,
+        server_start: declare_runtime_fn(
+            module,
+            "duumbi_server_start",
+            &[i64t, i64t, i64t],
+            &[i64t],
+        )?,
+        server_close: declare_runtime_fn(module, "duumbi_server_close", &[i64t], &[i64t])?,
+        server_free: declare_runtime_fn(module, "duumbi_server_free", &[i64t], &[])?,
         trace,
     })
 }
@@ -373,6 +395,7 @@ fn duumbi_type_to_cl(ty: &DuumbiType) -> cranelift_codegen::ir::Type {
         | DuumbiType::Json
         | DuumbiType::TcpSocket
         | DuumbiType::TcpListener
+        | DuumbiType::HttpServer
         | DuumbiType::Array(_)
         | DuumbiType::Struct(_) => types::I64,
         // References are pointer-sized (Phase 9a-2)
@@ -901,6 +924,12 @@ fn compile_function(
         obj_module.declare_func_in_func(runtime.tcp_socket_free, builder.func);
     let tcp_listener_free_ref =
         obj_module.declare_func_in_func(runtime.tcp_listener_free, builder.func);
+    let server_new_ref = obj_module.declare_func_in_func(runtime.server_new, builder.func);
+    let route_add_static_ref =
+        obj_module.declare_func_in_func(runtime.route_add_static, builder.func);
+    let server_start_ref = obj_module.declare_func_in_func(runtime.server_start, builder.func);
+    let server_close_ref = obj_module.declare_func_in_func(runtime.server_close, builder.func);
+    let server_free_ref = obj_module.declare_func_in_func(runtime.server_free, builder.func);
     let trace_refs = runtime.trace.as_ref().map(|trace| RuntimeTraceRefs {
         init: obj_module.declare_func_in_func(trace.init, builder.func),
         function_enter: obj_module.declare_func_in_func(trace.function_enter, builder.func),
@@ -1166,6 +1195,9 @@ fn compile_function(
                             }
                             DuumbiType::TcpListener => {
                                 builder.ins().call(tcp_listener_free_ref, &[*val]);
+                            }
+                            DuumbiType::HttpServer => {
+                                builder.ins().call(server_free_ref, &[*val]);
                             }
                             DuumbiType::Array(_) => {
                                 builder.ins().call(array_free_ref, &[*val]);
@@ -1589,6 +1621,9 @@ fn compile_function(
                         Some(DuumbiType::TcpListener) => {
                             builder.ins().call(tcp_listener_free_ref, &[operand_val]);
                         }
+                        Some(DuumbiType::HttpServer) => {
+                            builder.ins().call(server_free_ref, &[operand_val]);
+                        }
                         Some(DuumbiType::Array(_)) => {
                             builder.ins().call(array_free_ref, &[operand_val]);
                         }
@@ -1912,6 +1947,51 @@ fn compile_function(
                 Op::TcpListenerClose => {
                     let listener_val = get_unary_operand(graph, node_idx, &value_map)?;
                     let call = builder.ins().call(tcp_listener_close_ref, &[listener_val]);
+                    let result = builder.inst_results(call)[0];
+                    value_map.insert(node.id.clone(), result);
+                }
+                Op::ServerNew => {
+                    let host_val = get_unary_operand(graph, node_idx, &value_map)?;
+                    let port_val = get_left_operand(graph, node_idx, &value_map)?;
+                    let timeout_val = get_right_operand(graph, node_idx, &value_map)?;
+                    let call = builder
+                        .ins()
+                        .call(server_new_ref, &[host_val, port_val, timeout_val]);
+                    let result = builder.inst_results(call)[0];
+                    value_map.insert(node.id.clone(), result);
+                }
+                Op::RouteAddStatic => {
+                    let server_val = get_unary_operand(graph, node_idx, &value_map)?;
+                    let args = get_call_args(graph, node_idx, &value_map)?;
+                    if args.len() != 5 {
+                        return Err(CompileError::Cranelift {
+                            message: format!(
+                                "RouteAddStatic node '{}' must have exactly 5 args",
+                                node.id
+                            ),
+                        });
+                    }
+                    let call = builder.ins().call(
+                        route_add_static_ref,
+                        &[server_val, args[0], args[1], args[2], args[3], args[4]],
+                    );
+                    let result = builder.inst_results(call)[0];
+                    value_map.insert(node.id.clone(), result);
+                }
+                Op::ServerStart => {
+                    let server_val = get_unary_operand(graph, node_idx, &value_map)?;
+                    let max_requests_val = get_left_operand(graph, node_idx, &value_map)?;
+                    let timeout_val = get_right_operand(graph, node_idx, &value_map)?;
+                    let call = builder.ins().call(
+                        server_start_ref,
+                        &[server_val, max_requests_val, timeout_val],
+                    );
+                    let result = builder.inst_results(call)[0];
+                    value_map.insert(node.id.clone(), result);
+                }
+                Op::ServerClose => {
+                    let server_val = get_unary_operand(graph, node_idx, &value_map)?;
+                    let call = builder.ins().call(server_close_ref, &[server_val]);
                     let result = builder.inst_results(call)[0];
                     value_map.insert(node.id.clone(), result);
                 }
@@ -2257,6 +2337,7 @@ fn type_size(ty: &DuumbiType) -> i64 {
         | DuumbiType::Json
         | DuumbiType::TcpSocket
         | DuumbiType::TcpListener
+        | DuumbiType::HttpServer
         | DuumbiType::Array(_)
         | DuumbiType::Struct(_) => 8,
         // References are pointer-sized (Phase 9a-2)
@@ -2563,6 +2644,134 @@ mod tests {
         let sg = build_graph(&module).expect("invariant: fixture must build");
         let obj_bytes = compile_to_object(&sg).expect("compilation should succeed");
         assert_valid_object(&obj_bytes);
+    }
+
+    #[test]
+    fn compile_server_stdlib_graph_produces_runtime_imports() {
+        let module = parse_jsonld(
+            &std::fs::read_to_string("stdlib/server.jsonld")
+                .expect("invariant: server stdlib graph must exist"),
+        )
+        .expect("server stdlib graph must parse");
+        let sg = crate::graph::builder::build_graph_no_call_check(&module)
+            .expect("server stdlib graph must build");
+        let obj_bytes = compile_to_object(&sg).expect("compilation should succeed");
+        assert_valid_object(&obj_bytes);
+        assert!(object_contains(&obj_bytes, "duumbi_server_new"));
+        assert!(object_contains(&obj_bytes, "duumbi_route_add_static"));
+        assert!(object_contains(&obj_bytes, "duumbi_server_start"));
+        assert!(object_contains(&obj_bytes, "duumbi_server_close"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn c_runtime_server_handles_one_loopback_request() {
+        use std::io::Write as _;
+        use std::net::TcpListener;
+        use std::process::Command;
+
+        let probe = TcpListener::bind("127.0.0.1:0").expect("free loopback port");
+        let port = probe.local_addr().expect("local addr").port();
+        drop(probe);
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let harness = tmp.path().join("server_harness.c");
+        let binary = tmp.path().join("server_harness");
+        let mut file = std::fs::File::create(&harness).expect("create harness");
+        writeln!(
+            file,
+            r#"
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include "duumbi_runtime.h"
+
+static void *str(const char *s) {{
+    return duumbi_string_new(s, (uint64_t)strlen(s));
+}}
+
+static void client_request(int port) {{
+    usleep(100000);
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    assert(fd >= 0);
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons((uint16_t)port);
+    assert(inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr) == 1);
+    assert(connect(fd, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+    const char *req = "GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    assert(send(fd, req, strlen(req), 0) > 0);
+    char buf[512];
+    int n = (int)recv(fd, buf, sizeof(buf) - 1, 0);
+    assert(n > 0);
+    buf[n] = '\0';
+    assert(strstr(buf, "HTTP/1.1 200 OK") != NULL);
+    assert(strstr(buf, "Content-Length: 2") != NULL);
+    assert(strstr(buf, "\r\n\r\nok") != NULL);
+    close(fd);
+    _exit(0);
+}}
+
+int main(void) {{
+    void *server_res = duumbi_server_new(str("127.0.0.1"), {port}, 1000);
+    assert(duumbi_result_is_ok(server_res));
+    void *server = (void *)(intptr_t)duumbi_result_unwrap(server_res);
+    void *headers_res = duumbi_json_parse(str("{{}}"));
+    assert(duumbi_result_is_ok(headers_res));
+    void *headers = (void *)(intptr_t)duumbi_result_unwrap(headers_res);
+    void *route_res = duumbi_route_add_static(
+        server, str("GET"), str("/health"), 200, headers, str("ok")
+    );
+    assert(duumbi_result_is_ok(route_res));
+    pid_t child = fork();
+    assert(child >= 0);
+    if (child == 0) client_request({port});
+    void *start_res = duumbi_server_start(server, 1, 2000);
+    assert(duumbi_result_is_ok(start_res));
+    assert(duumbi_result_unwrap(start_res) == 1);
+    int status = 0;
+    assert(waitpid(child, &status, 0) == child);
+    assert(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+    void *close_res = duumbi_server_close(server);
+    assert(duumbi_result_is_ok(close_res));
+    duumbi_server_free(server);
+    return 0;
+}}
+"#
+        )
+        .expect("write harness");
+
+        let compile = Command::new("cc")
+            .arg("runtime/duumbi_runtime.c")
+            .arg(&harness)
+            .arg("-Iruntime")
+            .arg("-lm")
+            .arg("-o")
+            .arg(&binary)
+            .output()
+            .expect("run cc");
+        assert!(
+            compile.status.success(),
+            "cc failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&compile.stdout),
+            String::from_utf8_lossy(&compile.stderr)
+        );
+
+        let run = Command::new(&binary).output().expect("run harness");
+        assert!(
+            run.status.success(),
+            "server harness failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&run.stdout),
+            String::from_utf8_lossy(&run.stderr)
+        );
     }
 
     #[test]

--- a/src/compiler/lowering.rs
+++ b/src/compiler/lowering.rs
@@ -2967,9 +2967,15 @@ static void client_request(int port) {{
     const char *req = "GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n";
     assert(send(fd, req, strlen(req), 0) > 0);
     char buf[512];
-    int n = (int)recv(fd, buf, sizeof(buf) - 1, 0);
-    assert(n > 0);
-    buf[n] = '\0';
+    int total = 0;
+    for (;;) {{
+        int n = (int)recv(fd, buf + total, sizeof(buf) - 1 - (size_t)total, 0);
+        if (n <= 0) break;
+        total += n;
+        if (total >= (int)sizeof(buf) - 1) break;
+    }}
+    assert(total > 0);
+    buf[total] = '\0';
     assert(strstr(buf, "HTTP/1.1 200 OK") != NULL);
     assert(strstr(buf, "Content-Length: 2") != NULL);
     assert(strstr(buf, "\r\n\r\nok") != NULL);

--- a/src/graph/result_safety.rs
+++ b/src/graph/result_safety.rs
@@ -38,6 +38,10 @@ pub fn has_result_option_ops(graph: &SemanticGraph) -> bool {
                 | Op::FileExists
                 | Op::ListDir
                 | Op::PathJoin
+                | Op::ServerNew
+                | Op::RouteAddStatic
+                | Op::ServerStart
+                | Op::ServerClose
         )
     })
 }
@@ -114,6 +118,10 @@ fn direct_result_or_option_type(node: &GraphNode) -> Option<&DuumbiType> {
             | Op::FileExists
             | Op::ListDir
             | Op::PathJoin
+            | Op::ServerNew
+            | Op::RouteAddStatic
+            | Op::ServerStart
+            | Op::ServerClose
     ) {
         return None;
     }

--- a/src/graph/validator.rs
+++ b/src/graph/validator.rs
@@ -333,6 +333,127 @@ fn check_types(graph: &SemanticGraph, diagnostics: &mut Vec<Diagnostic>) {
                     diagnostics,
                 );
             }
+            Op::ServerNew => {
+                check_operand_type(
+                    graph,
+                    node_idx,
+                    node,
+                    GraphEdge::Operand,
+                    &DuumbiType::String,
+                    "ServerNew host must be string",
+                    diagnostics,
+                );
+                check_operand_type(
+                    graph,
+                    node_idx,
+                    node,
+                    GraphEdge::Left,
+                    &DuumbiType::I64,
+                    "ServerNew port must be i64",
+                    diagnostics,
+                );
+                check_operand_type(
+                    graph,
+                    node_idx,
+                    node,
+                    GraphEdge::Right,
+                    &DuumbiType::I64,
+                    "ServerNew timeout_ms must be i64",
+                    diagnostics,
+                );
+                check_exact_result_type(
+                    node,
+                    &DuumbiType::Result(
+                        Box::new(DuumbiType::HttpServer),
+                        Box::new(DuumbiType::String),
+                    ),
+                    "ServerNew must return result<http_server,string>",
+                    diagnostics,
+                );
+            }
+            Op::RouteAddStatic => {
+                check_operand_type(
+                    graph,
+                    node_idx,
+                    node,
+                    GraphEdge::Operand,
+                    &DuumbiType::HttpServer,
+                    "RouteAddStatic server must be http_server",
+                    diagnostics,
+                );
+                check_arg_types(
+                    graph,
+                    node_idx,
+                    node,
+                    &[
+                        DuumbiType::String,
+                        DuumbiType::String,
+                        DuumbiType::I64,
+                        DuumbiType::Json,
+                        DuumbiType::String,
+                    ],
+                    "RouteAddStatic args must be method string, path string, status i64, headers json, body string",
+                    diagnostics,
+                );
+                check_exact_result_type(
+                    node,
+                    &result_i64_string(),
+                    "RouteAddStatic must return result<i64,string>",
+                    diagnostics,
+                );
+            }
+            Op::ServerStart => {
+                check_operand_type(
+                    graph,
+                    node_idx,
+                    node,
+                    GraphEdge::Operand,
+                    &DuumbiType::HttpServer,
+                    "ServerStart server must be http_server",
+                    diagnostics,
+                );
+                check_operand_type(
+                    graph,
+                    node_idx,
+                    node,
+                    GraphEdge::Left,
+                    &DuumbiType::I64,
+                    "ServerStart max_requests must be i64",
+                    diagnostics,
+                );
+                check_operand_type(
+                    graph,
+                    node_idx,
+                    node,
+                    GraphEdge::Right,
+                    &DuumbiType::I64,
+                    "ServerStart timeout_ms must be i64",
+                    diagnostics,
+                );
+                check_exact_result_type(
+                    node,
+                    &result_i64_string(),
+                    "ServerStart must return result<i64,string>",
+                    diagnostics,
+                );
+            }
+            Op::ServerClose => {
+                check_operand_type(
+                    graph,
+                    node_idx,
+                    node,
+                    GraphEdge::Operand,
+                    &DuumbiType::HttpServer,
+                    "ServerClose server must be http_server",
+                    diagnostics,
+                );
+                check_exact_result_type(
+                    node,
+                    &result_i64_string(),
+                    "ServerClose must return result<i64,string>",
+                    diagnostics,
+                );
+            }
             _ => {}
         }
     }
@@ -414,6 +535,68 @@ fn check_operand_type(
                 .with_node(&node.id)
                 .with_details(details),
         );
+    }
+}
+
+fn check_arg_types(
+    graph: &SemanticGraph,
+    node_idx: petgraph::stable_graph::NodeIndex,
+    node: &super::GraphNode,
+    expected: &[DuumbiType],
+    message: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let mut args: Vec<(usize, Option<DuumbiType>)> = Vec::new();
+    for edge_ref in graph
+        .graph
+        .edges_directed(node_idx, petgraph::Direction::Incoming)
+    {
+        if let GraphEdge::Arg(idx) = edge_ref.weight() {
+            let source_node = &graph.graph[edge_ref.source()];
+            args.push((*idx, resolve_output_type(source_node)));
+        }
+    }
+    args.sort_by_key(|(idx, _)| *idx);
+
+    if args.len() != expected.len() {
+        let mut details = HashMap::new();
+        details.insert("expected".to_string(), expected.len().to_string());
+        details.insert("found".to_string(), args.len().to_string());
+        diagnostics.push(
+            Diagnostic::error(codes::E009_SCHEMA_INVALID, message)
+                .with_node(&node.id)
+                .with_details(details),
+        );
+        return;
+    }
+
+    for (idx, actual) in args {
+        let Some(expected_type) = expected.get(idx) else {
+            let mut details = HashMap::new();
+            details.insert("expected".to_string(), expected.len().to_string());
+            details.insert("found".to_string(), idx.to_string());
+            diagnostics.push(
+                Diagnostic::error(codes::E009_SCHEMA_INVALID, message)
+                    .with_node(&node.id)
+                    .with_details(details),
+            );
+            continue;
+        };
+        if actual.as_ref() != Some(expected_type) {
+            let mut details = HashMap::new();
+            details.insert("expected".to_string(), expected_type.to_string());
+            details.insert(
+                "found".to_string(),
+                actual
+                    .map(|ty| ty.to_string())
+                    .unwrap_or_else(|| "<missing>".to_string()),
+            );
+            diagnostics.push(
+                Diagnostic::error(codes::E001_TYPE_MISMATCH, message)
+                    .with_node(&node.id)
+                    .with_details(details),
+            );
+        }
     }
 }
 
@@ -661,6 +844,17 @@ mod tests {
     fn valid_add_graph_no_errors() {
         let module = parse_jsonld(&fixture_add()).expect("invariant: fixture must parse");
         let sg = build_graph(&module).expect("invariant: fixture must build");
+        let diags = validate(&sg);
+        assert!(diags.is_empty(), "Expected no errors, got: {diags:?}");
+    }
+
+    #[test]
+    fn server_stdlib_graph_validates() {
+        let json = std::fs::read_to_string("stdlib/server.jsonld")
+            .expect("invariant: server stdlib graph must exist");
+        let module = parse_jsonld(&json).expect("server stdlib graph must parse");
+        let sg = crate::graph::builder::build_graph_no_call_check(&module)
+            .expect("server stdlib graph must build");
         let diags = validate(&sg);
         assert!(diags.is_empty(), "Expected no errors, got: {diags:?}");
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -125,6 +125,7 @@ fn parse_type_str(s: &str) -> Result<DuumbiType, ParseError> {
         "json" => Ok(DuumbiType::Json),
         "tcp_socket" => Ok(DuumbiType::TcpSocket),
         "tcp_listener" => Ok(DuumbiType::TcpListener),
+        "http_server" => Ok(DuumbiType::HttpServer),
         _ if s.starts_with("array<") && s.ends_with('>') => {
             let inner = &s[6..s.len() - 1];
             let elem_type = parse_type_str(inner)?;
@@ -203,6 +204,35 @@ fn parse_node_ref(
     Ok(NodeRef {
         id: NodeId(id.to_string()),
     })
+}
+
+fn parse_node_refs_array(
+    obj: &serde_json::Value,
+    field: &str,
+    node_id: &str,
+) -> Result<Vec<NodeRef>, ParseError> {
+    let args_arr =
+        obj.get(field)
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| ParseError::MissingField {
+                code: codes::E003_MISSING_FIELD,
+                field: field.to_string(),
+                node_id: node_id.to_string(),
+            })?;
+    let mut refs = Vec::with_capacity(args_arr.len());
+    for arg_val in args_arr {
+        let id = arg_val.get("@id").and_then(|v| v.as_str()).ok_or_else(|| {
+            ParseError::MissingField {
+                code: codes::E003_MISSING_FIELD,
+                field: format!("{field}.@id"),
+                node_id: node_id.to_string(),
+            }
+        })?;
+        refs.push(NodeRef {
+            id: NodeId(id.to_string()),
+        });
+    }
+    Ok(refs)
 }
 
 fn parse_module(value: &serde_json::Value) -> Result<ModuleAst, ParseError> {
@@ -495,25 +525,8 @@ fn parse_op(value: &serde_json::Value) -> Result<OpAst, ParseError> {
                 .get("duumbi:module")
                 .and_then(|v| v.as_str())
                 .map(str::to_string);
-            let args = if let Some(args_val) = value.get("duumbi:args") {
-                if let Some(args_arr) = args_val.as_array() {
-                    let mut refs = Vec::with_capacity(args_arr.len());
-                    for arg_val in args_arr {
-                        let id = arg_val.get("@id").and_then(|v| v.as_str()).ok_or_else(|| {
-                            ParseError::MissingField {
-                                code: codes::E003_MISSING_FIELD,
-                                field: "duumbi:args.@id".to_string(),
-                                node_id: node_id_str.to_string(),
-                            }
-                        })?;
-                        refs.push(NodeRef {
-                            id: NodeId(id.to_string()),
-                        });
-                    }
-                    refs
-                } else {
-                    Vec::new()
-                }
+            let args = if value.get("duumbi:args").is_some() {
+                parse_node_refs_array(value, "duumbi:args", node_id_str)?
             } else {
                 Vec::new()
             };
@@ -987,6 +1000,42 @@ fn parse_op(value: &serde_json::Value) -> Result<OpAst, ParseError> {
                 _ => unreachable!(),
             };
             let mut ast = make_op_ast(NodeId(node_id_str.to_string()), op, result_type);
+            ast.operand = Some(operand);
+            Ok(ast)
+        }
+        "duumbi:ServerNew" | "duumbi:ServerStart" => {
+            let operand = parse_node_ref(value, "duumbi:operand", node_id_str)?;
+            let left = parse_node_ref(value, "duumbi:left", node_id_str)?;
+            let right = parse_node_ref(value, "duumbi:right", node_id_str)?;
+            let op = match at_type {
+                "duumbi:ServerNew" => Op::ServerNew,
+                "duumbi:ServerStart" => Op::ServerStart,
+                _ => unreachable!(),
+            };
+            let mut ast = make_op_ast(NodeId(node_id_str.to_string()), op, result_type);
+            ast.operand = Some(operand);
+            ast.left = Some(left);
+            ast.right = Some(right);
+            Ok(ast)
+        }
+        "duumbi:RouteAddStatic" => {
+            let operand = parse_node_ref(value, "duumbi:operand", node_id_str)?;
+            let mut ast = make_op_ast(
+                NodeId(node_id_str.to_string()),
+                Op::RouteAddStatic,
+                result_type,
+            );
+            ast.operand = Some(operand);
+            ast.args = parse_node_refs_array(value, "duumbi:args", node_id_str)?;
+            Ok(ast)
+        }
+        "duumbi:ServerClose" => {
+            let operand = parse_node_ref(value, "duumbi:operand", node_id_str)?;
+            let mut ast = make_op_ast(
+                NodeId(node_id_str.to_string()),
+                Op::ServerClose,
+                result_type,
+            );
             ast.operand = Some(operand);
             Ok(ast)
         }
@@ -1771,6 +1820,50 @@ mod tests {
             ops[5].right.as_ref().unwrap().id.0,
             "duumbi:t/main/e/timeout"
         );
+    }
+
+    #[test]
+    fn parse_type_str_http_server_resource() {
+        assert_eq!(
+            parse_type_str("http_server").unwrap(),
+            DuumbiType::HttpServer
+        );
+        assert_eq!(
+            parse_type_str("result<http_server,string>").unwrap(),
+            DuumbiType::Result(
+                Box::new(DuumbiType::HttpServer),
+                Box::new(DuumbiType::String)
+            )
+        );
+    }
+
+    #[test]
+    fn parse_server_stdlib_graph() {
+        let json = std::fs::read_to_string("stdlib/server.jsonld")
+            .expect("invariant: server stdlib graph must exist");
+        let module = parse_jsonld(&json).expect("server stdlib graph should parse");
+        assert_eq!(module.name.0, "server");
+        assert_eq!(
+            module.exports,
+            vec![
+                "server_new",
+                "route_add_static",
+                "server_start",
+                "server_close"
+            ]
+        );
+
+        let route_fn = module
+            .functions
+            .iter()
+            .find(|func| func.name.0 == "route_add_static")
+            .expect("route_add_static must exist");
+        let op = route_fn.blocks[0]
+            .ops
+            .iter()
+            .find(|op| matches!(op.op, Op::RouteAddStatic))
+            .expect("RouteAddStatic op must exist");
+        assert_eq!(op.args.len(), 5);
     }
 
     #[test]

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -10,6 +10,8 @@ pub mod credentials;
 #[allow(dead_code)]
 pub mod package;
 #[allow(dead_code)]
+pub mod publish_matrix;
+#[allow(dead_code)]
 pub mod types;
 
 #[allow(unused_imports)]

--- a/src/registry/package.rs
+++ b/src/registry/package.rs
@@ -67,8 +67,9 @@ pub enum PackageError {
 /// Packs a duumbi module workspace into a `.tar.gz` archive in memory.
 ///
 /// Reads `manifest.toml` and all `.jsonld` files from the workspace's
-/// `.duumbi/graph/` directory. Validates required manifest fields (name, version).
-/// Produces a reproducible archive: sorted entries, fixed timestamps.
+/// `.duumbi/graph/` directory. Validates required release manifest fields
+/// (name, version, description, license, and exports). Produces a reproducible
+/// archive: sorted entries, fixed timestamps.
 ///
 /// # Errors
 ///
@@ -125,14 +126,24 @@ pub fn pack_module(workspace_path: &Path) -> Result<Vec<u8>, PackageError> {
 
 /// Validates that the manifest has all required fields for publishing.
 fn validate_manifest(manifest: &ModuleManifest) -> Result<(), PackageError> {
-    if manifest.module.name.is_empty() {
+    if manifest.module.name.trim().is_empty() {
         return Err(PackageError::MissingField {
             field: "module.name".to_string(),
         });
     }
-    if manifest.module.version.is_empty() {
+    if manifest.module.version.trim().is_empty() {
         return Err(PackageError::MissingField {
             field: "module.version".to_string(),
+        });
+    }
+    if manifest.module.description.trim().is_empty() {
+        return Err(PackageError::MissingField {
+            field: "module.description".to_string(),
+        });
+    }
+    if manifest.module.license.trim().is_empty() {
+        return Err(PackageError::MissingField {
+            field: "module.license".to_string(),
         });
     }
     if manifest.exports.functions.is_empty() {
@@ -439,6 +450,50 @@ mod tests {
         assert!(
             matches!(err, PackageError::MissingField { .. }),
             "expected MissingField for exports, got: {err}"
+        );
+    }
+
+    #[test]
+    fn pack_module_empty_description_returns_error() {
+        let tmp = TempDir::new().expect("invariant: tempdir");
+        let duumbi = tmp.path().join(".duumbi");
+        let graph = duumbi.join("graph");
+        fs::create_dir_all(&graph).expect("create dirs");
+        fs::write(graph.join("main.jsonld"), "{}").expect("write");
+
+        let manifest = ModuleManifest::new("@test/no-desc", "1.0.0", "", vec!["fn".into()]);
+        fs::write(duumbi.join("manifest.toml"), manifest.to_toml()).expect("write");
+
+        let err = pack_module(tmp.path()).expect_err("must fail with empty description");
+        assert!(
+            matches!(
+                err,
+                PackageError::MissingField { ref field } if field == "module.description"
+            ),
+            "expected MissingField for description, got: {err}"
+        );
+    }
+
+    #[test]
+    fn pack_module_empty_license_returns_error() {
+        let tmp = TempDir::new().expect("invariant: tempdir");
+        let duumbi = tmp.path().join(".duumbi");
+        let graph = duumbi.join("graph");
+        fs::create_dir_all(&graph).expect("create dirs");
+        fs::write(graph.join("main.jsonld"), "{}").expect("write");
+
+        let mut manifest =
+            ModuleManifest::new("@test/no-license", "1.0.0", "desc", vec!["fn".into()]);
+        manifest.module.license.clear();
+        fs::write(duumbi.join("manifest.toml"), manifest.to_toml()).expect("write");
+
+        let err = pack_module(tmp.path()).expect_err("must fail with empty license");
+        assert!(
+            matches!(
+                err,
+                PackageError::MissingField { ref field } if field == "module.license"
+            ),
+            "expected MissingField for license, got: {err}"
         );
     }
 

--- a/src/registry/publish_matrix.rs
+++ b/src/registry/publish_matrix.rs
@@ -1,0 +1,223 @@
+//! Source-backed Tier 1 publish matrix for DUUMBI-381.
+//!
+//! The matrix is implementation evidence, not a registry policy engine. It
+//! records which modules are ready to package after local verification and
+//! which modules must stay deferred to an upstream issue.
+
+/// Release-readiness state for a Tier 1 stdlib module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublishMatrixState {
+    /// The module has source in this repository and can be packaged after local
+    /// verification succeeds.
+    PublishableAfterVerify,
+    /// The module is blocked by an upstream issue/spec/implementation gate and
+    /// must not be published by DUUMBI-381.
+    DeferredUpstream,
+}
+
+impl PublishMatrixState {
+    /// Returns the stable evidence label used in specs and issue reports.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::PublishableAfterVerify => "publishable-after-verify",
+            Self::DeferredUpstream => "deferred-upstream",
+        }
+    }
+}
+
+/// One source-backed Tier 1 publish-matrix row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PublishMatrixEntry {
+    /// Scoped registry module name.
+    pub module: &'static str,
+    /// Current release-readiness state.
+    pub state: PublishMatrixState,
+    /// Local graph source backing this row, when present in this repository.
+    pub source_graph: Option<&'static str>,
+    /// Upstream GitHub issue that owns unresolved work, if any.
+    pub upstream_issue: Option<u32>,
+    /// Human-readable basis for the row.
+    pub evidence: &'static str,
+}
+
+/// DUUMBI-381 Tier 1 source-backed publish matrix.
+pub const TIER1_PUBLISH_MATRIX: &[PublishMatrixEntry] = &[
+    PublishMatrixEntry {
+        module: "@duumbi/stdlib-math",
+        state: PublishMatrixState::PublishableAfterVerify,
+        source_graph: Some("stdlib/math.jsonld"),
+        upstream_issue: None,
+        evidence: "Core source module exists and default init uses it.",
+    },
+    PublishMatrixEntry {
+        module: "@duumbi/stdlib-io",
+        state: PublishMatrixState::PublishableAfterVerify,
+        source_graph: Some("stdlib/io.jsonld"),
+        upstream_issue: None,
+        evidence: "Core source module exists and default init uses it.",
+    },
+    PublishMatrixEntry {
+        module: "@duumbi/stdlib-lang",
+        state: PublishMatrixState::PublishableAfterVerify,
+        source_graph: Some("stdlib/lang.jsonld"),
+        upstream_issue: None,
+        evidence: "Core source module exists and default init uses it.",
+    },
+    PublishMatrixEntry {
+        module: "@duumbi/stdlib-string",
+        state: PublishMatrixState::PublishableAfterVerify,
+        source_graph: Some("stdlib/string.jsonld"),
+        upstream_issue: None,
+        evidence: "Core source module exists and default init uses it.",
+    },
+    PublishMatrixEntry {
+        module: "@duumbi/stdlib-file",
+        state: PublishMatrixState::PublishableAfterVerify,
+        source_graph: Some("stdlib/file.jsonld"),
+        upstream_issue: Some(378),
+        evidence: "#378 completed Stage 12 and source module exists.",
+    },
+    PublishMatrixEntry {
+        module: "@duumbi/stdlib-json",
+        state: PublishMatrixState::PublishableAfterVerify,
+        source_graph: Some("stdlib/json.jsonld"),
+        upstream_issue: Some(379),
+        evidence: "#379 completed Stage 12 and source module exists.",
+    },
+    PublishMatrixEntry {
+        module: "@duumbi/stdlib-net",
+        state: PublishMatrixState::PublishableAfterVerify,
+        source_graph: Some("stdlib/net.jsonld"),
+        upstream_issue: Some(379),
+        evidence: "#379 completed Stage 12 and source module exists.",
+    },
+    PublishMatrixEntry {
+        module: "@duumbi/stdlib-server",
+        state: PublishMatrixState::DeferredUpstream,
+        source_graph: None,
+        upstream_issue: Some(381),
+        evidence: "DUUMBI-381 owns the server module; it remains deferred until implementation evidence exists.",
+    },
+    PublishMatrixEntry {
+        module: "@duumbi/stdlib-http",
+        state: PublishMatrixState::DeferredUpstream,
+        source_graph: None,
+        upstream_issue: Some(380),
+        evidence: "#380 owns HTTP client behavior and publication readiness.",
+    },
+    PublishMatrixEntry {
+        module: "@duumbi/stdlib-tls",
+        state: PublishMatrixState::DeferredUpstream,
+        source_graph: None,
+        upstream_issue: Some(380),
+        evidence: "#380 must decide whether TLS is separate or HTTP behavior.",
+    },
+    PublishMatrixEntry {
+        module: "@duumbi/stdlib-db",
+        state: PublishMatrixState::DeferredUpstream,
+        source_graph: None,
+        upstream_issue: Some(380),
+        evidence: "#380 owns database behavior and publication readiness.",
+    },
+];
+
+/// Returns the DUUMBI-381 Tier 1 publish matrix.
+#[must_use]
+pub const fn tier1_publish_matrix() -> &'static [PublishMatrixEntry] {
+    TIER1_PUBLISH_MATRIX
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+    use std::path::Path;
+
+    fn entry(module: &str) -> PublishMatrixEntry {
+        *tier1_publish_matrix()
+            .iter()
+            .find(|row| row.module == module)
+            .expect("matrix row must exist")
+    }
+
+    #[test]
+    fn ready_modules_are_source_backed_publishable_after_verify() {
+        for module in [
+            "@duumbi/stdlib-math",
+            "@duumbi/stdlib-io",
+            "@duumbi/stdlib-lang",
+            "@duumbi/stdlib-string",
+            "@duumbi/stdlib-file",
+            "@duumbi/stdlib-json",
+            "@duumbi/stdlib-net",
+        ] {
+            let row = entry(module);
+            assert_eq!(row.state, PublishMatrixState::PublishableAfterVerify);
+            assert!(
+                row.source_graph.is_some(),
+                "{module} must cite a source graph"
+            );
+        }
+    }
+
+    #[test]
+    fn cited_source_graphs_exist() {
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        for row in tier1_publish_matrix() {
+            if let Some(source_graph) = row.source_graph {
+                assert!(
+                    repo_root.join(source_graph).exists(),
+                    "{} cites missing graph source {source_graph}",
+                    row.module
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn issue_380_owned_modules_remain_deferred() {
+        for module in [
+            "@duumbi/stdlib-http",
+            "@duumbi/stdlib-tls",
+            "@duumbi/stdlib-db",
+        ] {
+            let row = entry(module);
+            assert_eq!(row.state, PublishMatrixState::DeferredUpstream);
+            assert_eq!(row.upstream_issue, Some(380));
+            assert_eq!(row.source_graph, None);
+        }
+    }
+
+    #[test]
+    fn server_module_remains_deferred_until_issue_381_implementation() {
+        let row = entry("@duumbi/stdlib-server");
+        assert_eq!(row.state, PublishMatrixState::DeferredUpstream);
+        assert_eq!(row.upstream_issue, Some(381));
+        assert_eq!(row.source_graph, None);
+    }
+
+    #[test]
+    fn matrix_has_no_duplicate_modules() {
+        let mut modules = BTreeSet::new();
+        for row in tier1_publish_matrix() {
+            assert!(
+                modules.insert(row.module),
+                "duplicate row for {}",
+                row.module
+            );
+        }
+    }
+
+    #[test]
+    fn state_labels_match_spec_terms() {
+        assert_eq!(
+            PublishMatrixState::PublishableAfterVerify.as_str(),
+            "publishable-after-verify"
+        );
+        assert_eq!(
+            PublishMatrixState::DeferredUpstream.as_str(),
+            "deferred-upstream"
+        );
+    }
+}

--- a/src/registry/publish_matrix.rs
+++ b/src/registry/publish_matrix.rs
@@ -94,10 +94,10 @@ pub const TIER1_PUBLISH_MATRIX: &[PublishMatrixEntry] = &[
     },
     PublishMatrixEntry {
         module: "@duumbi/stdlib-server",
-        state: PublishMatrixState::DeferredUpstream,
-        source_graph: None,
+        state: PublishMatrixState::PublishableAfterVerify,
+        source_graph: Some("stdlib/server.jsonld"),
         upstream_issue: Some(381),
-        evidence: "DUUMBI-381 owns the server module; it remains deferred until implementation evidence exists.",
+        evidence: "DUUMBI-381 implementation evidence added the bounded server source module.",
     },
     PublishMatrixEntry {
         module: "@duumbi/stdlib-http",
@@ -190,11 +190,11 @@ mod tests {
     }
 
     #[test]
-    fn server_module_remains_deferred_until_issue_381_implementation() {
+    fn server_module_is_source_backed_after_issue_381_implementation() {
         let row = entry("@duumbi/stdlib-server");
-        assert_eq!(row.state, PublishMatrixState::DeferredUpstream);
+        assert_eq!(row.state, PublishMatrixState::PublishableAfterVerify);
         assert_eq!(row.upstream_issue, Some(381));
-        assert_eq!(row.source_graph, None);
+        assert_eq!(row.source_graph, Some("stdlib/server.jsonld"));
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -289,6 +289,16 @@ pub enum Op {
     /// Close a TCP listener: `duumbi:TcpListenerClose`
     TcpListenerClose,
 
+    // -- HTTP server operations (DUUMBI-381) --
+    /// Create a bounded local HTTP server: `duumbi:ServerNew`
+    ServerNew,
+    /// Register a static HTTP route: `duumbi:RouteAddStatic`
+    RouteAddStatic,
+    /// Serve bounded requests: `duumbi:ServerStart`
+    ServerStart,
+    /// Close an HTTP server resource: `duumbi:ServerClose`
+    ServerClose,
+
     // -- Match operation (Phase 9a-3) --
     /// Pattern match on Result/Option — branches to Ok/Some or Err/None block: `duumbi:Match`
     Match {
@@ -412,6 +422,10 @@ impl fmt::Display for Op {
             Op::TcpWrite => f.write_str("TcpWrite"),
             Op::TcpClose => f.write_str("TcpClose"),
             Op::TcpListenerClose => f.write_str("TcpListenerClose"),
+            Op::ServerNew => f.write_str("ServerNew"),
+            Op::RouteAddStatic => f.write_str("RouteAddStatic"),
+            Op::ServerStart => f.write_str("ServerStart"),
+            Op::ServerClose => f.write_str("ServerClose"),
             Op::Match {
                 ok_block,
                 err_block,
@@ -479,7 +493,11 @@ impl Op {
             | Op::TcpRead
             | Op::TcpWrite
             | Op::TcpClose
-            | Op::TcpListenerClose => result_type.clone(),
+            | Op::TcpListenerClose
+            | Op::ServerNew
+            | Op::RouteAddStatic
+            | Op::ServerStart
+            | Op::ServerClose => result_type.clone(),
             Op::Compare(_) | Op::StringEquals | Op::StringContains => Some(DuumbiType::Bool),
             Op::StringCompare(_) => Some(DuumbiType::Bool),
             Op::StringConcat
@@ -546,6 +564,8 @@ pub enum DuumbiType {
     TcpSocket,
     /// Opaque runtime-owned TCP listener resource.
     TcpListener,
+    /// Opaque runtime-owned HTTP server resource.
+    HttpServer,
     /// Homogeneous dynamic array, generic over element type.
     #[allow(dead_code)] // Used starting from Phase 9a-1 array ops
     Array(Box<DuumbiType>),
@@ -578,6 +598,7 @@ impl DuumbiType {
                 | DuumbiType::Json
                 | DuumbiType::TcpSocket
                 | DuumbiType::TcpListener
+                | DuumbiType::HttpServer
                 | DuumbiType::Array(_)
                 | DuumbiType::Struct(_)
                 | DuumbiType::Result(_, _)
@@ -635,6 +656,7 @@ impl fmt::Display for DuumbiType {
             DuumbiType::Json => f.write_str("json"),
             DuumbiType::TcpSocket => f.write_str("tcp_socket"),
             DuumbiType::TcpListener => f.write_str("tcp_listener"),
+            DuumbiType::HttpServer => f.write_str("http_server"),
             DuumbiType::Array(elem) => write!(f, "array<{elem}>"),
             DuumbiType::Struct(name) => write!(f, "struct<{name}>"),
             DuumbiType::Ref(inner) => write!(f, "&{inner}"),
@@ -721,6 +743,7 @@ mod tests {
         assert_eq!(DuumbiType::Json.to_string(), "json");
         assert_eq!(DuumbiType::TcpSocket.to_string(), "tcp_socket");
         assert_eq!(DuumbiType::TcpListener.to_string(), "tcp_listener");
+        assert_eq!(DuumbiType::HttpServer.to_string(), "http_server");
     }
 
     #[test]
@@ -733,6 +756,7 @@ mod tests {
         assert!(DuumbiType::Json.is_heap_type());
         assert!(DuumbiType::TcpSocket.is_heap_type());
         assert!(DuumbiType::TcpListener.is_heap_type());
+        assert!(DuumbiType::HttpServer.is_heap_type());
         assert!(DuumbiType::Array(Box::new(DuumbiType::I64)).is_heap_type());
         assert!(DuumbiType::Struct("Point".to_string()).is_heap_type());
     }
@@ -945,6 +969,27 @@ mod tests {
         );
         assert_eq!(
             Op::TcpListenerClose.output_type(&Some(close_result.clone())),
+            Some(close_result.clone())
+        );
+
+        let server_result = DuumbiType::Result(
+            Box::new(DuumbiType::HttpServer),
+            Box::new(DuumbiType::String),
+        );
+        assert_eq!(
+            Op::ServerNew.output_type(&Some(server_result.clone())),
+            Some(server_result)
+        );
+        assert_eq!(
+            Op::RouteAddStatic.output_type(&Some(close_result.clone())),
+            Some(close_result.clone())
+        );
+        assert_eq!(
+            Op::ServerStart.output_type(&Some(close_result.clone())),
+            Some(close_result.clone())
+        );
+        assert_eq!(
+            Op::ServerClose.output_type(&Some(close_result.clone())),
             Some(close_result)
         );
     }

--- a/stdlib/server.jsonld
+++ b/stdlib/server.jsonld
@@ -1,0 +1,105 @@
+{
+  "@context": {"duumbi": "https://duumbi.dev/ns/core#"},
+  "@type": "duumbi:Module",
+  "@id": "duumbi:server",
+  "duumbi:name": "server",
+  "duumbi:exports": [
+    "server_new",
+    "route_add_static",
+    "server_start",
+    "server_close"
+  ],
+  "duumbi:functions": [
+    {
+      "@type": "duumbi:Function",
+      "@id": "duumbi:server/server_new",
+      "duumbi:name": "server_new",
+      "duumbi:returnType": "result<http_server,string>",
+      "duumbi:params": [
+        {"duumbi:name": "host", "duumbi:paramType": "string"},
+        {"duumbi:name": "port", "duumbi:paramType": "i64"},
+        {"duumbi:name": "timeout_ms", "duumbi:paramType": "i64"}
+      ],
+      "duumbi:blocks": [{"@type": "duumbi:Block", "@id": "duumbi:server/server_new/entry", "duumbi:label": "entry", "duumbi:ops": [
+        {"@type": "duumbi:Load", "@id": "duumbi:server/server_new/entry/0", "duumbi:variable": "host", "duumbi:resultType": "string"},
+        {"@type": "duumbi:Load", "@id": "duumbi:server/server_new/entry/1", "duumbi:variable": "port", "duumbi:resultType": "i64"},
+        {"@type": "duumbi:Load", "@id": "duumbi:server/server_new/entry/2", "duumbi:variable": "timeout_ms", "duumbi:resultType": "i64"},
+        {"@type": "duumbi:ServerNew", "@id": "duumbi:server/server_new/entry/3",
+          "duumbi:operand": {"@id": "duumbi:server/server_new/entry/0"},
+          "duumbi:left": {"@id": "duumbi:server/server_new/entry/1"},
+          "duumbi:right": {"@id": "duumbi:server/server_new/entry/2"},
+          "duumbi:resultType": "result<http_server,string>"},
+        {"@type": "duumbi:Return", "@id": "duumbi:server/server_new/entry/4", "duumbi:operand": {"@id": "duumbi:server/server_new/entry/3"}}
+      ]}]
+    },
+    {
+      "@type": "duumbi:Function",
+      "@id": "duumbi:server/route_add_static",
+      "duumbi:name": "route_add_static",
+      "duumbi:returnType": "result<i64,string>",
+      "duumbi:params": [
+        {"duumbi:name": "server", "duumbi:paramType": "http_server"},
+        {"duumbi:name": "method", "duumbi:paramType": "string"},
+        {"duumbi:name": "path", "duumbi:paramType": "string"},
+        {"duumbi:name": "status", "duumbi:paramType": "i64"},
+        {"duumbi:name": "headers", "duumbi:paramType": "json"},
+        {"duumbi:name": "body", "duumbi:paramType": "string"}
+      ],
+      "duumbi:blocks": [{"@type": "duumbi:Block", "@id": "duumbi:server/route_add_static/entry", "duumbi:label": "entry", "duumbi:ops": [
+        {"@type": "duumbi:Load", "@id": "duumbi:server/route_add_static/entry/0", "duumbi:variable": "server", "duumbi:resultType": "http_server"},
+        {"@type": "duumbi:Load", "@id": "duumbi:server/route_add_static/entry/1", "duumbi:variable": "method", "duumbi:resultType": "string"},
+        {"@type": "duumbi:Load", "@id": "duumbi:server/route_add_static/entry/2", "duumbi:variable": "path", "duumbi:resultType": "string"},
+        {"@type": "duumbi:Load", "@id": "duumbi:server/route_add_static/entry/3", "duumbi:variable": "status", "duumbi:resultType": "i64"},
+        {"@type": "duumbi:Load", "@id": "duumbi:server/route_add_static/entry/4", "duumbi:variable": "headers", "duumbi:resultType": "json"},
+        {"@type": "duumbi:Load", "@id": "duumbi:server/route_add_static/entry/5", "duumbi:variable": "body", "duumbi:resultType": "string"},
+        {"@type": "duumbi:RouteAddStatic", "@id": "duumbi:server/route_add_static/entry/6",
+          "duumbi:operand": {"@id": "duumbi:server/route_add_static/entry/0"},
+          "duumbi:args": [
+            {"@id": "duumbi:server/route_add_static/entry/1"},
+            {"@id": "duumbi:server/route_add_static/entry/2"},
+            {"@id": "duumbi:server/route_add_static/entry/3"},
+            {"@id": "duumbi:server/route_add_static/entry/4"},
+            {"@id": "duumbi:server/route_add_static/entry/5"}
+          ],
+          "duumbi:resultType": "result<i64,string>"},
+        {"@type": "duumbi:Return", "@id": "duumbi:server/route_add_static/entry/7", "duumbi:operand": {"@id": "duumbi:server/route_add_static/entry/6"}}
+      ]}]
+    },
+    {
+      "@type": "duumbi:Function",
+      "@id": "duumbi:server/server_start",
+      "duumbi:name": "server_start",
+      "duumbi:returnType": "result<i64,string>",
+      "duumbi:params": [
+        {"duumbi:name": "server", "duumbi:paramType": "http_server"},
+        {"duumbi:name": "max_requests", "duumbi:paramType": "i64"},
+        {"duumbi:name": "timeout_ms", "duumbi:paramType": "i64"}
+      ],
+      "duumbi:blocks": [{"@type": "duumbi:Block", "@id": "duumbi:server/server_start/entry", "duumbi:label": "entry", "duumbi:ops": [
+        {"@type": "duumbi:Load", "@id": "duumbi:server/server_start/entry/0", "duumbi:variable": "server", "duumbi:resultType": "http_server"},
+        {"@type": "duumbi:Load", "@id": "duumbi:server/server_start/entry/1", "duumbi:variable": "max_requests", "duumbi:resultType": "i64"},
+        {"@type": "duumbi:Load", "@id": "duumbi:server/server_start/entry/2", "duumbi:variable": "timeout_ms", "duumbi:resultType": "i64"},
+        {"@type": "duumbi:ServerStart", "@id": "duumbi:server/server_start/entry/3",
+          "duumbi:operand": {"@id": "duumbi:server/server_start/entry/0"},
+          "duumbi:left": {"@id": "duumbi:server/server_start/entry/1"},
+          "duumbi:right": {"@id": "duumbi:server/server_start/entry/2"},
+          "duumbi:resultType": "result<i64,string>"},
+        {"@type": "duumbi:Return", "@id": "duumbi:server/server_start/entry/4", "duumbi:operand": {"@id": "duumbi:server/server_start/entry/3"}}
+      ]}]
+    },
+    {
+      "@type": "duumbi:Function",
+      "@id": "duumbi:server/server_close",
+      "duumbi:name": "server_close",
+      "duumbi:returnType": "result<i64,string>",
+      "duumbi:params": [{"duumbi:name": "server", "duumbi:paramType": "http_server"}],
+      "duumbi:blocks": [{"@type": "duumbi:Block", "@id": "duumbi:server/server_close/entry", "duumbi:label": "entry", "duumbi:ops": [
+        {"@type": "duumbi:Load", "@id": "duumbi:server/server_close/entry/0", "duumbi:variable": "server", "duumbi:resultType": "http_server"},
+        {"@type": "duumbi:ServerClose", "@id": "duumbi:server/server_close/entry/1",
+          "duumbi:operand": {"@id": "duumbi:server/server_close/entry/0"},
+          "duumbi:resultType": "result<i64,string>"},
+        {"@type": "duumbi:Return", "@id": "duumbi:server/server_close/entry/2", "duumbi:operand": {"@id": "duumbi:server/server_close/entry/1"}}
+      ]}]
+    }
+  ]
+}

--- a/stdlib/server.manifest.toml
+++ b/stdlib/server.manifest.toml
@@ -1,0 +1,13 @@
+[module]
+name = "@duumbi/stdlib-server"
+version = "1.0.0"
+description = "Bounded local static-route HTTP server functions"
+license = "MPL-2.0"
+
+[exports]
+functions = [
+    "server_new",
+    "route_add_static",
+    "server_start",
+    "server_close",
+]

--- a/tests/integration_duumbi_381_cycle3.rs
+++ b/tests/integration_duumbi_381_cycle3.rs
@@ -1,0 +1,499 @@
+//! DUUMBI-381 Cycle 3 evidence: embedded-registry, clean-workspace, and server E2E.
+
+#![recursion_limit = "512"]
+
+use std::collections::{BTreeSet, HashMap};
+use std::fs;
+use std::io::{ErrorKind, Read as _, Write as _};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use duumbi::config::{self, DependencyConfig, WorkspaceSection};
+use duumbi::registry::client::{RegistryClient, RegistryCredential};
+use duumbi::workspace::{build_workspace, run_workspace_binary, workspace_output_path};
+use duumbi_registry::{
+    AppState, AuthMode,
+    auth::rate_limit::RateLimiter,
+    build_app,
+    db::{CreateUser, Database},
+    storage::Storage,
+};
+use serde_json::json;
+
+const SERVER_GRAPH: &str = include_str!("../stdlib/server.jsonld");
+const SERVER_MANIFEST: &str = include_str!("../stdlib/server.manifest.toml");
+
+fn duumbi_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_duumbi"))
+}
+
+fn run_duumbi_init(workspace: &Path) {
+    let output = Command::new(duumbi_binary())
+        .arg("init")
+        .arg(workspace)
+        .output()
+        .expect("duumbi init should run");
+    assert!(
+        output.status.success(),
+        "duumbi init failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn unused_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind unused port");
+    listener.local_addr().expect("local addr").port()
+}
+
+fn write_main_graph(workspace: &Path, graph: serde_json::Value) {
+    let graph_dir = workspace.join(".duumbi/graph");
+    fs::create_dir_all(&graph_dir).expect("create graph dir");
+    fs::write(
+        graph_dir.join("main.jsonld"),
+        serde_json::to_string_pretty(&graph).expect("serialize graph"),
+    )
+    .expect("write main graph");
+}
+
+fn make_server_package(workspace: &Path) {
+    let graph_dir = workspace.join(".duumbi/graph");
+    fs::create_dir_all(&graph_dir).expect("create package graph dir");
+    fs::write(graph_dir.join("server.jsonld"), SERVER_GRAPH).expect("write server graph");
+    fs::write(workspace.join(".duumbi/manifest.toml"), SERVER_MANIFEST)
+        .expect("write server manifest");
+}
+
+async fn start_test_server() -> (String, String, tempfile::TempDir) {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+
+    let database = Database::open(":memory:").expect("in-memory db");
+    database.migrate().expect("migration");
+
+    let token = "duu_duumbi_381_cycle3_token";
+    let user_id = database
+        .create_user(&CreateUser {
+            username: "duumbi381",
+            display_name: None,
+            avatar_url: None,
+            email: None,
+            password_hash: None,
+        })
+        .expect("create test user");
+    database
+        .create_token(user_id, "duumbi-381-cycle3", token)
+        .expect("create token");
+
+    let storage = Storage::new(tmp.path().join("modules").to_str().unwrap()).expect("storage");
+
+    let state = Arc::new(AppState {
+        db: database,
+        storage,
+        auth_mode: AuthMode::LocalPassword,
+        jwt_secret: "test-jwt-secret".to_string(),
+        base_url: "http://localhost".to_string(),
+        github_client_id: None,
+        github_client_secret: None,
+        rate_limiter: RateLimiter::new(),
+    });
+
+    let app = build_app(state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr: SocketAddr = listener.local_addr().expect("local addr");
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve");
+    });
+
+    (format!("http://{}", addr), token.to_string(), tmp)
+}
+
+fn registry_client(registry_url: &str, token: Option<&str>) -> RegistryClient {
+    let mut registries = HashMap::new();
+    registries.insert("local".to_string(), registry_url.to_string());
+
+    let mut credentials = HashMap::new();
+    if let Some(token) = token {
+        credentials.insert(
+            "local".to_string(),
+            RegistryCredential {
+                token: token.to_string(),
+            },
+        );
+    }
+
+    RegistryClient::new(registries, credentials, None).expect("registry client")
+}
+
+fn assert_default_dependency_policy(workspace: &Path) {
+    let cfg = config::load_config(workspace).expect("config should parse");
+    let actual: BTreeSet<&str> = cfg.dependencies.keys().map(String::as_str).collect();
+    let expected = BTreeSet::from([
+        "@duumbi/stdlib-io",
+        "@duumbi/stdlib-lang",
+        "@duumbi/stdlib-math",
+        "@duumbi/stdlib-string",
+    ]);
+    assert_eq!(
+        actual, expected,
+        "default dependencies must remain core-only"
+    );
+
+    for opt_in_module in [
+        "@duumbi/stdlib-json",
+        "@duumbi/stdlib-net",
+        "@duumbi/stdlib-server",
+        "@duumbi/stdlib-http",
+        "@duumbi/stdlib-db",
+    ] {
+        assert!(
+            !cfg.dependencies.contains_key(opt_in_module),
+            "{opt_in_module} must not be a default dependency"
+        );
+    }
+}
+
+fn configure_local_registry(workspace: &Path, registry_url: &str) {
+    let mut cfg = config::load_config(workspace).expect("config should parse");
+    cfg.registries
+        .insert("local".to_string(), registry_url.to_string());
+    let ws = cfg.workspace.get_or_insert_with(WorkspaceSection::default);
+    ws.default_registry = Some("local".to_string());
+    config::save_config(workspace, &cfg).expect("save local registry config");
+}
+
+fn add_downloaded_server_dependency(workspace: &Path) {
+    let mut cfg = config::load_config(workspace).expect("config should parse");
+    cfg.dependencies.insert(
+        "@duumbi/stdlib-server".to_string(),
+        DependencyConfig::VersionWithRegistry {
+            version: "1.0.0".to_string(),
+            registry: "local".to_string(),
+        },
+    );
+    config::save_config(workspace, &cfg).expect("save dependency config");
+}
+
+fn server_importer_graph(port: u16) -> serde_json::Value {
+    json!({
+        "@context": {"duumbi": "https://duumbi.dev/ns/core#"},
+        "@type": "duumbi:Module",
+        "@id": "duumbi:main",
+        "duumbi:name": "main",
+        "duumbi:imports": [{
+            "duumbi:module": "server",
+            "duumbi:path": "@duumbi/stdlib-server",
+            "duumbi:functions": [
+                "server_new",
+                "route_add_static",
+                "server_start",
+                "server_close"
+            ]
+        }],
+        "duumbi:functions": [{
+            "@type": "duumbi:Function",
+            "@id": "duumbi:main/main",
+            "duumbi:name": "main",
+            "duumbi:returnType": "i64",
+            "duumbi:blocks": [{
+                "@type": "duumbi:Block",
+                "@id": "duumbi:main/main/entry",
+                "duumbi:label": "entry",
+                "duumbi:ops": [
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/0", "duumbi:value": "127.0.0.1", "duumbi:resultType": "string"},
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/1", "duumbi:value": i64::from(port), "duumbi:resultType": "i64"},
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/2", "duumbi:value": 1000, "duumbi:resultType": "i64"},
+                    {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/3", "duumbi:module": "server", "duumbi:function": "server_new", "duumbi:args": [
+                        {"@id": "duumbi:main/main/entry/0"}, {"@id": "duumbi:main/main/entry/1"}, {"@id": "duumbi:main/main/entry/2"}
+                    ], "duumbi:resultType": "result<http_server,string>"},
+                    {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/4", "duumbi:operand": {"@id": "duumbi:main/main/entry/3"}, "duumbi:resultType": "http_server"},
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/5", "duumbi:value": "GET", "duumbi:resultType": "string"},
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/6", "duumbi:value": "/health", "duumbi:resultType": "string"},
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/7", "duumbi:value": 200, "duumbi:resultType": "i64"},
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/8", "duumbi:value": "{}", "duumbi:resultType": "string"},
+                    {"@type": "duumbi:JsonParse", "@id": "duumbi:main/main/entry/9", "duumbi:operand": {"@id": "duumbi:main/main/entry/8"}, "duumbi:resultType": "result<json,string>"},
+                    {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/10", "duumbi:operand": {"@id": "duumbi:main/main/entry/9"}, "duumbi:resultType": "json"},
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/11", "duumbi:value": "ok", "duumbi:resultType": "string"},
+                    {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/12", "duumbi:module": "server", "duumbi:function": "route_add_static", "duumbi:args": [
+                        {"@id": "duumbi:main/main/entry/4"}, {"@id": "duumbi:main/main/entry/5"}, {"@id": "duumbi:main/main/entry/6"},
+                        {"@id": "duumbi:main/main/entry/7"}, {"@id": "duumbi:main/main/entry/10"}, {"@id": "duumbi:main/main/entry/11"}
+                    ], "duumbi:resultType": "result<i64,string>"},
+                    {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/13", "duumbi:operand": {"@id": "duumbi:main/main/entry/12"}, "duumbi:resultType": "i64"},
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/14", "duumbi:value": 1, "duumbi:resultType": "i64"},
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/15", "duumbi:value": 2000, "duumbi:resultType": "i64"},
+                    {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/16", "duumbi:module": "server", "duumbi:function": "server_start", "duumbi:args": [
+                        {"@id": "duumbi:main/main/entry/4"}, {"@id": "duumbi:main/main/entry/14"}, {"@id": "duumbi:main/main/entry/15"}
+                    ], "duumbi:resultType": "result<i64,string>"},
+                    {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/17", "duumbi:operand": {"@id": "duumbi:main/main/entry/16"}, "duumbi:resultType": "i64"},
+                    {"@type": "duumbi:Call", "@id": "duumbi:main/main/entry/18", "duumbi:module": "server", "duumbi:function": "server_close", "duumbi:args": [
+                        {"@id": "duumbi:main/main/entry/4"}
+                    ], "duumbi:resultType": "result<i64,string>"},
+                    {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/19", "duumbi:operand": {"@id": "duumbi:main/main/entry/18"}, "duumbi:resultType": "i64"},
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/20", "duumbi:value": 0, "duumbi:resultType": "i64"},
+                    {"@type": "duumbi:Return", "@id": "duumbi:main/main/entry/21", "duumbi:operand": {"@id": "duumbi:main/main/entry/20"}}
+                ]
+            }]
+        }]
+    })
+}
+
+fn server_negative_graph(
+    timeout_port: u16,
+    invalid_port: u16,
+    closed_port: u16,
+) -> serde_json::Value {
+    json!({
+        "@context": {"duumbi": "https://duumbi.dev/ns/core#"},
+        "@type": "duumbi:Module",
+        "@id": "duumbi:main",
+        "duumbi:name": "main",
+        "duumbi:functions": [{
+            "@type": "duumbi:Function",
+            "@id": "duumbi:main/main",
+            "duumbi:name": "main",
+            "duumbi:returnType": "i64",
+            "duumbi:blocks": [{
+                "@type": "duumbi:Block",
+                "@id": "duumbi:main/main/entry",
+                "duumbi:label": "entry",
+                "duumbi:ops": [
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/host", "duumbi:value": "127.0.0.1", "duumbi:resultType": "string"},
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/timeout_port", "duumbi:value": i64::from(timeout_port), "duumbi:resultType": "i64"},
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/init_timeout", "duumbi:value": 1000, "duumbi:resultType": "i64"},
+                    {"@type": "duumbi:ServerNew", "@id": "duumbi:main/main/entry/timeout_new", "duumbi:operand": {"@id": "duumbi:main/main/entry/host"}, "duumbi:left": {"@id": "duumbi:main/main/entry/timeout_port"}, "duumbi:right": {"@id": "duumbi:main/main/entry/init_timeout"}, "duumbi:resultType": "result<http_server,string>"},
+                    {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/timeout_server", "duumbi:operand": {"@id": "duumbi:main/main/entry/timeout_new"}, "duumbi:resultType": "http_server"},
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/get", "duumbi:value": "GET", "duumbi:resultType": "string"},
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/health", "duumbi:value": "/health", "duumbi:resultType": "string"},
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/status", "duumbi:value": 200, "duumbi:resultType": "i64"},
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/headers_src", "duumbi:value": "{}", "duumbi:resultType": "string"},
+                    {"@type": "duumbi:JsonParse", "@id": "duumbi:main/main/entry/headers_parse", "duumbi:operand": {"@id": "duumbi:main/main/entry/headers_src"}, "duumbi:resultType": "result<json,string>"},
+                    {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/headers", "duumbi:operand": {"@id": "duumbi:main/main/entry/headers_parse"}, "duumbi:resultType": "json"},
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/body", "duumbi:value": "ok", "duumbi:resultType": "string"},
+                    {"@type": "duumbi:RouteAddStatic", "@id": "duumbi:main/main/entry/route_ok", "duumbi:operand": {"@id": "duumbi:main/main/entry/timeout_server"}, "duumbi:args": [
+                        {"@id": "duumbi:main/main/entry/get"}, {"@id": "duumbi:main/main/entry/health"}, {"@id": "duumbi:main/main/entry/status"}, {"@id": "duumbi:main/main/entry/headers"}, {"@id": "duumbi:main/main/entry/body"}
+                    ], "duumbi:resultType": "result<i64,string>"},
+                    {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/route_ok_unwrap", "duumbi:operand": {"@id": "duumbi:main/main/entry/route_ok"}, "duumbi:resultType": "i64"},
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/max_one", "duumbi:value": 1, "duumbi:resultType": "i64"},
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/short_timeout", "duumbi:value": 50, "duumbi:resultType": "i64"},
+                    {"@type": "duumbi:ServerStart", "@id": "duumbi:main/main/entry/timeout_start", "duumbi:operand": {"@id": "duumbi:main/main/entry/timeout_server"}, "duumbi:left": {"@id": "duumbi:main/main/entry/max_one"}, "duumbi:right": {"@id": "duumbi:main/main/entry/short_timeout"}, "duumbi:resultType": "result<i64,string>"},
+                    {"@type": "duumbi:ResultUnwrapErr", "@id": "duumbi:main/main/entry/timeout_err", "duumbi:operand": {"@id": "duumbi:main/main/entry/timeout_start"}, "duumbi:resultType": "string"},
+                    {"@type": "duumbi:ServerClose", "@id": "duumbi:main/main/entry/timeout_close", "duumbi:operand": {"@id": "duumbi:main/main/entry/timeout_server"}, "duumbi:resultType": "result<i64,string>"},
+                    {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/timeout_close_unwrap", "duumbi:operand": {"@id": "duumbi:main/main/entry/timeout_close"}, "duumbi:resultType": "i64"},
+
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/invalid_port", "duumbi:value": i64::from(invalid_port), "duumbi:resultType": "i64"},
+                    {"@type": "duumbi:ServerNew", "@id": "duumbi:main/main/entry/invalid_new", "duumbi:operand": {"@id": "duumbi:main/main/entry/host"}, "duumbi:left": {"@id": "duumbi:main/main/entry/invalid_port"}, "duumbi:right": {"@id": "duumbi:main/main/entry/init_timeout"}, "duumbi:resultType": "result<http_server,string>"},
+                    {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/invalid_server", "duumbi:operand": {"@id": "duumbi:main/main/entry/invalid_new"}, "duumbi:resultType": "http_server"},
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/bad_path", "duumbi:value": "health", "duumbi:resultType": "string"},
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/headers2_src", "duumbi:value": "{}", "duumbi:resultType": "string"},
+                    {"@type": "duumbi:JsonParse", "@id": "duumbi:main/main/entry/headers2_parse", "duumbi:operand": {"@id": "duumbi:main/main/entry/headers2_src"}, "duumbi:resultType": "result<json,string>"},
+                    {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/headers2", "duumbi:operand": {"@id": "duumbi:main/main/entry/headers2_parse"}, "duumbi:resultType": "json"},
+                    {"@type": "duumbi:RouteAddStatic", "@id": "duumbi:main/main/entry/invalid_route", "duumbi:operand": {"@id": "duumbi:main/main/entry/invalid_server"}, "duumbi:args": [
+                        {"@id": "duumbi:main/main/entry/get"}, {"@id": "duumbi:main/main/entry/bad_path"}, {"@id": "duumbi:main/main/entry/status"}, {"@id": "duumbi:main/main/entry/headers2"}, {"@id": "duumbi:main/main/entry/body"}
+                    ], "duumbi:resultType": "result<i64,string>"},
+                    {"@type": "duumbi:ResultUnwrapErr", "@id": "duumbi:main/main/entry/invalid_route_err", "duumbi:operand": {"@id": "duumbi:main/main/entry/invalid_route"}, "duumbi:resultType": "string"},
+                    {"@type": "duumbi:ServerClose", "@id": "duumbi:main/main/entry/invalid_close", "duumbi:operand": {"@id": "duumbi:main/main/entry/invalid_server"}, "duumbi:resultType": "result<i64,string>"},
+                    {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/invalid_close_unwrap", "duumbi:operand": {"@id": "duumbi:main/main/entry/invalid_close"}, "duumbi:resultType": "i64"},
+
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/closed_port", "duumbi:value": i64::from(closed_port), "duumbi:resultType": "i64"},
+                    {"@type": "duumbi:ServerNew", "@id": "duumbi:main/main/entry/closed_new", "duumbi:operand": {"@id": "duumbi:main/main/entry/host"}, "duumbi:left": {"@id": "duumbi:main/main/entry/closed_port"}, "duumbi:right": {"@id": "duumbi:main/main/entry/init_timeout"}, "duumbi:resultType": "result<http_server,string>"},
+                    {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/closed_server", "duumbi:operand": {"@id": "duumbi:main/main/entry/closed_new"}, "duumbi:resultType": "http_server"},
+                    {"@type": "duumbi:ServerClose", "@id": "duumbi:main/main/entry/closed_close", "duumbi:operand": {"@id": "duumbi:main/main/entry/closed_server"}, "duumbi:resultType": "result<i64,string>"},
+                    {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/closed_close_unwrap", "duumbi:operand": {"@id": "duumbi:main/main/entry/closed_close"}, "duumbi:resultType": "i64"},
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/headers3_src", "duumbi:value": "{}", "duumbi:resultType": "string"},
+                    {"@type": "duumbi:JsonParse", "@id": "duumbi:main/main/entry/headers3_parse", "duumbi:operand": {"@id": "duumbi:main/main/entry/headers3_src"}, "duumbi:resultType": "result<json,string>"},
+                    {"@type": "duumbi:ResultUnwrap", "@id": "duumbi:main/main/entry/headers3", "duumbi:operand": {"@id": "duumbi:main/main/entry/headers3_parse"}, "duumbi:resultType": "json"},
+                    {"@type": "duumbi:RouteAddStatic", "@id": "duumbi:main/main/entry/closed_route", "duumbi:operand": {"@id": "duumbi:main/main/entry/closed_server"}, "duumbi:args": [
+                        {"@id": "duumbi:main/main/entry/get"}, {"@id": "duumbi:main/main/entry/health"}, {"@id": "duumbi:main/main/entry/status"}, {"@id": "duumbi:main/main/entry/headers3"}, {"@id": "duumbi:main/main/entry/body"}
+                    ], "duumbi:resultType": "result<i64,string>"},
+                    {"@type": "duumbi:ResultUnwrapErr", "@id": "duumbi:main/main/entry/closed_route_err", "duumbi:operand": {"@id": "duumbi:main/main/entry/closed_route"}, "duumbi:resultType": "string"},
+                    {"@type": "duumbi:ServerStart", "@id": "duumbi:main/main/entry/closed_start", "duumbi:operand": {"@id": "duumbi:main/main/entry/closed_server"}, "duumbi:left": {"@id": "duumbi:main/main/entry/max_one"}, "duumbi:right": {"@id": "duumbi:main/main/entry/short_timeout"}, "duumbi:resultType": "result<i64,string>"},
+                    {"@type": "duumbi:ResultUnwrapErr", "@id": "duumbi:main/main/entry/closed_start_err", "duumbi:operand": {"@id": "duumbi:main/main/entry/closed_start"}, "duumbi:resultType": "string"},
+                    {"@type": "duumbi:Const", "@id": "duumbi:main/main/entry/return_zero", "duumbi:value": 0, "duumbi:resultType": "i64"},
+                    {"@type": "duumbi:Return", "@id": "duumbi:main/main/entry/return", "duumbi:operand": {"@id": "duumbi:main/main/entry/return_zero"}}
+                ]
+            }]
+        }]
+    })
+}
+
+fn http_get_health(port: u16) -> Result<String, String> {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    let mut last_error = None::<String>;
+
+    while Instant::now() < deadline {
+        match TcpStream::connect(("127.0.0.1", port)) {
+            Ok(mut stream) => {
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(2)))
+                    .expect("set read timeout");
+                stream
+                    .write_all(
+                        b"GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+                    )
+                    .expect("write request");
+                let mut bytes = Vec::new();
+                let mut buf = [0_u8; 512];
+                loop {
+                    match stream.read(&mut buf) {
+                        Ok(0) => break,
+                        Ok(n) => bytes.extend_from_slice(&buf[..n]),
+                        Err(error)
+                            if error.kind() == ErrorKind::ConnectionReset && !bytes.is_empty() =>
+                        {
+                            break;
+                        }
+                        Err(error) => return Err(format!("read response: {error}")),
+                    }
+                }
+                let response = String::from_utf8(bytes).expect("response should be utf8");
+                return Ok(response);
+            }
+            Err(error) => {
+                last_error = Some(error.to_string());
+                std::thread::sleep(Duration::from_millis(20));
+            }
+        }
+    }
+
+    Err(format!(
+        "server did not return a loopback response: {last_error:?}"
+    ))
+}
+
+fn wait_with_timeout(mut child: std::process::Child, timeout: Duration) -> Output {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if child.try_wait().expect("poll child").is_some() {
+            return child.wait_with_output().expect("collect child output");
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let output = child
+                .wait_with_output()
+                .expect("collect killed child output");
+            panic!(
+                "compiled server fixture timed out\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+#[tokio::test]
+async fn embedded_registry_clean_workspace_import_build_run_server() {
+    let (registry_url, token, _registry_tmp) = start_test_server().await;
+    let publisher = registry_client(&registry_url, Some(&token));
+    let public_client = registry_client(&registry_url, None);
+
+    let package_ws = tempfile::TempDir::new().expect("package workspace");
+    make_server_package(package_ws.path());
+    let tarball = duumbi::registry::package::pack_module(package_ws.path()).expect("pack server");
+    let published = publisher
+        .publish("local", "@duumbi/stdlib-server", &tarball)
+        .await
+        .expect("publish server to embedded registry");
+    assert_eq!(published.name, "@duumbi/stdlib-server");
+    assert_eq!(published.version, "1.0.0");
+
+    let search = public_client
+        .search("local", "stdlib-server")
+        .await
+        .expect("search embedded registry");
+    assert!(
+        search
+            .results
+            .iter()
+            .any(|hit| { hit.name == "@duumbi/stdlib-server" && hit.latest_version == "1.0.0" })
+    );
+
+    let workspace = tempfile::TempDir::new().expect("clean workspace");
+    run_duumbi_init(workspace.path());
+    assert_default_dependency_policy(workspace.path());
+    assert!(
+        workspace
+            .path()
+            .join(".duumbi/cache/@duumbi/stdlib-server@1.0.0/graph/server.jsonld")
+            .exists(),
+        "server may be cached for explicit dependency use"
+    );
+
+    configure_local_registry(workspace.path(), &registry_url);
+    let cache_dir = workspace.path().join(".duumbi/cache");
+    let manifest = public_client
+        .download_module("local", "@duumbi/stdlib-server", "1.0.0", &cache_dir)
+        .await
+        .expect("download server module without credentials");
+    assert_eq!(manifest.module.name, "@duumbi/stdlib-server");
+    assert_eq!(manifest.module.version, "1.0.0");
+
+    let cache_entry = cache_dir.join("@duumbi/stdlib-server@1.0.0");
+    assert!(cache_entry.join("manifest.toml").exists());
+    assert!(cache_entry.join("graph/server.jsonld").exists());
+    assert!(cache_entry.join(".integrity").exists());
+
+    add_downloaded_server_dependency(workspace.path());
+
+    let port = unused_port();
+    write_main_graph(workspace.path(), server_importer_graph(port));
+    let output_path = workspace_output_path(workspace.path());
+    build_workspace(workspace.path(), &output_path, false).expect("build clean importer");
+
+    let mut child = Command::new(&output_path)
+        .current_dir(workspace.path())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn server fixture");
+
+    let response = match http_get_health(port) {
+        Ok(response) => response,
+        Err(error) => {
+            let _ = child.kill();
+            let run = child.wait_with_output().expect("collect child output");
+            panic!(
+                "{error}\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&run.stdout),
+                String::from_utf8_lossy(&run.stderr)
+            );
+        }
+    };
+    assert!(
+        response.starts_with("HTTP/1.1 200 OK"),
+        "unexpected response: {response:?}"
+    );
+    assert!(response.contains("Content-Length: 2"));
+    assert!(response.ends_with("ok"));
+
+    let run = wait_with_timeout(child, Duration::from_secs(3));
+    assert!(
+        run.status.success(),
+        "server fixture failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+}
+
+#[test]
+fn compiled_server_negative_paths_are_bounded_and_visible() {
+    let workspace = tempfile::TempDir::new().expect("negative workspace");
+    write_main_graph(
+        workspace.path(),
+        server_negative_graph(unused_port(), unused_port(), unused_port()),
+    );
+
+    let output_path = workspace_output_path(workspace.path());
+    build_workspace(workspace.path(), &output_path, false).expect("build negative fixture");
+    let run = run_workspace_binary(workspace.path(), &[]).expect("run negative fixture");
+
+    assert_eq!(run.exit_code, 0);
+    assert_eq!(run.stdout.trim(), "");
+    assert_eq!(run.stderr.trim(), "");
+}

--- a/tests/kill_criterion_phase7.rs
+++ b/tests/kill_criterion_phase7.rs
@@ -112,6 +112,7 @@ fn make_publishable_module(dir: &Path, name: &str, version: &str) {
 name = "@test/{name}"
 version = "{version}"
 description = "Test module for kill criterion"
+license = "MPL-2.0"
 
 [exports]
 functions = ["helper"]


### PR DESCRIPTION
Related to #381.

Product spec: https://github.com/hgahub/duumbi/pull/669
Technical spec: https://github.com/hgahub/duumbi/pull/672

Workflow note: this implementation PR must leave issue #381 open for Stage 11 implementation review and Stage 12 closure. Do not auto-close the execution issue from this PR.

## Summary

- Validates publish inputs across all `.duumbi/graph/*.jsonld` files and requires release manifest metadata before dry-run or production publish.
- Adds `@duumbi/stdlib-server` v1 as a bounded local static-route HTTP server module with parser, validator, lowering, runtime, stdlib graph, manifest, and init-cache support.
- Adds embedded-registry, clean-workspace, import/build/run, server loopback, and bounded negative-path E2E evidence.
- Keeps #380-owned HTTP/TLS/DB modules deferred and keeps server/JSON/TCP out of default `duumbi init` dependencies.

## Ralph Cycle Evidence

- Cycle 1: https://github.com/hgahub/duumbi/issues/381#issuecomment-4683502513
- Cycle 2: https://github.com/hgahub/duumbi/issues/381#issuecomment-4684523067
- Cycle 3: https://github.com/hgahub/duumbi/issues/381#issuecomment-4684872301

## Verification

- `cargo fmt`
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p duumbi --test integration_duumbi_381_cycle3`
- `cargo test init_`
- `cargo test registry::publish_matrix::tests --lib`
- `cargo test compiler::lowering::tests::c_runtime_server_handles_one_loopback_request --lib`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all`

## Resource Policy

- External LLM calls: 0
- External LLM cost: USD 0
- Public internet/default CI calls: 0
- Production publish calls: 0
- Real credential reads/writes/changes: 0
- Greptile/manual deep review: not invoked
