### PR TITLE
DUUMBI-684: Add semantic rewrite engine

### DIFF
--- a/docs/rewrite-engine.md
+++ b/docs/rewrite-engine.md
@@ -1,0 +1,186 @@
+# Semantic Rewrite Engine
+
+DUUMBI's V1 Semantic Rewrite Engine is a deterministic graph-to-graph rewrite
+substrate for small, reviewable transformations over JSON-LD semantic graphs.
+It is provider-free and uses the existing parse -> build -> validate pipeline.
+
+V1 is intentionally conservative. It is not an optimizer framework, proof
+system, or autonomous agent loop.
+
+## Rule Model
+
+Each rule has stable metadata:
+
+- `id`: stable kebab-case rule ID.
+- `displayName`: human-readable name.
+- `category`: `canonicalization`, `local-optimization`, or
+  `structural-cleanup`.
+- `safetyClass`: `structural-only`, `local-semantics-preserving`, or
+  `experimental`.
+- `preconditions`: local facts that must hold before a match is valid.
+- `effectSummary`: what the rewrite changes.
+- `defaultCost`: deterministic per-match cost estimate.
+- `explanationTemplate`: human-readable safety explanation.
+- `applyCapable`: false for experimental rules.
+
+The backend owns rule discovery, matching, preview evidence, apply planning,
+cost limits, patch construction, and candidate validation. CLI and MCP adapters
+only load modules, ask the backend for evidence, save snapshots, and write
+validated candidates when apply is explicitly requested.
+
+## Built-In V1 Rules
+
+Apply-capable rules:
+
+- `i64-add-zero-right`: rewrites downstream uses of `Add(x, 0)` to `x`.
+- `i64-add-zero-left`: rewrites downstream uses of `Add(0, x)` to `x`.
+- `i64-mul-one-right`: rewrites downstream uses of `Mul(x, 1)` to `x`.
+
+Preview-only rule:
+
+- `experimental-fold-i64-const-add`: detects `Add(Const(a), Const(b))` and
+  reports the folded value, but apply rejects it in V1.
+
+The identity rules redirect supported downstream JSON-LD references such as
+`duumbi:left`, `duumbi:right`, `duumbi:operand`, and `duumbi:condition`. They do
+not delete or reorder block operations in V1.
+
+## CLI
+
+List rules:
+
+```sh
+duumbi rewrite list
+duumbi rewrite list --json
+```
+
+Preview a rule without mutation:
+
+```sh
+duumbi rewrite preview --rule i64-add-zero-right
+duumbi rewrite preview --module main --rule i64-add-zero-right --limit 5 --json
+```
+
+Apply one match:
+
+```sh
+duumbi rewrite apply --rule i64-add-zero-right --match '<match-id>' --yes
+```
+
+Apply all matches within a bound:
+
+```sh
+duumbi rewrite apply --rule i64-add-zero-right --all --max-matches 3 --yes
+```
+
+If `--module` is omitted, DUUMBI uses `.duumbi/graph/main.jsonld`. A bare module
+name such as `main` resolves to `.duumbi/graph/main.jsonld`; a `.jsonld` path is
+used as provided.
+
+Interactive apply asks for confirmation unless `--yes` is supplied. Declining
+confirmation does not create a snapshot.
+
+## MCP Tools
+
+MCP exposes the same backend behavior:
+
+- `rewrite_list_rules`: read-only rule discovery.
+- `rewrite_preview`: read-only preview for one rule and module.
+- `rewrite_apply`: write-capable apply for one match or bounded all-matches
+  request.
+
+MCP apply has no interactive confirmation because the tool call itself is the
+explicit write request. It still reruns matching, validates the candidate, saves
+an undo snapshot, and writes only after validation succeeds.
+
+## Evidence
+
+Preview evidence includes:
+
+- `status`
+- `rule`
+- `matches`
+- `cost`
+- `warnings`
+
+Each match includes:
+
+- `matchId`
+- `ruleId`
+- `module`
+- `primaryNodeId`
+- `touchedNodeIds`
+- `operationSummary`
+- `explanation`
+- `cost`
+- `validation`
+
+Apply evidence includes:
+
+- selected match IDs
+- touched node IDs
+- validation status
+- patch operation count
+- cost evidence
+- snapshot path at the CLI/MCP adapter layer
+
+Match IDs use this shape:
+
+```text
+<rule-id>:<module-name>:<primary-node-id>:<ordinal>
+```
+
+Apply never trusts a preview object from the caller. It reruns matching against
+the current graph and rejects missing or changed match IDs as stale.
+
+## Safety And Bounds
+
+Default bounds:
+
+- max preview matches: 100
+- max single apply matches: 1
+- max apply-all matches: 10
+- max touched nodes per match: 25
+- max patch operations per match: 25
+- max explanation nodes: 20
+
+List and preview do not write graph files, snapshots, config, credentials,
+registry cache, intent files, or telemetry.
+
+Apply sequence:
+
+1. Load JSON-LD source.
+2. Parse source.
+3. Build `SemanticGraph`.
+4. Validate current graph.
+5. Rerun matching and preconditions.
+6. Enforce safety class and cost bounds.
+7. Apply the rewrite patch to a clone in memory.
+8. Parse, build, and validate the candidate graph.
+9. Save an undo snapshot of the original source.
+10. Write the pretty JSON-LD candidate.
+
+Snapshot failure prevents graph writes. Candidate validation failure prevents
+snapshots and writes.
+
+## Relationship To Existing Mutation Paths
+
+The rewrite engine does not replace `GraphPatch`, `duumbi add`, intent
+execution, or MCP `graph_mutate`.
+
+V1 rewrite apply uses `GraphPatch` internally as a safe candidate transform
+primitive, then validates the candidate before adapters write it. Existing
+provider-backed mutation and intent workflows keep their current behavior.
+Query mode remains read-only.
+
+## Non-Goals
+
+V1 does not provide:
+
+- e-graph equality saturation;
+- an `egg` or equivalence-graph dependency;
+- formal proof generation;
+- SMT or VCGen proof-carrying rewrites;
+- autonomous self-evolution;
+- live LLM rule selection or rule synthesis;
+- broad compiler optimization passes.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -17,6 +17,7 @@ pub mod provider_startup;
 pub mod publish;
 pub mod registry;
 pub mod repl;
+pub mod rewrite;
 pub mod theme;
 pub mod upgrade;
 pub mod yank;
@@ -168,6 +169,13 @@ pub enum Commands {
 
     /// Undo the last AI mutation (restores from snapshot in `.duumbi/history/`).
     Undo,
+
+    /// Discover, preview, and explicitly apply semantic rewrite rules.
+    Rewrite {
+        /// Rewrite subcommand.
+        #[command(subcommand)]
+        subcommand: RewriteSubcommand,
+    },
 
     /// Manage local path dependencies declared in `.duumbi/config.toml`.
     Deps {
@@ -404,6 +412,58 @@ pub enum TelemetrySubcommand {
         /// Optional path for writing the repair validation evidence JSON.
         #[arg(long)]
         output: Option<PathBuf>,
+    },
+}
+
+/// Subcommands for `duumbi rewrite`.
+#[derive(Subcommand, Debug)]
+pub enum RewriteSubcommand {
+    /// List available rewrite rules.
+    List {
+        /// Emit JSON instead of human-readable text.
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Preview a rewrite rule without mutating the graph.
+    Preview {
+        /// Module name such as `main`, or a path to a `.jsonld` file.
+        #[arg(long)]
+        module: Option<String>,
+        /// Rewrite rule ID.
+        #[arg(long)]
+        rule: String,
+        /// Emit JSON instead of human-readable text.
+        #[arg(long)]
+        json: bool,
+        /// Maximum matches to return, bounded by rewrite limits.
+        #[arg(long)]
+        limit: Option<usize>,
+    },
+
+    /// Apply one selected rewrite match or bounded all-matches request.
+    Apply {
+        /// Module name such as `main`, or a path to a `.jsonld` file.
+        #[arg(long)]
+        module: Option<String>,
+        /// Rewrite rule ID.
+        #[arg(long)]
+        rule: String,
+        /// Selected match ID from preview.
+        #[arg(long = "match")]
+        match_id: Option<String>,
+        /// Apply all matches within the configured bound.
+        #[arg(long)]
+        all: bool,
+        /// Maximum matches for `--all`, bounded by rewrite limits.
+        #[arg(long)]
+        max_matches: Option<usize>,
+        /// Apply immediately without confirmation prompt.
+        #[arg(short = 'y', long)]
+        yes: bool,
+        /// Emit JSON instead of human-readable text.
+        #[arg(long)]
+        json: bool,
     },
 }
 
@@ -806,6 +866,74 @@ mod tests {
             cli.command,
             Commands::Telemetry {
                 subcommand: TelemetrySubcommand::RepairValidate { .. }
+            }
+        ));
+    }
+
+    #[test]
+    fn rewrite_list_parses() {
+        let cli =
+            Cli::try_parse_from(["duumbi", "rewrite", "list", "--json"]).expect("CLI must parse");
+
+        assert!(matches!(
+            cli.command,
+            Commands::Rewrite {
+                subcommand: RewriteSubcommand::List { json: true }
+            }
+        ));
+    }
+
+    #[test]
+    fn rewrite_preview_parses() {
+        let cli = Cli::try_parse_from([
+            "duumbi",
+            "rewrite",
+            "preview",
+            "--module",
+            "main",
+            "--rule",
+            "i64-add-zero-right",
+            "--limit",
+            "5",
+            "--json",
+        ])
+        .expect("CLI must parse rewrite preview");
+
+        assert!(matches!(
+            cli.command,
+            Commands::Rewrite {
+                subcommand: RewriteSubcommand::Preview {
+                    module: Some(_),
+                    rule,
+                    json: true,
+                    limit: Some(5),
+                }
+            } if rule == "i64-add-zero-right"
+        ));
+    }
+
+    #[test]
+    fn rewrite_apply_match_parses() {
+        let cli = Cli::try_parse_from([
+            "duumbi",
+            "rewrite",
+            "apply",
+            "--rule",
+            "i64-add-zero-right",
+            "--match",
+            "m1",
+            "--yes",
+        ])
+        .expect("CLI must parse rewrite apply");
+
+        assert!(matches!(
+            cli.command,
+            Commands::Rewrite {
+                subcommand: RewriteSubcommand::Apply {
+                    match_id: Some(_),
+                    yes: true,
+                    ..
+                }
             }
         ));
     }

--- a/src/cli/rewrite.rs
+++ b/src/cli/rewrite.rs
@@ -3,6 +3,7 @@
 use std::fs;
 use std::io::{self, Write as _};
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 
@@ -148,13 +149,15 @@ fn run_apply(
         }
     }
 
-    let snapshot_path = snapshot::save_snapshot(workspace, &source_str)
-        .context("Failed to save rewrite undo snapshot")?;
     let patched_str = serde_json::to_string_pretty(&outcome.candidate_source)
         .context("Failed to serialize rewritten graph")?;
-    fs::write(&module_path, patched_str).with_context(|| {
+    let temp_path = write_temp_candidate(&module_path, &patched_str)?;
+    let snapshot_path = snapshot::save_snapshot(workspace, &source_str)
+        .context("Failed to save rewrite undo snapshot")?;
+    fs::rename(&temp_path, &module_path).with_context(|| {
+        let _ = fs::remove_file(&temp_path);
         format!(
-            "Failed to write rewritten graph '{}'",
+            "Failed to replace rewritten graph '{}'",
             module_path.display()
         )
     })?;
@@ -194,6 +197,39 @@ fn read_module_source(path: &Path) -> Result<(String, serde_json::Value)> {
     let source = serde_json::from_str(&source_str)
         .with_context(|| format!("Failed to parse module '{}' as JSON", path.display()))?;
     Ok((source_str, source))
+}
+
+fn write_temp_candidate(module_path: &Path, contents: &str) -> Result<PathBuf> {
+    let parent = module_path.parent().with_context(|| {
+        format!(
+            "Module path '{}' has no parent directory",
+            module_path.display()
+        )
+    })?;
+    let file_name = module_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .with_context(|| {
+            format!(
+                "Module path '{}' has no valid file name",
+                module_path.display()
+            )
+        })?;
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("System clock error while creating rewrite temp file")?
+        .as_nanos();
+    let temp_path = parent.join(format!(".{file_name}.{unique}.tmp"));
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temp_path)
+        .with_context(|| format!("Failed to create temp file '{}'", temp_path.display()))?;
+    file.write_all(contents.as_bytes())
+        .with_context(|| format!("Failed to write temp file '{}'", temp_path.display()))?;
+    file.sync_all()
+        .with_context(|| format!("Failed to sync temp file '{}'", temp_path.display()))?;
+    Ok(temp_path)
 }
 
 fn print_preview(preview: &RewritePreview) {

--- a/src/cli/rewrite.rs
+++ b/src/cli/rewrite.rs
@@ -1,0 +1,274 @@
+//! CLI adapter for semantic rewrite rules.
+
+use std::fs;
+use std::io::{self, Write as _};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+use crate::rewrite::{
+    ApplyMode, ApplyOptions, RewriteApplyPlan, RewriteEngine, RewriteMatch, RewritePreview,
+};
+use crate::snapshot;
+
+use super::RewriteSubcommand;
+
+/// Dispatches `duumbi rewrite` subcommands.
+pub fn run_rewrite(subcommand: RewriteSubcommand, workspace: &Path) -> Result<()> {
+    match subcommand {
+        RewriteSubcommand::List { json } => run_list(json),
+        RewriteSubcommand::Preview {
+            module,
+            rule,
+            json,
+            limit,
+        } => run_preview(workspace, module.as_deref(), &rule, json, limit),
+        RewriteSubcommand::Apply {
+            module,
+            rule,
+            match_id,
+            all,
+            max_matches,
+            yes,
+            json,
+        } => run_apply(
+            workspace,
+            module.as_deref(),
+            &rule,
+            match_id,
+            all,
+            max_matches,
+            yes,
+            json,
+        ),
+    }
+}
+
+fn run_list(json_output: bool) -> Result<()> {
+    let rules = RewriteEngine::default().list_rules();
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&rules)?);
+        return Ok(());
+    }
+
+    if rules.is_empty() {
+        println!("No rewrite rules registered.");
+        return Ok(());
+    }
+
+    for rule in rules {
+        println!(
+            "{}\n  category: {:?}\n  safety: {:?}\n  apply-capable: {}\n  preconditions: {}\n  effect: {}\n",
+            rule.id,
+            rule.category,
+            rule.safety_class,
+            rule.apply_capable,
+            rule.preconditions,
+            rule.effect_summary
+        );
+    }
+    Ok(())
+}
+
+fn run_preview(
+    workspace: &Path,
+    module: Option<&str>,
+    rule_id: &str,
+    json_output: bool,
+    limit: Option<usize>,
+) -> Result<()> {
+    let module_path = resolve_module_path(workspace, module);
+    let (_, source) = read_module_source(&module_path)?;
+    let preview = RewriteEngine::default()
+        .preview_source(&source, rule_id, limit)
+        .map_err(|err| anyhow::anyhow!("{err}"))?;
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&preview)?);
+    } else {
+        print_preview(&preview);
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_apply(
+    workspace: &Path,
+    module: Option<&str>,
+    rule_id: &str,
+    match_id: Option<String>,
+    all: bool,
+    max_matches: Option<usize>,
+    yes: bool,
+    json_output: bool,
+) -> Result<()> {
+    if all == match_id.is_some() {
+        anyhow::bail!("Specify exactly one of --match <match-id> or --all");
+    }
+
+    let module_path = resolve_module_path(workspace, module);
+    let (source_str, source) = read_module_source(&module_path)?;
+    let mode = if all {
+        ApplyMode::All
+    } else {
+        ApplyMode::Match
+    };
+    let options = ApplyOptions {
+        rule_id: rule_id.to_string(),
+        module: None,
+        mode,
+        match_id,
+        max_matches,
+    };
+    let outcome = RewriteEngine::default()
+        .apply_to_source(&source, &options)
+        .map_err(|err| anyhow::anyhow!("{err}"))?;
+
+    if !yes {
+        print_apply_plan(&outcome.plan);
+        eprint!("Apply rewrite? [y/N] ");
+        io::stderr().flush().ok();
+        let mut input = String::new();
+        io::stdin()
+            .read_line(&mut input)
+            .context("Failed to read confirmation")?;
+        if !input.trim().eq_ignore_ascii_case("y") {
+            if json_output {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "status": "cancelled",
+                        "message": "No rewrite applied"
+                    })
+                );
+            } else {
+                eprintln!("No rewrite applied.");
+            }
+            return Ok(());
+        }
+    }
+
+    let snapshot_path = snapshot::save_snapshot(workspace, &source_str)
+        .context("Failed to save rewrite undo snapshot")?;
+    let patched_str = serde_json::to_string_pretty(&outcome.candidate_source)
+        .context("Failed to serialize rewritten graph")?;
+    fs::write(&module_path, patched_str).with_context(|| {
+        format!(
+            "Failed to write rewritten graph '{}'",
+            module_path.display()
+        )
+    })?;
+
+    if json_output {
+        let mut value = serde_json::to_value(&outcome.plan)?;
+        value["snapshotPath"] = serde_json::Value::String(snapshot_path.display().to_string());
+        println!("{}", serde_json::to_string_pretty(&value)?);
+    } else {
+        print_apply_plan(&outcome.plan);
+        println!("Snapshot: {}", snapshot_path.display());
+        println!("Graph updated: {}", module_path.display());
+    }
+
+    Ok(())
+}
+
+fn resolve_module_path(workspace: &Path, module: Option<&str>) -> PathBuf {
+    match module {
+        None => workspace.join(".duumbi").join("graph").join("main.jsonld"),
+        Some(name)
+            if Path::new(name).extension().is_none()
+                && !name.contains(std::path::MAIN_SEPARATOR) =>
+        {
+            workspace
+                .join(".duumbi")
+                .join("graph")
+                .join(format!("{name}.jsonld"))
+        }
+        Some(path) => PathBuf::from(path),
+    }
+}
+
+fn read_module_source(path: &Path) -> Result<(String, serde_json::Value)> {
+    let source_str = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read module '{}'", path.display()))?;
+    let source = serde_json::from_str(&source_str)
+        .with_context(|| format!("Failed to parse module '{}' as JSON", path.display()))?;
+    Ok((source_str, source))
+}
+
+fn print_preview(preview: &RewritePreview) {
+    println!("Rule: {}", preview.rule.id);
+    println!("Safety: {:?}", preview.rule.safety_class);
+    println!("Matches: {}", preview.matches.len());
+    println!(
+        "Cost: considered={}, returned={}, truncated={}, patchOps={}",
+        preview.cost.matches_considered,
+        preview.cost.matches_returned,
+        preview.cost.matches_truncated,
+        preview.cost.patch_op_count
+    );
+    if preview.matches.is_empty() {
+        println!("No matches.");
+        return;
+    }
+    for matched in &preview.matches {
+        print_match(matched);
+    }
+}
+
+fn print_apply_plan(plan: &RewriteApplyPlan) {
+    println!("Rule: {}", plan.rule.id);
+    println!("Matches: {}", plan.match_ids.join(", "));
+    println!(
+        "Validation: ran={}, valid={}",
+        plan.validation.ran, plan.validation.valid
+    );
+    println!(
+        "Cost: returned={}, patchOps={}",
+        plan.cost.matches_returned, plan.cost.patch_op_count
+    );
+    println!("{}", plan.operation_summary);
+}
+
+fn print_match(matched: &RewriteMatch) {
+    println!("- {}", matched.match_id);
+    println!("  primary: {}", matched.primary_node_id);
+    println!("  touched: {}", matched.touched_node_ids.join(", "));
+    println!("  effect: {}", matched.operation_summary);
+    println!("  explanation: {}", matched.explanation);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_default_module_to_workspace_main() {
+        assert_eq!(
+            resolve_module_path(Path::new("/tmp/workspace"), None),
+            Path::new("/tmp/workspace")
+                .join(".duumbi")
+                .join("graph")
+                .join("main.jsonld")
+        );
+    }
+
+    #[test]
+    fn resolves_named_module_to_workspace_graph_file() {
+        assert_eq!(
+            resolve_module_path(Path::new("/tmp/workspace"), Some("main")),
+            Path::new("/tmp/workspace")
+                .join(".duumbi")
+                .join("graph")
+                .join("main.jsonld")
+        );
+    }
+
+    #[test]
+    fn resolves_explicit_jsonld_path_as_path() {
+        assert_eq!(
+            resolve_module_path(Path::new("/tmp/workspace"), Some("fixtures/rewrite.jsonld")),
+            Path::new("fixtures/rewrite.jsonld")
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod parser;
 pub mod patch;
 pub mod query;
 pub mod registry;
+pub mod rewrite;
 pub mod session;
 pub mod snapshot;
 pub mod telemetry;

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,8 @@ mod patch;
 // Binary uses query engine through CLI; library exports full API
 mod query;
 mod registry;
+#[allow(dead_code, unused_imports)]
+mod rewrite;
 #[allow(dead_code)] // Binary uses a subset; full API used via lib crate
 mod session;
 mod snapshot;
@@ -211,6 +213,7 @@ fn command_name(command: &Commands) -> &'static str {
         Commands::Describe { .. } => "describe",
         Commands::Add { .. } => "add",
         Commands::Undo => "undo",
+        Commands::Rewrite { .. } => "rewrite",
         Commands::Deps { .. } => "deps",
         Commands::Search { .. } => "search",
         Commands::Intent { .. } => "intent",
@@ -394,6 +397,10 @@ async fn run(cli: Cli) -> Result<i32> {
         }
         Commands::Add { request, yes } => success_exit(add(&request, yes).await),
         Commands::Undo => success_exit(undo()),
+        Commands::Rewrite { subcommand } => {
+            let workspace = PathBuf::from(".");
+            success_exit(cli::rewrite::run_rewrite(subcommand, &workspace))
+        }
         Commands::Search { query, registry } => {
             let workspace = PathBuf::from(".");
             success_exit(cli::deps::run_search(&workspace, &query, registry.as_deref()).await)

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -742,6 +742,9 @@ mod tests {
             "model_access_summary",
             "model_performance_summary",
             "model_telemetry_health",
+            "rewrite_list_rules",
+            "rewrite_preview",
+            "rewrite_apply",
         ];
 
         for name in &expected_names {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -375,6 +375,81 @@ impl McpServer {
                     "additionalProperties": false
                 }),
             },
+            ToolDefinition {
+                name: "rewrite_list_rules".to_string(),
+                description: "Read-only semantic rewrite rule discovery. Does not read or write graph files, snapshots, config, credentials, registry cache, intents, or telemetry."
+                    .to_string(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "include_experimental": {
+                            "type": "boolean",
+                            "description": "Include preview-only experimental rules; defaults to true"
+                        }
+                    },
+                    "additionalProperties": false
+                }),
+            },
+            ToolDefinition {
+                name: "rewrite_preview".to_string(),
+                description: "Read-only semantic rewrite preview for one rule and module. Parses, builds, validates, and matches without writing graph files or snapshots."
+                    .to_string(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "required": ["rule_id"],
+                    "properties": {
+                        "rule_id": {
+                            "type": "string",
+                            "description": "Stable rewrite rule ID"
+                        },
+                        "module": {
+                            "type": "string",
+                            "description": "Module name such as 'main', or a path to a .jsonld file; defaults to main"
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 100,
+                            "description": "Maximum matches to return, bounded by engine limits"
+                        }
+                    },
+                    "additionalProperties": false
+                }),
+            },
+            ToolDefinition {
+                name: "rewrite_apply".to_string(),
+                description: "Write-capable semantic rewrite apply. Reruns matching and validation, saves an undo snapshot, then writes only after the candidate graph validates."
+                    .to_string(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "required": ["rule_id"],
+                    "properties": {
+                        "rule_id": {
+                            "type": "string",
+                            "description": "Stable rewrite rule ID"
+                        },
+                        "module": {
+                            "type": "string",
+                            "description": "Module name such as 'main', or a path to a .jsonld file; defaults to main"
+                        },
+                        "match_id": {
+                            "type": "string",
+                            "description": "Selected match ID from rewrite_preview"
+                        },
+                        "all": {
+                            "type": "boolean",
+                            "description": "Apply all matches within the bounded max_matches setting"
+                        },
+                        "max_matches": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 10,
+                            "description": "Maximum matches for all=true"
+                        }
+                    },
+                    "additionalProperties": false
+                }),
+            },
         ]
     }
 
@@ -454,6 +529,9 @@ impl McpServer {
             "model_telemetry_health" => {
                 tools::model_telemetry::model_telemetry_health(workspace, args)
             }
+            "rewrite_list_rules" => tools::rewrite::rewrite_list_rules(workspace, args),
+            "rewrite_preview" => tools::rewrite::rewrite_preview(workspace, args),
+            "rewrite_apply" => tools::rewrite::rewrite_apply(workspace, args),
             _ => {
                 return Err(JsonRpcError {
                     code: rpc_codes::METHOD_NOT_FOUND,

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -8,3 +8,4 @@ pub mod deps;
 pub mod graph;
 pub mod intent;
 pub mod model_telemetry;
+pub mod rewrite;

--- a/src/mcp/tools/rewrite.rs
+++ b/src/mcp/tools/rewrite.rs
@@ -1,7 +1,9 @@
 //! MCP rewrite tools: rule discovery, preview, and explicit apply.
 
 use std::fs;
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::Value;
 
@@ -26,7 +28,7 @@ pub fn rewrite_preview(workspace: &Path, params: &Value) -> Result<Value, String
     let rule_id = required_string(params, "rule_id")?;
     let module = optional_string(params, "module")?;
     let limit = optional_usize(params, "limit")?;
-    let module_path = resolve_module_path(workspace, module.as_deref());
+    let module_path = resolve_module_path(workspace, module.as_deref())?;
     let (_, source) = read_module_source(&module_path)?;
     let preview = RewriteEngine::default()
         .preview_source(&source, &rule_id, limit)
@@ -49,7 +51,7 @@ pub fn rewrite_apply(workspace: &Path, params: &Value) -> Result<Value, String> 
         return Err("Specify exactly one of match_id or all=true".to_string());
     }
 
-    let module_path = resolve_module_path(workspace, module.as_deref());
+    let module_path = resolve_module_path(workspace, module.as_deref())?;
     let (source_text, source) = read_module_source(&module_path)?;
     let outcome = RewriteEngine::default()
         .apply_to_source(
@@ -68,20 +70,23 @@ pub fn rewrite_apply(workspace: &Path, params: &Value) -> Result<Value, String> 
         )
         .map_err(|err| err.to_string())?;
 
-    let snapshot_path = snapshot::save_snapshot(workspace, &source_text)
-        .map_err(|err| format!("Snapshot failed: {err:#}"))?;
     let patched = serde_json::to_string_pretty(&outcome.candidate_source)
         .map_err(|err| format!("Serialization failed: {err}"))?;
-    fs::write(&module_path, patched)
-        .map_err(|err| format!("Cannot write '{}': {err}", module_path.display()))?;
+    let temp_path = write_temp_candidate(&module_path, &patched)?;
+    let snapshot_path = snapshot::save_snapshot(workspace, &source_text)
+        .map_err(|err| format!("Snapshot failed: {err:#}"))?;
+    if let Err(err) = fs::rename(&temp_path, &module_path) {
+        let _ = fs::remove_file(&temp_path);
+        return Err(format!("Cannot replace '{}': {err}", module_path.display()));
+    }
 
     let mut result = serde_json::to_value(outcome.plan).map_err(|err| err.to_string())?;
     result["snapshotPath"] = Value::String(snapshot_path.display().to_string());
     Ok(result)
 }
 
-fn resolve_module_path(workspace: &Path, module: Option<&str>) -> PathBuf {
-    match module {
+fn resolve_module_path(workspace: &Path, module: Option<&str>) -> Result<PathBuf, String> {
+    let candidate = match module {
         None => workspace.join(".duumbi").join("graph").join("main.jsonld"),
         Some(name)
             if Path::new(name).extension().is_none()
@@ -92,8 +97,24 @@ fn resolve_module_path(workspace: &Path, module: Option<&str>) -> PathBuf {
                 .join("graph")
                 .join(format!("{name}.jsonld"))
         }
-        Some(path) => PathBuf::from(path),
+        Some(path) if Path::new(path).is_absolute() => PathBuf::from(path),
+        Some(path) => workspace.join(path),
+    };
+
+    let workspace_root = workspace
+        .canonicalize()
+        .map_err(|err| format!("Cannot resolve workspace '{}': {err}", workspace.display()))?;
+    let module_path = candidate
+        .canonicalize()
+        .map_err(|err| format!("Cannot resolve module '{}': {err}", candidate.display()))?;
+    if !module_path.starts_with(&workspace_root) {
+        return Err(format!(
+            "Module path '{}' must stay inside workspace '{}'",
+            module_path.display(),
+            workspace_root.display()
+        ));
     }
+    Ok(module_path)
 }
 
 fn read_module_source(path: &Path) -> Result<(String, Value), String> {
@@ -102,6 +123,39 @@ fn read_module_source(path: &Path) -> Result<(String, Value), String> {
     let source = serde_json::from_str(&source_text)
         .map_err(|err| format!("Invalid JSON in '{}': {err}", path.display()))?;
     Ok((source_text, source))
+}
+
+fn write_temp_candidate(module_path: &Path, contents: &str) -> Result<PathBuf, String> {
+    let parent = module_path.parent().ok_or_else(|| {
+        format!(
+            "Module path '{}' has no parent directory",
+            module_path.display()
+        )
+    })?;
+    let file_name = module_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            format!(
+                "Module path '{}' has no valid file name",
+                module_path.display()
+            )
+        })?;
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|err| format!("System clock error: {err}"))?
+        .as_nanos();
+    let temp_path = parent.join(format!(".{file_name}.{unique}.tmp"));
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temp_path)
+        .map_err(|err| format!("Cannot create temp file '{}': {err}", temp_path.display()))?;
+    file.write_all(contents.as_bytes())
+        .map_err(|err| format!("Cannot write temp file '{}': {err}", temp_path.display()))?;
+    file.sync_all()
+        .map_err(|err| format!("Cannot sync temp file '{}': {err}", temp_path.display()))?;
+    Ok(temp_path)
 }
 
 fn reject_unknown_fields(params: &Value, allowed: &[&str]) -> Result<(), String> {

--- a/src/mcp/tools/rewrite.rs
+++ b/src/mcp/tools/rewrite.rs
@@ -1,0 +1,155 @@
+//! MCP rewrite tools: rule discovery, preview, and explicit apply.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use crate::rewrite::{ApplyMode, ApplyOptions, RewriteEngine};
+use crate::snapshot;
+
+/// List available semantic rewrite rules.
+pub fn rewrite_list_rules(_workspace: &Path, params: &Value) -> Result<Value, String> {
+    reject_unknown_fields(params, &["include_experimental"])?;
+    let include_experimental = optional_bool(params, "include_experimental")?.unwrap_or(true);
+    let rules = RewriteEngine::default()
+        .list_rules()
+        .into_iter()
+        .filter(|rule| include_experimental || rule.apply_capable)
+        .collect::<Vec<_>>();
+    Ok(serde_json::json!({ "rules": rules }))
+}
+
+/// Preview one semantic rewrite rule without mutating workspace state.
+pub fn rewrite_preview(workspace: &Path, params: &Value) -> Result<Value, String> {
+    reject_unknown_fields(params, &["rule_id", "module", "limit"])?;
+    let rule_id = required_string(params, "rule_id")?;
+    let module = optional_string(params, "module")?;
+    let limit = optional_usize(params, "limit")?;
+    let module_path = resolve_module_path(workspace, module.as_deref());
+    let (_, source) = read_module_source(&module_path)?;
+    let preview = RewriteEngine::default()
+        .preview_source(&source, &rule_id, limit)
+        .map_err(|err| err.to_string())?;
+    serde_json::to_value(preview).map_err(|err| err.to_string())
+}
+
+/// Apply one semantic rewrite rule after validation and snapshot creation.
+pub fn rewrite_apply(workspace: &Path, params: &Value) -> Result<Value, String> {
+    reject_unknown_fields(
+        params,
+        &["rule_id", "module", "match_id", "all", "max_matches"],
+    )?;
+    let rule_id = required_string(params, "rule_id")?;
+    let module = optional_string(params, "module")?;
+    let match_id = optional_string(params, "match_id")?;
+    let all = optional_bool(params, "all")?.unwrap_or(false);
+    let max_matches = optional_usize(params, "max_matches")?;
+    if all == match_id.is_some() {
+        return Err("Specify exactly one of match_id or all=true".to_string());
+    }
+
+    let module_path = resolve_module_path(workspace, module.as_deref());
+    let (source_text, source) = read_module_source(&module_path)?;
+    let outcome = RewriteEngine::default()
+        .apply_to_source(
+            &source,
+            &ApplyOptions {
+                rule_id,
+                module: None,
+                mode: if all {
+                    ApplyMode::All
+                } else {
+                    ApplyMode::Match
+                },
+                match_id,
+                max_matches,
+            },
+        )
+        .map_err(|err| err.to_string())?;
+
+    let snapshot_path = snapshot::save_snapshot(workspace, &source_text)
+        .map_err(|err| format!("Snapshot failed: {err:#}"))?;
+    let patched = serde_json::to_string_pretty(&outcome.candidate_source)
+        .map_err(|err| format!("Serialization failed: {err}"))?;
+    fs::write(&module_path, patched)
+        .map_err(|err| format!("Cannot write '{}': {err}", module_path.display()))?;
+
+    let mut result = serde_json::to_value(outcome.plan).map_err(|err| err.to_string())?;
+    result["snapshotPath"] = Value::String(snapshot_path.display().to_string());
+    Ok(result)
+}
+
+fn resolve_module_path(workspace: &Path, module: Option<&str>) -> PathBuf {
+    match module {
+        None => workspace.join(".duumbi").join("graph").join("main.jsonld"),
+        Some(name)
+            if Path::new(name).extension().is_none()
+                && !name.contains(std::path::MAIN_SEPARATOR) =>
+        {
+            workspace
+                .join(".duumbi")
+                .join("graph")
+                .join(format!("{name}.jsonld"))
+        }
+        Some(path) => PathBuf::from(path),
+    }
+}
+
+fn read_module_source(path: &Path) -> Result<(String, Value), String> {
+    let source_text = fs::read_to_string(path)
+        .map_err(|err| format!("Cannot read module '{}': {err}", path.display()))?;
+    let source = serde_json::from_str(&source_text)
+        .map_err(|err| format!("Invalid JSON in '{}': {err}", path.display()))?;
+    Ok((source_text, source))
+}
+
+fn reject_unknown_fields(params: &Value, allowed: &[&str]) -> Result<(), String> {
+    let object = params
+        .as_object()
+        .ok_or_else(|| "Tool arguments must be a JSON object".to_string())?;
+    if let Some(key) = object.keys().find(|key| {
+        !allowed
+            .iter()
+            .any(|allowed_key| allowed_key == &key.as_str())
+    }) {
+        return Err(format!("Unknown field '{key}'"));
+    }
+    Ok(())
+}
+
+fn required_string(params: &Value, field: &str) -> Result<String, String> {
+    params
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| format!("Missing or invalid required field '{field}'"))
+}
+
+fn optional_string(params: &Value, field: &str) -> Result<Option<String>, String> {
+    match params.get(field) {
+        None => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value.clone())),
+        Some(_) => Err(format!("Field '{field}' must be a string")),
+    }
+}
+
+fn optional_bool(params: &Value, field: &str) -> Result<Option<bool>, String> {
+    match params.get(field) {
+        None => Ok(None),
+        Some(Value::Bool(value)) => Ok(Some(*value)),
+        Some(_) => Err(format!("Field '{field}' must be a boolean")),
+    }
+}
+
+fn optional_usize(params: &Value, field: &str) -> Result<Option<usize>, String> {
+    match params.get(field) {
+        None => Ok(None),
+        Some(Value::Number(value)) => value
+            .as_u64()
+            .and_then(|value| usize::try_from(value).ok())
+            .map(Some)
+            .ok_or_else(|| format!("Field '{field}' must be a positive integer")),
+        Some(_) => Err(format!("Field '{field}' must be an integer")),
+    }
+}

--- a/src/rewrite/catalog.rs
+++ b/src/rewrite/catalog.rs
@@ -1,0 +1,157 @@
+//! Built-in rewrite rule catalog.
+
+use super::rule::{RuleCategory, RuleSummary, SafetyClass};
+
+/// Internal matcher kind for built-in V1 rules.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuiltInRuleKind {
+    /// Match `Add(x, 0)` where all values are i64.
+    I64AddZeroRight,
+    /// Match `Add(0, x)` where all values are i64.
+    I64AddZeroLeft,
+    /// Match `Mul(x, 1)` where all values are i64.
+    I64MulOneRight,
+    /// Preview-only constant folding for `Add(Const(a), Const(b))`.
+    ExperimentalFoldI64ConstAdd,
+}
+
+/// One registered rewrite rule.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuleDefinition {
+    /// Public rule metadata.
+    pub summary: RuleSummary,
+    /// Built-in matcher implementation.
+    pub kind: BuiltInRuleKind,
+}
+
+impl RuleDefinition {
+    fn new(summary: RuleSummary, kind: BuiltInRuleKind) -> Self {
+        Self { summary, kind }
+    }
+}
+
+/// Deterministic catalog of available rewrite rules.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RewriteCatalog {
+    rules: Vec<RuleDefinition>,
+}
+
+impl RewriteCatalog {
+    /// Returns the V1 built-in rule catalog.
+    #[must_use]
+    pub fn built_in() -> Self {
+        Self {
+            rules: vec![
+                RuleDefinition::new(
+                    RuleSummary::new(
+                        "i64-add-zero-right",
+                        "I64 add zero right",
+                        RuleCategory::LocalOptimization,
+                        SafetyClass::LocalSemanticsPreserving,
+                        "Detects i64 Add nodes whose right operand is zero.",
+                        "The operation and both operands are i64, and the right operand is Const(0).",
+                        "Replace the Add result with the left operand.",
+                        1,
+                        "Adding zero on the right preserves the left operand value.",
+                    ),
+                    BuiltInRuleKind::I64AddZeroRight,
+                ),
+                RuleDefinition::new(
+                    RuleSummary::new(
+                        "i64-add-zero-left",
+                        "I64 add zero left",
+                        RuleCategory::LocalOptimization,
+                        SafetyClass::LocalSemanticsPreserving,
+                        "Detects i64 Add nodes whose left operand is zero.",
+                        "The operation and both operands are i64, and the left operand is Const(0).",
+                        "Replace the Add result with the right operand.",
+                        1,
+                        "Adding zero on the left preserves the right operand value.",
+                    ),
+                    BuiltInRuleKind::I64AddZeroLeft,
+                ),
+                RuleDefinition::new(
+                    RuleSummary::new(
+                        "i64-mul-one-right",
+                        "I64 multiply one right",
+                        RuleCategory::LocalOptimization,
+                        SafetyClass::LocalSemanticsPreserving,
+                        "Detects i64 Mul nodes whose right operand is one.",
+                        "The operation and both operands are i64, and the right operand is Const(1).",
+                        "Replace the Mul result with the left operand.",
+                        1,
+                        "Multiplying by one on the right preserves the left operand value.",
+                    ),
+                    BuiltInRuleKind::I64MulOneRight,
+                ),
+                RuleDefinition::new(
+                    RuleSummary::new(
+                        "experimental-fold-i64-const-add",
+                        "Experimental fold i64 const add",
+                        RuleCategory::Canonicalization,
+                        SafetyClass::Experimental,
+                        "Detects i64 Add nodes with two constant operands.",
+                        "Both operands are i64 constants.",
+                        "Would replace the Add result with one folded i64 Const.",
+                        1,
+                        "Constant i64 Add can be folded when both operands are known.",
+                    ),
+                    BuiltInRuleKind::ExperimentalFoldI64ConstAdd,
+                ),
+            ],
+        }
+    }
+
+    /// Returns summaries for all registered rules in catalog order.
+    #[must_use]
+    pub fn summaries(&self) -> Vec<RuleSummary> {
+        self.rules.iter().map(|rule| rule.summary.clone()).collect()
+    }
+
+    /// Returns one registered rule by stable rule ID.
+    #[must_use]
+    pub fn find(&self, rule_id: &str) -> Option<&RuleDefinition> {
+        self.rules.iter().find(|rule| rule.summary.id == rule_id)
+    }
+}
+
+impl Default for RewriteCatalog {
+    fn default() -> Self {
+        Self::built_in()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn built_in_catalog_exposes_expected_rule_ids() {
+        let ids: Vec<_> = RewriteCatalog::built_in()
+            .summaries()
+            .into_iter()
+            .map(|summary| summary.id)
+            .collect();
+
+        assert_eq!(
+            ids,
+            vec![
+                "i64-add-zero-right",
+                "i64-add-zero-left",
+                "i64-mul-one-right",
+                "experimental-fold-i64-const-add",
+            ]
+        );
+    }
+
+    #[test]
+    fn experimental_const_fold_is_preview_only() {
+        let catalog = RewriteCatalog::built_in();
+        let rule = catalog
+            .find("experimental-fold-i64-const-add")
+            .expect("invariant: built-in rule exists");
+
+        assert!(!rule.summary.apply_capable);
+        assert_eq!(rule.kind, BuiltInRuleKind::ExperimentalFoldI64ConstAdd);
+    }
+}

--- a/src/rewrite/engine.rs
+++ b/src/rewrite/engine.rs
@@ -1,0 +1,868 @@
+//! Deterministic rewrite preview engine.
+
+use petgraph::stable_graph::NodeIndex;
+use petgraph::visit::EdgeRef;
+
+use crate::graph::builder::build_graph;
+use crate::graph::validator::validate;
+use crate::graph::{GraphEdge, GraphNode, SemanticGraph};
+use crate::parser::parse_jsonld;
+use crate::patch::{GraphPatch, PatchOp, apply_patch};
+use crate::types::{DuumbiType, Op};
+
+use super::catalog::{BuiltInRuleKind, RewriteCatalog, RuleDefinition};
+use super::error::RewriteError;
+use super::evidence::{
+    ApplyMode, ApplyOptions, CostEvidence, RewriteApplyOutcome, RewriteApplyPlan, RewriteLimits,
+    RewriteMatch, RewritePreview, ValidationEvidence,
+};
+use super::rule::RuleSummary;
+
+/// Provider-free rewrite engine for rule listing and preview matching.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RewriteEngine {
+    catalog: RewriteCatalog,
+    limits: RewriteLimits,
+}
+
+impl RewriteEngine {
+    /// Creates an engine with the supplied catalog and limits.
+    #[must_use]
+    pub fn new(catalog: RewriteCatalog, limits: RewriteLimits) -> Self {
+        Self { catalog, limits }
+    }
+
+    /// Returns rule summaries in deterministic catalog order.
+    #[must_use]
+    pub fn list_rules(&self) -> Vec<RuleSummary> {
+        self.catalog.summaries()
+    }
+
+    /// Previews one rule against raw JSON-LD source without mutating it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RewriteError`] when the current source cannot parse, build,
+    /// validate, or references an unknown rule.
+    pub fn preview_source(
+        &self,
+        source: &serde_json::Value,
+        rule_id: &str,
+        max_matches: Option<usize>,
+    ) -> Result<RewritePreview, RewriteError> {
+        let graph = current_graph_from_source(source)?;
+        self.preview_graph(&graph.module_name.to_string(), &graph, rule_id, max_matches)
+    }
+
+    /// Previews one rule against an already-built semantic graph.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RewriteError::UnknownRule`] when `rule_id` is not registered.
+    pub fn preview_graph(
+        &self,
+        module: &str,
+        graph: &SemanticGraph,
+        rule_id: &str,
+        max_matches: Option<usize>,
+    ) -> Result<RewritePreview, RewriteError> {
+        let rule = self
+            .catalog
+            .find(rule_id)
+            .ok_or_else(|| RewriteError::UnknownRule(rule_id.to_string()))?;
+        let requested_limit = max_matches.unwrap_or(self.limits.max_matches_per_preview);
+        let limit = requested_limit.min(self.limits.max_matches_per_preview);
+        let mut considered = 0usize;
+        let mut returned = Vec::new();
+
+        for node_idx in ordered_nodes(graph) {
+            if let Some(matched) = self.match_rule(module, graph, rule, node_idx, considered) {
+                considered += 1;
+                if returned.len() < limit {
+                    returned.push(matched);
+                }
+            }
+        }
+
+        let cost = aggregate_cost(&returned, considered, self.limits);
+
+        Ok(RewritePreview {
+            status: "success".to_string(),
+            rule: rule.summary.clone(),
+            matches: returned,
+            cost,
+            warnings: Vec::new(),
+        })
+    }
+
+    /// Applies a selected rule to cloned JSON-LD source in memory.
+    ///
+    /// Apply reruns parse, graph build, validation, matching, preconditions,
+    /// safety-class checks, patch construction, patch application, and
+    /// candidate validation. It never saves a snapshot or writes a file.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RewriteError`] for invalid current graphs, unknown rules,
+    /// stale matches, unsupported safety classes, cost-bound failures, patch
+    /// failures, and invalid candidates.
+    pub fn apply_to_source(
+        &self,
+        source: &serde_json::Value,
+        options: &ApplyOptions,
+    ) -> Result<RewriteApplyOutcome, RewriteError> {
+        let graph = current_graph_from_source(source)?;
+        let module = options
+            .module
+            .clone()
+            .unwrap_or_else(|| graph.module_name.to_string());
+        let rule = self
+            .catalog
+            .find(&options.rule_id)
+            .ok_or_else(|| RewriteError::UnknownRule(options.rule_id.clone()))?;
+
+        if !rule.summary.apply_capable {
+            return Err(RewriteError::UnsupportedSafetyClass(
+                options.rule_id.clone(),
+            ));
+        }
+
+        let preview = self.preview_graph(
+            &module,
+            &graph,
+            &options.rule_id,
+            Some(self.limits.max_matches_per_preview),
+        )?;
+        let selected = select_matches(&preview.matches, options, self.limits)?;
+        let patch = self.patch_for_matches(&graph, rule, &selected)?;
+
+        let candidate = apply_patch(source, &patch)
+            .map_err(|err| RewriteError::ValidationFailed(err.to_string()))?;
+        validate_candidate_source(&candidate)?;
+
+        let touched_node_ids = selected
+            .iter()
+            .flat_map(|matched| matched.touched_node_ids.iter().cloned())
+            .collect::<Vec<_>>();
+        let cost = CostEvidence {
+            matches_considered: preview.cost.matches_considered,
+            matches_returned: selected.len(),
+            matches_truncated: 0,
+            touched_node_count: selected
+                .iter()
+                .map(|matched| matched.cost.touched_node_count)
+                .sum(),
+            patch_op_count: patch.ops.len(),
+            estimated_cost_units: selected
+                .iter()
+                .map(|matched| matched.cost.estimated_cost_units)
+                .sum(),
+            limits: self.limits,
+        };
+
+        Ok(RewriteApplyOutcome {
+            candidate_source: candidate,
+            plan: RewriteApplyPlan {
+                status: "success".to_string(),
+                rule: rule.summary.clone(),
+                match_ids: selected
+                    .iter()
+                    .map(|matched| matched.match_id.clone())
+                    .collect(),
+                touched_node_ids,
+                operation_summary: format!(
+                    "Prepared {} rewrite patch operation(s) for {} match(es).",
+                    patch.ops.len(),
+                    selected.len()
+                ),
+                validation: ValidationEvidence::valid(),
+                cost,
+                warnings: Vec::new(),
+            },
+        })
+    }
+
+    fn patch_for_matches(
+        &self,
+        graph: &SemanticGraph,
+        rule: &RuleDefinition,
+        matches: &[RewriteMatch],
+    ) -> Result<GraphPatch, RewriteError> {
+        let mut ops = Vec::new();
+        for matched in matches {
+            let node_idx = graph
+                .node_map
+                .get(&crate::types::NodeId(matched.primary_node_id.clone()))
+                .copied()
+                .ok_or_else(|| RewriteError::StaleMatch(matched.match_id.clone()))?;
+            let replacement = replacement_node_id(graph, rule, node_idx)
+                .ok_or_else(|| RewriteError::StaleMatch(matched.match_id.clone()))?;
+            let mut match_ops = redirect_consumers(graph, node_idx, &replacement)?;
+            if match_ops.is_empty() {
+                return Err(RewriteError::InvalidRequest(format!(
+                    "rewrite match '{}' has no downstream references to replace",
+                    matched.match_id
+                )));
+            }
+            if match_ops.len() > self.limits.max_patch_ops_per_match {
+                return Err(RewriteError::CostBoundExceeded(format!(
+                    "match '{}' would produce {} patch ops, limit is {}",
+                    matched.match_id,
+                    match_ops.len(),
+                    self.limits.max_patch_ops_per_match
+                )));
+            }
+            ops.append(&mut match_ops);
+        }
+
+        Ok(GraphPatch { ops })
+    }
+
+    fn match_rule(
+        &self,
+        module: &str,
+        graph: &SemanticGraph,
+        rule: &RuleDefinition,
+        node_idx: NodeIndex,
+        ordinal: usize,
+    ) -> Option<RewriteMatch> {
+        let node = graph.graph.node_weight(node_idx)?;
+        let operands = binary_operands(graph, node_idx)?;
+        let effect = match rule.kind {
+            BuiltInRuleKind::I64AddZeroRight
+                if is_i64_add(node) && is_i64(operands.left) && is_i64_const(operands.right, 0) =>
+            {
+                format!(
+                    "Replace {} with left operand {}.",
+                    node.id, operands.left.id
+                )
+            }
+            BuiltInRuleKind::I64AddZeroLeft
+                if is_i64_add(node) && is_i64_const(operands.left, 0) && is_i64(operands.right) =>
+            {
+                format!(
+                    "Replace {} with right operand {}.",
+                    node.id, operands.right.id
+                )
+            }
+            BuiltInRuleKind::I64MulOneRight
+                if is_i64_mul(node) && is_i64(operands.left) && is_i64_const(operands.right, 1) =>
+            {
+                format!(
+                    "Replace {} with left operand {}.",
+                    node.id, operands.left.id
+                )
+            }
+            BuiltInRuleKind::ExperimentalFoldI64ConstAdd
+                if is_i64_add(node)
+                    && is_i64_const_node(operands.left)
+                    && is_i64_const_node(operands.right) =>
+            {
+                let left_value = const_i64_value(operands.left)?;
+                let right_value = const_i64_value(operands.right)?;
+                format!(
+                    "Would replace {} with Const({}).",
+                    node.id,
+                    left_value + right_value
+                )
+            }
+            _ => return None,
+        };
+
+        let match_cost = CostEvidence {
+            matches_considered: 1,
+            matches_returned: 1,
+            matches_truncated: 0,
+            touched_node_count: 3,
+            patch_op_count: usize::from(rule.summary.apply_capable),
+            estimated_cost_units: rule.summary.default_cost,
+            limits: self.limits,
+        };
+
+        Some(RewriteMatch {
+            match_id: format!("{}:{}:{}:{}", rule.summary.id, module, node.id, ordinal),
+            rule_id: rule.summary.id.clone(),
+            module: module.to_string(),
+            primary_node_id: node.id.to_string(),
+            touched_node_ids: vec![
+                operands.left.id.to_string(),
+                operands.right.id.to_string(),
+                node.id.to_string(),
+            ],
+            operation_summary: effect,
+            explanation: rule.summary.explanation_template.clone(),
+            cost: match_cost,
+            validation: ValidationEvidence::not_run(),
+            warnings: Vec::new(),
+        })
+    }
+}
+
+impl Default for RewriteEngine {
+    fn default() -> Self {
+        Self::new(RewriteCatalog::built_in(), RewriteLimits::default())
+    }
+}
+
+struct BinaryOperands<'a> {
+    left: &'a GraphNode,
+    right: &'a GraphNode,
+}
+
+fn ordered_nodes(graph: &SemanticGraph) -> Vec<NodeIndex> {
+    graph
+        .functions
+        .iter()
+        .flat_map(|function| function.blocks.iter())
+        .flat_map(|block| block.nodes.iter().copied())
+        .collect()
+}
+
+fn binary_operands(graph: &SemanticGraph, node_idx: NodeIndex) -> Option<BinaryOperands<'_>> {
+    let mut left = None;
+    let mut right = None;
+
+    for edge in graph.graph.edges_directed(node_idx, petgraph::Incoming) {
+        match edge.weight() {
+            GraphEdge::Left => left = graph.graph.node_weight(edge.source()),
+            GraphEdge::Right => right = graph.graph.node_weight(edge.source()),
+            _ => {}
+        }
+    }
+
+    Some(BinaryOperands {
+        left: left?,
+        right: right?,
+    })
+}
+
+fn replacement_node_id(
+    graph: &SemanticGraph,
+    rule: &RuleDefinition,
+    node_idx: NodeIndex,
+) -> Option<String> {
+    let operands = binary_operands(graph, node_idx)?;
+    match rule.kind {
+        BuiltInRuleKind::I64AddZeroRight | BuiltInRuleKind::I64MulOneRight => {
+            Some(operands.left.id.to_string())
+        }
+        BuiltInRuleKind::I64AddZeroLeft => Some(operands.right.id.to_string()),
+        BuiltInRuleKind::ExperimentalFoldI64ConstAdd => None,
+    }
+}
+
+fn redirect_consumers(
+    graph: &SemanticGraph,
+    node_idx: NodeIndex,
+    replacement_id: &str,
+) -> Result<Vec<PatchOp>, RewriteError> {
+    let mut refs = Vec::new();
+    for edge in graph.graph.edges_directed(node_idx, petgraph::Outgoing) {
+        let Some(field) = edge_field(edge.weight()) else {
+            let Some(consumer) = graph.graph.node_weight(edge.target()) else {
+                return Err(RewriteError::StaleMatch(
+                    "missing consumer node".to_string(),
+                ));
+            };
+            return Err(RewriteError::InvalidRequest(format!(
+                "cannot rewrite unsupported consumer edge {:?} on {}",
+                edge.weight(),
+                consumer.id
+            )));
+        };
+        let Some(consumer) = graph.graph.node_weight(edge.target()) else {
+            return Err(RewriteError::StaleMatch(
+                "missing consumer node".to_string(),
+            ));
+        };
+        refs.push((consumer.id.to_string(), field.to_string()));
+    }
+
+    refs.sort();
+    Ok(refs
+        .into_iter()
+        .map(|(node_id, field)| PatchOp::SetEdge {
+            node_id,
+            field,
+            target_id: replacement_id.to_string(),
+        })
+        .collect())
+}
+
+fn edge_field(edge: &GraphEdge) -> Option<&'static str> {
+    match edge {
+        GraphEdge::Left => Some("duumbi:left"),
+        GraphEdge::Right => Some("duumbi:right"),
+        GraphEdge::Operand => Some("duumbi:operand"),
+        GraphEdge::Condition => Some("duumbi:condition"),
+        _ => None,
+    }
+}
+
+fn is_i64_add(node: &GraphNode) -> bool {
+    matches!(node.op, Op::Add) && is_i64(node)
+}
+
+fn is_i64_mul(node: &GraphNode) -> bool {
+    matches!(node.op, Op::Mul) && is_i64(node)
+}
+
+fn is_i64(node: &GraphNode) -> bool {
+    node.result_type == Some(DuumbiType::I64)
+}
+
+fn is_i64_const(node: &GraphNode, value: i64) -> bool {
+    matches!(node.op, Op::Const(actual) if actual == value) && is_i64(node)
+}
+
+fn is_i64_const_node(node: &GraphNode) -> bool {
+    matches!(node.op, Op::Const(_)) && is_i64(node)
+}
+
+fn const_i64_value(node: &GraphNode) -> Option<i64> {
+    match node.op {
+        Op::Const(value) if is_i64(node) => Some(value),
+        _ => None,
+    }
+}
+
+fn aggregate_cost(
+    matches: &[RewriteMatch],
+    matches_considered: usize,
+    limits: RewriteLimits,
+) -> CostEvidence {
+    CostEvidence {
+        matches_considered,
+        matches_returned: matches.len(),
+        matches_truncated: matches_considered.saturating_sub(matches.len()),
+        touched_node_count: matches
+            .iter()
+            .map(|matched| matched.cost.touched_node_count)
+            .sum(),
+        patch_op_count: matches
+            .iter()
+            .map(|matched| matched.cost.patch_op_count)
+            .sum(),
+        estimated_cost_units: matches
+            .iter()
+            .map(|matched| matched.cost.estimated_cost_units)
+            .sum(),
+        limits,
+    }
+}
+
+fn current_graph_from_source(source: &serde_json::Value) -> Result<SemanticGraph, RewriteError> {
+    let graph = graph_from_source(source).map_err(RewriteError::InvalidCurrentGraph)?;
+    let diagnostics = validate(&graph);
+    if !diagnostics.is_empty() {
+        let messages = diagnostics
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(RewriteError::InvalidCurrentGraph(messages));
+    }
+    Ok(graph)
+}
+
+fn validate_candidate_source(source: &serde_json::Value) -> Result<(), RewriteError> {
+    let graph = graph_from_source(source).map_err(RewriteError::ValidationFailed)?;
+    let diagnostics = validate(&graph);
+    if !diagnostics.is_empty() {
+        let messages = diagnostics
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(RewriteError::ValidationFailed(messages));
+    }
+    Ok(())
+}
+
+fn graph_from_source(source: &serde_json::Value) -> Result<SemanticGraph, String> {
+    let json = serde_json::to_string(source).map_err(|err| err.to_string())?;
+    let ast = parse_jsonld(&json).map_err(|err| err.to_string())?;
+    build_graph(&ast).map_err(|errors| {
+        errors
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("; ")
+    })
+}
+
+fn select_matches(
+    matches: &[RewriteMatch],
+    options: &ApplyOptions,
+    limits: RewriteLimits,
+) -> Result<Vec<RewriteMatch>, RewriteError> {
+    match options.mode {
+        ApplyMode::Match => {
+            let match_id = options.match_id.as_ref().ok_or_else(|| {
+                RewriteError::InvalidRequest("--match requires match_id".to_string())
+            })?;
+            matches
+                .iter()
+                .find(|matched| matched.match_id == *match_id)
+                .cloned()
+                .map(|matched| vec![matched])
+                .ok_or_else(|| RewriteError::StaleMatch(match_id.clone()))
+        }
+        ApplyMode::All => {
+            let requested = options.max_matches.unwrap_or(limits.max_matches_per_apply);
+            if requested > limits.max_apply_all_matches {
+                return Err(RewriteError::CostBoundExceeded(format!(
+                    "apply-all requested {requested} matches, limit is {}",
+                    limits.max_apply_all_matches
+                )));
+            }
+            if matches.len() > requested {
+                return Err(RewriteError::CostBoundExceeded(format!(
+                    "{} matches found, requested apply bound is {requested}",
+                    matches.len()
+                )));
+            }
+            if matches.is_empty() {
+                return Err(RewriteError::StaleMatch(
+                    "no matches available for apply-all".to_string(),
+                ));
+            }
+            Ok(matches.to_vec())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use petgraph::stable_graph::StableGraph;
+    use serde_json::{Value, json};
+
+    use super::*;
+    use crate::graph::{BlockInfo, FunctionInfo, GraphNode, SemanticGraph};
+    use crate::types::{BlockLabel, FunctionName, ModuleName, NodeId};
+
+    fn source_fixture() -> Value {
+        json!({
+            "@context": {"duumbi": "https://duumbi.dev/ontology#"},
+            "@type": "duumbi:Module",
+            "@id": "duumbi:rewrite",
+            "duumbi:name": "rewrite",
+            "duumbi:functions": [{
+                "@type": "duumbi:Function",
+                "@id": "duumbi:rewrite/main",
+                "duumbi:name": "main",
+                "duumbi:returnType": "i64",
+                "duumbi:blocks": [{
+                    "@type": "duumbi:Block",
+                    "@id": "duumbi:rewrite/main/entry",
+                    "duumbi:label": "entry",
+                    "duumbi:ops": [
+                        {
+                            "@type": "duumbi:Const",
+                            "@id": "duumbi:rewrite/main/entry/left",
+                            "duumbi:value": 42,
+                            "duumbi:resultType": "i64"
+                        },
+                        {
+                            "@type": "duumbi:Const",
+                            "@id": "duumbi:rewrite/main/entry/zero",
+                            "duumbi:value": 0,
+                            "duumbi:resultType": "i64"
+                        },
+                        {
+                            "@type": "duumbi:Add",
+                            "@id": "duumbi:rewrite/main/entry/add",
+                            "duumbi:left": {"@id": "duumbi:rewrite/main/entry/left"},
+                            "duumbi:right": {"@id": "duumbi:rewrite/main/entry/zero"},
+                            "duumbi:resultType": "i64"
+                        },
+                        {
+                            "@type": "duumbi:Return",
+                            "@id": "duumbi:rewrite/main/entry/return",
+                            "duumbi:operand": {"@id": "duumbi:rewrite/main/entry/add"}
+                        }
+                    ]
+                }]
+            }]
+        })
+    }
+
+    fn test_node(id: &str, op: Op, result_type: Option<DuumbiType>) -> GraphNode {
+        GraphNode {
+            id: NodeId(id.to_string()),
+            op,
+            result_type,
+            function: FunctionName("main".to_string()),
+            block: BlockLabel("entry".to_string()),
+            owner: None,
+            lifetime: None,
+            lifetime_param: None,
+        }
+    }
+
+    fn graph_for_rule(op: Op, left: Op, right: Op) -> SemanticGraph {
+        let mut graph = StableGraph::new();
+        let left_idx = graph.add_node(test_node("left", left, Some(DuumbiType::I64)));
+        let right_idx = graph.add_node(test_node("right", right, Some(DuumbiType::I64)));
+        let op_idx = graph.add_node(test_node("op", op, Some(DuumbiType::I64)));
+        graph.add_edge(left_idx, op_idx, GraphEdge::Left);
+        graph.add_edge(right_idx, op_idx, GraphEdge::Right);
+        let mut node_map = HashMap::new();
+        let node_indices = vec![left_idx, right_idx, op_idx];
+        for idx in &node_indices {
+            let node = graph
+                .node_weight(*idx)
+                .expect("invariant: test node exists");
+            node_map.insert(node.id.clone(), *idx);
+        }
+
+        SemanticGraph {
+            graph,
+            node_map,
+            functions: vec![FunctionInfo {
+                name: FunctionName("main".to_string()),
+                return_type: DuumbiType::I64,
+                params: Vec::new(),
+                blocks: vec![BlockInfo {
+                    label: BlockLabel("entry".to_string()),
+                    nodes: node_indices,
+                }],
+                lifetime_params: Vec::new(),
+            }],
+            branch_targets: HashMap::new(),
+            module_name: ModuleName("test".to_string()),
+        }
+    }
+
+    #[test]
+    fn list_rules_returns_catalog_order() {
+        let ids: Vec<_> = RewriteEngine::default()
+            .list_rules()
+            .into_iter()
+            .map(|summary| summary.id)
+            .collect();
+
+        assert_eq!(
+            ids,
+            vec![
+                "i64-add-zero-right",
+                "i64-add-zero-left",
+                "i64-mul-one-right",
+                "experimental-fold-i64-const-add",
+            ]
+        );
+    }
+
+    #[test]
+    fn preview_matches_i64_add_zero_right() {
+        let graph = graph_for_rule(Op::Add, Op::Const(42), Op::Const(0));
+        let preview = RewriteEngine::default()
+            .preview_graph("test", &graph, "i64-add-zero-right", None)
+            .expect("invariant: rule preview succeeds");
+
+        assert_eq!(preview.matches.len(), 1);
+        assert_eq!(preview.matches[0].match_id, "i64-add-zero-right:test:op:0");
+        assert_eq!(
+            preview.matches[0].touched_node_ids,
+            vec!["left", "right", "op"]
+        );
+        assert_eq!(preview.cost.matches_considered, 1);
+        assert_eq!(preview.cost.patch_op_count, 1);
+    }
+
+    #[test]
+    fn preview_matches_i64_add_zero_left() {
+        let graph = graph_for_rule(Op::Add, Op::Const(0), Op::Const(42));
+        let preview = RewriteEngine::default()
+            .preview_graph("test", &graph, "i64-add-zero-left", None)
+            .expect("invariant: rule preview succeeds");
+
+        assert_eq!(preview.matches.len(), 1);
+        assert_eq!(
+            preview.matches[0].operation_summary,
+            "Replace op with right operand right."
+        );
+    }
+
+    #[test]
+    fn preview_matches_i64_mul_one_right() {
+        let graph = graph_for_rule(Op::Mul, Op::Const(42), Op::Const(1));
+        let preview = RewriteEngine::default()
+            .preview_graph("test", &graph, "i64-mul-one-right", None)
+            .expect("invariant: rule preview succeeds");
+
+        assert_eq!(preview.matches.len(), 1);
+        assert_eq!(
+            preview.matches[0].operation_summary,
+            "Replace op with left operand left."
+        );
+    }
+
+    #[test]
+    fn experimental_const_fold_is_preview_only_and_has_no_patch_ops() {
+        let graph = graph_for_rule(Op::Add, Op::Const(40), Op::Const(2));
+        let preview = RewriteEngine::default()
+            .preview_graph("test", &graph, "experimental-fold-i64-const-add", None)
+            .expect("invariant: rule preview succeeds");
+
+        assert_eq!(preview.matches.len(), 1);
+        assert!(!preview.rule.apply_capable);
+        assert_eq!(
+            preview.matches[0].operation_summary,
+            "Would replace op with Const(42)."
+        );
+        assert_eq!(preview.cost.patch_op_count, 0);
+    }
+
+    #[test]
+    fn preview_applies_max_match_limit_deterministically() {
+        let mut graph = StableGraph::new();
+        let a = graph.add_node(test_node("a", Op::Const(1), Some(DuumbiType::I64)));
+        let zero = graph.add_node(test_node("zero", Op::Const(0), Some(DuumbiType::I64)));
+        let first = graph.add_node(test_node("first", Op::Add, Some(DuumbiType::I64)));
+        let second = graph.add_node(test_node("second", Op::Add, Some(DuumbiType::I64)));
+        graph.add_edge(a, first, GraphEdge::Left);
+        graph.add_edge(zero, first, GraphEdge::Right);
+        graph.add_edge(a, second, GraphEdge::Left);
+        graph.add_edge(zero, second, GraphEdge::Right);
+        let mut node_map = HashMap::new();
+        let node_indices = vec![a, zero, first, second];
+        for idx in &node_indices {
+            let node = graph
+                .node_weight(*idx)
+                .expect("invariant: test node exists");
+            node_map.insert(node.id.clone(), *idx);
+        }
+        let semantic_graph = SemanticGraph {
+            graph,
+            node_map,
+            functions: vec![FunctionInfo {
+                name: FunctionName("main".to_string()),
+                return_type: DuumbiType::I64,
+                params: Vec::new(),
+                blocks: vec![BlockInfo {
+                    label: BlockLabel("entry".to_string()),
+                    nodes: node_indices,
+                }],
+                lifetime_params: Vec::new(),
+            }],
+            branch_targets: HashMap::new(),
+            module_name: ModuleName("test".to_string()),
+        };
+
+        let preview = RewriteEngine::default()
+            .preview_graph("test", &semantic_graph, "i64-add-zero-right", Some(1))
+            .expect("invariant: rule preview succeeds");
+
+        assert_eq!(preview.matches.len(), 1);
+        assert_eq!(
+            preview.matches[0].match_id,
+            "i64-add-zero-right:test:first:0"
+        );
+        assert_eq!(preview.cost.matches_considered, 2);
+        assert_eq!(preview.cost.matches_truncated, 1);
+    }
+
+    #[test]
+    fn preview_rejects_unknown_rule() {
+        let graph = graph_for_rule(Op::Add, Op::Const(1), Op::Const(0));
+        let err = RewriteEngine::default()
+            .preview_graph("test", &graph, "missing-rule", None)
+            .expect_err("invariant: missing rule is rejected");
+
+        assert_eq!(err, RewriteError::UnknownRule("missing-rule".to_string()));
+    }
+
+    #[test]
+    fn preview_source_parses_builds_validates_and_matches() {
+        let preview = RewriteEngine::default()
+            .preview_source(&source_fixture(), "i64-add-zero-right", None)
+            .expect("invariant: preview source succeeds");
+
+        assert_eq!(preview.matches.len(), 1);
+        assert_eq!(
+            preview.matches[0].match_id,
+            "i64-add-zero-right:rewrite:duumbi:rewrite/main/entry/add:0"
+        );
+    }
+
+    #[test]
+    fn apply_to_source_reruns_match_and_validates_candidate() {
+        let source = source_fixture();
+        let preview = RewriteEngine::default()
+            .preview_source(&source, "i64-add-zero-right", None)
+            .expect("invariant: preview source succeeds");
+        let options = ApplyOptions {
+            rule_id: "i64-add-zero-right".to_string(),
+            module: None,
+            mode: ApplyMode::Match,
+            match_id: Some(preview.matches[0].match_id.clone()),
+            max_matches: None,
+        };
+
+        let outcome = RewriteEngine::default()
+            .apply_to_source(&source, &options)
+            .expect("invariant: apply source succeeds");
+
+        assert_eq!(outcome.plan.status, "success");
+        assert_eq!(
+            outcome.plan.match_ids,
+            vec![preview.matches[0].match_id.clone()]
+        );
+        assert_eq!(outcome.plan.validation, ValidationEvidence::valid());
+        assert_eq!(outcome.plan.cost.patch_op_count, 1);
+        assert_eq!(
+            outcome.candidate_source["duumbi:functions"][0]["duumbi:blocks"][0]["duumbi:ops"][3]["duumbi:operand"]
+                ["@id"],
+            "duumbi:rewrite/main/entry/left"
+        );
+        assert_eq!(
+            source["duumbi:functions"][0]["duumbi:blocks"][0]["duumbi:ops"][3]["duumbi:operand"]["@id"],
+            "duumbi:rewrite/main/entry/add"
+        );
+    }
+
+    #[test]
+    fn apply_rejects_stale_match_before_patch() {
+        let source = source_fixture();
+        let options = ApplyOptions {
+            rule_id: "i64-add-zero-right".to_string(),
+            module: None,
+            mode: ApplyMode::Match,
+            match_id: Some("i64-add-zero-right:rewrite:missing:0".to_string()),
+            max_matches: None,
+        };
+
+        let err = RewriteEngine::default()
+            .apply_to_source(&source, &options)
+            .expect_err("invariant: stale match is rejected");
+
+        assert_eq!(
+            err,
+            RewriteError::StaleMatch("i64-add-zero-right:rewrite:missing:0".to_string())
+        );
+    }
+
+    #[test]
+    fn apply_rejects_experimental_rule() {
+        let source = source_fixture();
+        let options = ApplyOptions {
+            rule_id: "experimental-fold-i64-const-add".to_string(),
+            module: None,
+            mode: ApplyMode::All,
+            match_id: None,
+            max_matches: Some(1),
+        };
+
+        let err = RewriteEngine::default()
+            .apply_to_source(&source, &options)
+            .expect_err("invariant: experimental apply is rejected");
+
+        assert_eq!(
+            err,
+            RewriteError::UnsupportedSafetyClass("experimental-fold-i64-const-add".to_string())
+        );
+    }
+}

--- a/src/rewrite/error.rs
+++ b/src/rewrite/error.rs
@@ -1,0 +1,39 @@
+//! Rewrite engine error types.
+
+use thiserror::Error;
+
+/// Errors produced by rewrite rule discovery, preview, and apply planning.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum RewriteError {
+    /// The requested rewrite rule is not registered.
+    #[error("Unknown rewrite rule: '{0}'")]
+    UnknownRule(String),
+
+    /// The requested module could not be loaded.
+    #[error("Module not found: '{0}'")]
+    ModuleNotFound(String),
+
+    /// The current graph is invalid and cannot be safely rewritten.
+    #[error("Current graph is invalid: {0}")]
+    InvalidCurrentGraph(String),
+
+    /// The selected match does not exist in the current graph state.
+    #[error("Rewrite match is stale or missing: '{0}'")]
+    StaleMatch(String),
+
+    /// The rule is preview-only in V1.
+    #[error("Rewrite rule is preview-only in V1: '{0}'")]
+    UnsupportedSafetyClass(String),
+
+    /// The requested rewrite would exceed configured bounds.
+    #[error("Rewrite cost bound exceeded: {0}")]
+    CostBoundExceeded(String),
+
+    /// The candidate graph failed parse, build, or validation.
+    #[error("Rewrite candidate validation failed: {0}")]
+    ValidationFailed(String),
+
+    /// The requested apply shape is invalid.
+    #[error("Invalid rewrite request: {0}")]
+    InvalidRequest(String),
+}

--- a/src/rewrite/evidence.rs
+++ b/src/rewrite/evidence.rs
@@ -1,0 +1,275 @@
+//! Rewrite preview and apply evidence contracts.
+
+use serde::{Deserialize, Serialize};
+
+use super::rule::RuleSummary;
+
+/// Safe default limits for preview and apply operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RewriteLimits {
+    /// Maximum matches returned by one preview.
+    pub max_matches_per_preview: usize,
+    /// Maximum matches applied without explicit apply-all.
+    pub max_matches_per_apply: usize,
+    /// Maximum matches applied by an explicit apply-all request.
+    pub max_apply_all_matches: usize,
+    /// Maximum graph nodes touched by one match.
+    pub max_touched_nodes_per_match: usize,
+    /// Maximum patch operations produced by one match.
+    pub max_patch_ops_per_match: usize,
+    /// Maximum node IDs rendered in explanations before truncation.
+    pub max_explanation_nodes: usize,
+}
+
+impl Default for RewriteLimits {
+    fn default() -> Self {
+        Self {
+            max_matches_per_preview: 100,
+            max_matches_per_apply: 1,
+            max_apply_all_matches: 10,
+            max_touched_nodes_per_match: 25,
+            max_patch_ops_per_match: 25,
+            max_explanation_nodes: 20,
+        }
+    }
+}
+
+/// Bounded cost evidence for a rewrite operation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CostEvidence {
+    /// Number of matches inspected.
+    pub matches_considered: usize,
+    /// Number of matches returned to the caller.
+    pub matches_returned: usize,
+    /// Number of matches omitted because of limits.
+    pub matches_truncated: usize,
+    /// Number of graph nodes touched.
+    pub touched_node_count: usize,
+    /// Number of patch operations produced.
+    pub patch_op_count: usize,
+    /// Deterministic abstract cost units.
+    pub estimated_cost_units: u32,
+    /// Limits used for the operation.
+    pub limits: RewriteLimits,
+}
+
+impl CostEvidence {
+    /// Creates zero-cost evidence using the provided limits.
+    #[must_use]
+    pub fn empty(limits: RewriteLimits) -> Self {
+        Self {
+            matches_considered: 0,
+            matches_returned: 0,
+            matches_truncated: 0,
+            touched_node_count: 0,
+            patch_op_count: 0,
+            estimated_cost_units: 0,
+            limits,
+        }
+    }
+}
+
+/// Validation status reported by preview or apply.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ValidationEvidence {
+    /// Whether validation was run.
+    pub ran: bool,
+    /// Whether the validated graph was valid.
+    pub valid: bool,
+    /// Sanitized validation diagnostic messages.
+    pub diagnostics: Vec<String>,
+}
+
+impl ValidationEvidence {
+    /// Returns evidence for a valid candidate.
+    #[must_use]
+    pub fn valid() -> Self {
+        Self {
+            ran: true,
+            valid: true,
+            diagnostics: Vec::new(),
+        }
+    }
+
+    /// Returns evidence for a step where validation was not run.
+    #[must_use]
+    pub fn not_run() -> Self {
+        Self {
+            ran: false,
+            valid: false,
+            diagnostics: Vec::new(),
+        }
+    }
+}
+
+/// One deterministic rewrite match.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RewriteMatch {
+    /// Stable match identifier for unchanged graph input.
+    pub match_id: String,
+    /// Rule ID that produced the match.
+    pub rule_id: String,
+    /// Module name or path inspected.
+    pub module: String,
+    /// Primary node for the match.
+    pub primary_node_id: String,
+    /// Nodes touched by the proposed rewrite.
+    pub touched_node_ids: Vec<String>,
+    /// Human-readable effect summary for this match.
+    pub operation_summary: String,
+    /// Human-readable explanation for this match.
+    pub explanation: String,
+    /// Cost evidence for this match.
+    pub cost: CostEvidence,
+    /// Validation evidence for the preview candidate, when available.
+    pub validation: ValidationEvidence,
+    /// Non-fatal warnings.
+    pub warnings: Vec<String>,
+}
+
+/// Preview response shared by CLI and MCP adapters.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RewritePreview {
+    /// Response status, such as `success`.
+    pub status: String,
+    /// Rule metadata.
+    pub rule: RuleSummary,
+    /// Matches returned by the preview.
+    pub matches: Vec<RewriteMatch>,
+    /// Aggregate preview cost evidence.
+    pub cost: CostEvidence,
+    /// Non-fatal warnings.
+    pub warnings: Vec<String>,
+}
+
+/// Apply selection mode.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ApplyMode {
+    /// Apply one selected match ID.
+    Match,
+    /// Apply all matches within configured bounds.
+    All,
+}
+
+/// Options for a backend apply operation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApplyOptions {
+    /// Rule ID to apply.
+    pub rule_id: String,
+    /// Optional module name or path.
+    pub module: Option<String>,
+    /// Apply mode.
+    pub mode: ApplyMode,
+    /// Selected match ID when mode is `match`.
+    pub match_id: Option<String>,
+    /// Maximum matches for apply-all mode.
+    pub max_matches: Option<usize>,
+}
+
+/// Validated apply plan before adapter-level snapshot/write.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RewriteApplyPlan {
+    /// Response status, such as `success`.
+    pub status: String,
+    /// Rule metadata.
+    pub rule: RuleSummary,
+    /// Match IDs selected for apply.
+    pub match_ids: Vec<String>,
+    /// Nodes touched by all selected matches.
+    pub touched_node_ids: Vec<String>,
+    /// Human-readable operation summary.
+    pub operation_summary: String,
+    /// Validation evidence for the candidate graph.
+    pub validation: ValidationEvidence,
+    /// Cost evidence for the apply plan.
+    pub cost: CostEvidence,
+    /// Non-fatal warnings.
+    pub warnings: Vec<String>,
+}
+
+/// In-memory candidate source plus apply evidence.
+///
+/// CLI and MCP adapters own snapshot and write behavior after receiving this
+/// outcome. The backend never writes the candidate source.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RewriteApplyOutcome {
+    /// Validated candidate JSON-LD source.
+    pub candidate_source: serde_json::Value,
+    /// Evidence describing the selected rewrite operation.
+    pub plan: RewriteApplyPlan,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rewrite::rule::{RuleCategory, SafetyClass};
+
+    fn test_rule() -> RuleSummary {
+        RuleSummary::new(
+            "i64-add-zero-right",
+            "I64 add zero right",
+            RuleCategory::LocalOptimization,
+            SafetyClass::LocalSemanticsPreserving,
+            "Simplifies Add by zero",
+            "Right operand is i64 zero",
+            "Uses the left operand value",
+            1,
+            "Add by zero preserves the left operand",
+        )
+    }
+
+    #[test]
+    fn rewrite_limits_default_matches_spec() {
+        let limits = RewriteLimits::default();
+        assert_eq!(limits.max_matches_per_preview, 100);
+        assert_eq!(limits.max_matches_per_apply, 1);
+        assert_eq!(limits.max_apply_all_matches, 10);
+        assert_eq!(limits.max_touched_nodes_per_match, 25);
+        assert_eq!(limits.max_patch_ops_per_match, 25);
+        assert_eq!(limits.max_explanation_nodes, 20);
+    }
+
+    #[test]
+    fn preview_serializes_with_camel_case_fields() {
+        let limits = RewriteLimits::default();
+        let preview = RewritePreview {
+            status: "success".to_string(),
+            rule: test_rule(),
+            matches: vec![RewriteMatch {
+                match_id: "i64-add-zero-right:main:duumbi:main/main/entry/2:0".to_string(),
+                rule_id: "i64-add-zero-right".to_string(),
+                module: "main".to_string(),
+                primary_node_id: "duumbi:main/main/entry/2".to_string(),
+                touched_node_ids: vec!["duumbi:main/main/entry/2".to_string()],
+                operation_summary: "Replace Add by zero with left operand".to_string(),
+                explanation: "The right operand is i64 zero".to_string(),
+                cost: CostEvidence::empty(limits),
+                validation: ValidationEvidence::not_run(),
+                warnings: Vec::new(),
+            }],
+            cost: CostEvidence::empty(limits),
+            warnings: Vec::new(),
+        };
+
+        let value = serde_json::to_value(preview).expect("invariant: preview serializes");
+        assert_eq!(value["status"], "success");
+        assert!(value["matches"][0].get("matchId").is_some());
+        assert!(value["matches"][0].get("touchedNodeIds").is_some());
+        assert!(value["cost"].get("estimatedCostUnits").is_some());
+    }
+
+    #[test]
+    fn apply_mode_serializes_to_kebab_case() {
+        let value = serde_json::to_value(ApplyMode::All).expect("invariant: mode serializes");
+        assert_eq!(value, serde_json::json!("all"));
+    }
+}

--- a/src/rewrite/mod.rs
+++ b/src/rewrite/mod.rs
@@ -1,0 +1,21 @@
+//! Semantic rewrite engine contracts.
+//!
+//! The rewrite module owns DUUMBI's deterministic graph-to-graph rewrite
+//! substrate. V1 starts with provider-free rule metadata, bounded preview/apply
+//! evidence, and typed errors. CLI, MCP, and apply adapters are layered on top
+//! of these contracts in later Ralph cycles.
+
+pub mod catalog;
+pub mod engine;
+pub mod error;
+pub mod evidence;
+pub mod rule;
+
+pub use catalog::{BuiltInRuleKind, RewriteCatalog, RuleDefinition};
+pub use engine::RewriteEngine;
+pub use error::RewriteError;
+pub use evidence::{
+    ApplyMode, ApplyOptions, CostEvidence, RewriteApplyOutcome, RewriteApplyPlan, RewriteLimits,
+    RewriteMatch, RewritePreview, ValidationEvidence,
+};
+pub use rule::{RuleCategory, RuleSummary, SafetyClass};

--- a/src/rewrite/rule.rs
+++ b/src/rewrite/rule.rs
@@ -1,0 +1,130 @@
+//! Rewrite rule metadata and safety classification.
+
+use serde::{Deserialize, Serialize};
+
+/// Stable category for a rewrite rule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RuleCategory {
+    /// Canonicalizes equivalent graph shapes into a preferred form.
+    Canonicalization,
+    /// Performs a local behavior-preserving simplification.
+    LocalOptimization,
+    /// Adjusts non-executable graph structure or metadata.
+    StructuralCleanup,
+}
+
+/// Declared safety level for a rewrite rule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SafetyClass {
+    /// Changes graph structure without changing executable behavior.
+    StructuralOnly,
+    /// Preserves executable behavior under declared local preconditions.
+    LocalSemanticsPreserving,
+    /// Preview-only in V1 unless a later spec changes the policy.
+    Experimental,
+}
+
+impl SafetyClass {
+    /// Returns whether this safety class may be applied in V1.
+    #[must_use]
+    pub fn is_apply_capable(self) -> bool {
+        !matches!(self, Self::Experimental)
+    }
+}
+
+/// Public metadata for one rewrite rule.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuleSummary {
+    /// Stable rule identifier, such as `i64-add-zero-right`.
+    pub id: String,
+    /// Human-readable display name.
+    pub display_name: String,
+    /// High-level rule category.
+    pub category: RuleCategory,
+    /// Declared safety class.
+    pub safety_class: SafetyClass,
+    /// Concise description of what the rule detects.
+    pub description: String,
+    /// Human-readable precondition summary.
+    pub preconditions: String,
+    /// Human-readable effect summary.
+    pub effect_summary: String,
+    /// Default bounded cost estimate for one match.
+    pub default_cost: u32,
+    /// Human-readable explanation template.
+    pub explanation_template: String,
+    /// Whether this rule can be applied in V1.
+    pub apply_capable: bool,
+}
+
+impl RuleSummary {
+    /// Creates a rule summary and derives apply capability from safety class.
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: impl Into<String>,
+        display_name: impl Into<String>,
+        category: RuleCategory,
+        safety_class: SafetyClass,
+        description: impl Into<String>,
+        preconditions: impl Into<String>,
+        effect_summary: impl Into<String>,
+        default_cost: u32,
+        explanation_template: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            display_name: display_name.into(),
+            category,
+            safety_class,
+            description: description.into(),
+            preconditions: preconditions.into(),
+            effect_summary: effect_summary.into(),
+            default_cost,
+            explanation_template: explanation_template.into(),
+            apply_capable: safety_class.is_apply_capable(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn safety_class_serializes_to_kebab_case() {
+        let value = serde_json::to_value(SafetyClass::LocalSemanticsPreserving)
+            .expect("invariant: safety class serializes");
+        assert_eq!(value, serde_json::json!("local-semantics-preserving"));
+    }
+
+    #[test]
+    fn experimental_rules_are_not_apply_capable() {
+        assert!(!SafetyClass::Experimental.is_apply_capable());
+        assert!(SafetyClass::LocalSemanticsPreserving.is_apply_capable());
+        assert!(SafetyClass::StructuralOnly.is_apply_capable());
+    }
+
+    #[test]
+    fn rule_summary_derives_apply_capable_from_safety_class() {
+        let summary = RuleSummary::new(
+            "experimental-fold-i64-const-add",
+            "Experimental fold i64 const add",
+            RuleCategory::Canonicalization,
+            SafetyClass::Experimental,
+            "Preview constant folding for i64 Add ops",
+            "Both operands are i64 constants",
+            "Would replace Add with one i64 Const",
+            1,
+            "Fold constant Add when both operands are known",
+        );
+
+        assert!(!summary.apply_capable);
+        let value = serde_json::to_value(&summary).expect("invariant: summary serializes");
+        assert_eq!(value["id"], "experimental-fold-i64-const-add");
+        assert_eq!(value["safetyClass"], "experimental");
+    }
+}

--- a/tests/integration_duumbi684_rewrite.rs
+++ b/tests/integration_duumbi684_rewrite.rs
@@ -258,13 +258,22 @@ fn rewrite_mcp_tools_are_discoverable_with_safety_descriptions() {
         .iter()
         .find(|tool| tool.name == "rewrite_preview")
         .expect("rewrite_preview must be listed");
+    let list = tools
+        .iter()
+        .find(|tool| tool.name == "rewrite_list_rules")
+        .expect("rewrite_list_rules must be listed");
     let apply = tools
         .iter()
         .find(|tool| tool.name == "rewrite_apply")
         .expect("rewrite_apply must be listed");
 
+    assert!(list.description.contains("Read-only"));
     assert!(preview.description.contains("Read-only"));
     assert!(apply.description.contains("Write-capable"));
+    assert_eq!(
+        list.input_schema["additionalProperties"],
+        serde_json::json!(false)
+    );
     assert_eq!(
         preview.input_schema["additionalProperties"],
         serde_json::json!(false)
@@ -298,6 +307,71 @@ fn rewrite_mcp_preview_is_read_only() {
         before
     );
     assert!(!tmp.path().join(".duumbi").join("history").exists());
+}
+
+#[test]
+fn rewrite_mcp_rejects_outside_workspace_module_paths() {
+    use duumbi::mcp::tools::rewrite;
+
+    let tmp = setup_workspace();
+    let outside = TempDir::new().expect("invariant: outside temp dir must be created");
+    let outside_graph = outside.path().join("outside.jsonld");
+    fs::write(&outside_graph, source_fixture().to_string())
+        .expect("invariant: outside graph must be written");
+    let outside_graph_arg = outside_graph
+        .to_str()
+        .expect("invariant: outside graph path is UTF-8");
+
+    let preview_err = rewrite::rewrite_preview(
+        tmp.path(),
+        &serde_json::json!({
+            "rule_id": "i64-add-zero-right",
+            "module": outside_graph_arg
+        }),
+    )
+    .expect_err("outside preview path must be rejected");
+    assert!(preview_err.contains("must stay inside workspace"));
+
+    let apply_err = rewrite::rewrite_apply(
+        tmp.path(),
+        &serde_json::json!({
+            "rule_id": "i64-add-zero-right",
+            "module": outside_graph_arg,
+            "match_id": "i64-add-zero-right:rewrite:duumbi:rewrite/main/entry/add:0"
+        }),
+    )
+    .expect_err("outside apply path must be rejected");
+    assert!(apply_err.contains("must stay inside workspace"));
+    assert!(!tmp.path().join(".duumbi").join("history").exists());
+}
+
+#[test]
+fn rewrite_mcp_rejects_workspace_relative_traversal_paths() {
+    use duumbi::mcp::tools::rewrite;
+
+    let tmp = setup_workspace();
+    let outside = TempDir::new().expect("invariant: outside temp dir must be created");
+    let outside_graph = outside.path().join("outside.jsonld");
+    fs::write(&outside_graph, source_fixture().to_string())
+        .expect("invariant: outside graph must be written");
+    let traversal = format!(
+        "../{}/outside.jsonld",
+        outside
+            .path()
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("invariant: temp dir name is UTF-8")
+    );
+
+    let err = rewrite::rewrite_preview(
+        tmp.path(),
+        &serde_json::json!({
+            "rule_id": "i64-add-zero-right",
+            "module": traversal
+        }),
+    )
+    .expect_err("workspace-relative traversal must be rejected");
+    assert!(err.contains("must stay inside workspace"));
 }
 
 #[test]

--- a/tests/integration_duumbi684_rewrite.rs
+++ b/tests/integration_duumbi684_rewrite.rs
@@ -1,0 +1,352 @@
+use std::fs;
+use std::process::Command;
+
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+fn duumbi() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_duumbi"))
+}
+
+fn setup_workspace() -> TempDir {
+    let tmp = TempDir::new().expect("invariant: temp dir must be created");
+    let graph_dir = tmp.path().join(".duumbi").join("graph");
+    fs::create_dir_all(&graph_dir).expect("invariant: graph dir must be created");
+    fs::write(graph_dir.join("main.jsonld"), source_fixture().to_string())
+        .expect("invariant: source fixture must be written");
+    tmp
+}
+
+fn source_fixture() -> Value {
+    json!({
+        "@context": {"duumbi": "https://duumbi.dev/ontology#"},
+        "@type": "duumbi:Module",
+        "@id": "duumbi:rewrite",
+        "duumbi:name": "rewrite",
+        "duumbi:functions": [{
+            "@type": "duumbi:Function",
+            "@id": "duumbi:rewrite/main",
+            "duumbi:name": "main",
+            "duumbi:returnType": "i64",
+            "duumbi:blocks": [{
+                "@type": "duumbi:Block",
+                "@id": "duumbi:rewrite/main/entry",
+                "duumbi:label": "entry",
+                "duumbi:ops": [
+                    {
+                        "@type": "duumbi:Const",
+                        "@id": "duumbi:rewrite/main/entry/left",
+                        "duumbi:value": 42,
+                        "duumbi:resultType": "i64"
+                    },
+                    {
+                        "@type": "duumbi:Const",
+                        "@id": "duumbi:rewrite/main/entry/zero",
+                        "duumbi:value": 0,
+                        "duumbi:resultType": "i64"
+                    },
+                    {
+                        "@type": "duumbi:Add",
+                        "@id": "duumbi:rewrite/main/entry/add",
+                        "duumbi:left": {"@id": "duumbi:rewrite/main/entry/left"},
+                        "duumbi:right": {"@id": "duumbi:rewrite/main/entry/zero"},
+                        "duumbi:resultType": "i64"
+                    },
+                    {
+                        "@type": "duumbi:Return",
+                        "@id": "duumbi:rewrite/main/entry/return",
+                        "duumbi:operand": {"@id": "duumbi:rewrite/main/entry/add"}
+                    }
+                ]
+            }]
+        }]
+    })
+}
+
+#[test]
+fn rewrite_list_json_exposes_rule_metadata() {
+    let output = duumbi()
+        .args(["rewrite", "list", "--json"])
+        .output()
+        .expect("invariant: duumbi binary must run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let rules: Value =
+        serde_json::from_slice(&output.stdout).expect("invariant: rules output is JSON");
+    let first = rules
+        .as_array()
+        .expect("invariant: rules output is array")
+        .iter()
+        .find(|rule| rule["id"] == "i64-add-zero-right")
+        .expect("expected i64-add-zero-right rule");
+
+    assert_eq!(first["category"], "local-optimization");
+    assert_eq!(first["safetyClass"], "local-semantics-preserving");
+    assert_eq!(first["applyCapable"], true);
+    assert!(
+        first["preconditions"]
+            .as_str()
+            .is_some_and(|text| text.contains("Const(0)"))
+    );
+}
+
+#[test]
+fn rewrite_preview_json_is_read_only_and_stable() {
+    let tmp = setup_workspace();
+    let graph_path = tmp.path().join(".duumbi").join("graph").join("main.jsonld");
+    let before = fs::read_to_string(&graph_path).expect("invariant: graph must be readable");
+
+    let output = duumbi()
+        .current_dir(tmp.path())
+        .args([
+            "rewrite",
+            "preview",
+            "--rule",
+            "i64-add-zero-right",
+            "--json",
+        ])
+        .output()
+        .expect("invariant: duumbi binary must run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let preview: Value =
+        serde_json::from_slice(&output.stdout).expect("invariant: preview output is JSON");
+    assert_eq!(
+        preview["matches"][0]["matchId"],
+        "i64-add-zero-right:rewrite:duumbi:rewrite/main/entry/add:0"
+    );
+    assert_eq!(
+        fs::read_to_string(&graph_path).expect("invariant: graph must remain readable"),
+        before
+    );
+    assert!(!tmp.path().join(".duumbi").join("history").exists());
+}
+
+#[test]
+fn rewrite_apply_json_writes_after_snapshot_and_validation() {
+    let tmp = setup_workspace();
+    let graph_path = tmp.path().join(".duumbi").join("graph").join("main.jsonld");
+
+    let output = duumbi()
+        .current_dir(tmp.path())
+        .args([
+            "rewrite",
+            "apply",
+            "--rule",
+            "i64-add-zero-right",
+            "--match",
+            "i64-add-zero-right:rewrite:duumbi:rewrite/main/entry/add:0",
+            "--yes",
+            "--json",
+        ])
+        .output()
+        .expect("invariant: duumbi binary must run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let result: Value =
+        serde_json::from_slice(&output.stdout).expect("invariant: apply output is JSON");
+    assert_eq!(result["status"], "success");
+    assert_eq!(result["validation"]["valid"], true);
+    assert!(
+        result["snapshotPath"]
+            .as_str()
+            .is_some_and(|path| path.ends_with("000001.jsonld"))
+    );
+
+    let rewritten: Value = serde_json::from_str(
+        &fs::read_to_string(&graph_path).expect("invariant: graph must be readable"),
+    )
+    .expect("invariant: rewritten graph must be JSON");
+    assert_eq!(
+        rewritten["duumbi:functions"][0]["duumbi:blocks"][0]["duumbi:ops"][3]["duumbi:operand"]["@id"],
+        "duumbi:rewrite/main/entry/left"
+    );
+    assert!(
+        tmp.path()
+            .join(".duumbi")
+            .join("history")
+            .join("000001.jsonld")
+            .exists()
+    );
+}
+
+#[test]
+fn rewrite_apply_explicit_path_uses_source_module_name_for_match_ids() {
+    let tmp = setup_workspace();
+    let graph_path = tmp.path().join(".duumbi").join("graph").join("main.jsonld");
+    let graph_arg = graph_path
+        .to_str()
+        .expect("invariant: temp graph path is UTF-8");
+
+    let output = duumbi()
+        .current_dir(tmp.path())
+        .args([
+            "rewrite",
+            "apply",
+            "--module",
+            graph_arg,
+            "--rule",
+            "i64-add-zero-right",
+            "--match",
+            "i64-add-zero-right:rewrite:duumbi:rewrite/main/entry/add:0",
+            "--yes",
+            "--json",
+        ])
+        .output()
+        .expect("invariant: duumbi binary must run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let result: Value =
+        serde_json::from_slice(&output.stdout).expect("invariant: apply output is JSON");
+    assert_eq!(result["status"], "success");
+}
+
+#[test]
+fn rewrite_apply_experimental_rule_is_rejected_without_snapshot() {
+    let tmp = setup_workspace();
+    let graph_path = tmp.path().join(".duumbi").join("graph").join("main.jsonld");
+    let before = fs::read_to_string(&graph_path).expect("invariant: graph must be readable");
+
+    let output = duumbi()
+        .current_dir(tmp.path())
+        .args([
+            "rewrite",
+            "apply",
+            "--rule",
+            "experimental-fold-i64-const-add",
+            "--all",
+            "--max-matches",
+            "1",
+            "--yes",
+        ])
+        .output()
+        .expect("invariant: duumbi binary must run");
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("preview-only"));
+    assert_eq!(
+        fs::read_to_string(&graph_path).expect("invariant: graph must remain readable"),
+        before
+    );
+    assert!(!tmp.path().join(".duumbi").join("history").exists());
+}
+
+#[test]
+fn rewrite_mcp_tools_are_discoverable_with_safety_descriptions() {
+    use duumbi::mcp::server::McpServer;
+
+    let tmp = setup_workspace();
+    let server = McpServer::new(tmp.path().to_path_buf());
+    let tools = server.list_tools();
+    let preview = tools
+        .iter()
+        .find(|tool| tool.name == "rewrite_preview")
+        .expect("rewrite_preview must be listed");
+    let apply = tools
+        .iter()
+        .find(|tool| tool.name == "rewrite_apply")
+        .expect("rewrite_apply must be listed");
+
+    assert!(preview.description.contains("Read-only"));
+    assert!(apply.description.contains("Write-capable"));
+    assert_eq!(
+        preview.input_schema["additionalProperties"],
+        serde_json::json!(false)
+    );
+    assert_eq!(
+        apply.input_schema["additionalProperties"],
+        serde_json::json!(false)
+    );
+}
+
+#[test]
+fn rewrite_mcp_preview_is_read_only() {
+    use duumbi::mcp::tools::rewrite;
+
+    let tmp = setup_workspace();
+    let graph_path = tmp.path().join(".duumbi").join("graph").join("main.jsonld");
+    let before = fs::read_to_string(&graph_path).expect("invariant: graph must be readable");
+
+    let preview = rewrite::rewrite_preview(
+        tmp.path(),
+        &serde_json::json!({"rule_id": "i64-add-zero-right"}),
+    )
+    .expect("MCP preview must succeed");
+
+    assert_eq!(
+        preview["matches"][0]["matchId"],
+        "i64-add-zero-right:rewrite:duumbi:rewrite/main/entry/add:0"
+    );
+    assert_eq!(
+        fs::read_to_string(&graph_path).expect("invariant: graph must remain readable"),
+        before
+    );
+    assert!(!tmp.path().join(".duumbi").join("history").exists());
+}
+
+#[test]
+fn rewrite_mcp_apply_is_snapshot_backed() {
+    use duumbi::mcp::tools::rewrite;
+
+    let tmp = setup_workspace();
+    let graph_path = tmp.path().join(".duumbi").join("graph").join("main.jsonld");
+
+    let result = rewrite::rewrite_apply(
+        tmp.path(),
+        &serde_json::json!({
+            "rule_id": "i64-add-zero-right",
+            "match_id": "i64-add-zero-right:rewrite:duumbi:rewrite/main/entry/add:0"
+        }),
+    )
+    .expect("MCP apply must succeed");
+
+    assert_eq!(result["status"], "success");
+    assert_eq!(result["validation"]["valid"], true);
+    assert!(
+        result["snapshotPath"]
+            .as_str()
+            .is_some_and(|path| path.ends_with("000001.jsonld"))
+    );
+
+    let rewritten: Value = serde_json::from_str(
+        &fs::read_to_string(&graph_path).expect("invariant: graph must be readable"),
+    )
+    .expect("invariant: rewritten graph must be JSON");
+    assert_eq!(
+        rewritten["duumbi:functions"][0]["duumbi:blocks"][0]["duumbi:ops"][3]["duumbi:operand"]["@id"],
+        "duumbi:rewrite/main/entry/left"
+    );
+}
+
+#[test]
+fn rewrite_mcp_rejects_unknown_fields() {
+    use duumbi::mcp::tools::rewrite;
+
+    let tmp = setup_workspace();
+    let err = rewrite::rewrite_preview(
+        tmp.path(),
+        &serde_json::json!({
+            "rule_id": "i64-add-zero-right",
+            "unexpected": true
+        }),
+    )
+    .expect_err("unknown fields must be rejected");
+
+    assert!(err.contains("Unknown field"));
+}


### PR DESCRIPTION
## Summary
- Add the V1 semantic rewrite backend with rule metadata, deterministic preview, in-memory apply validation, safety classes, limits, and evidence DTOs.
- Add CLI `duumbi rewrite` list/preview/apply with snapshot-backed writes.
- Add MCP rewrite list/preview/apply tools backed by the same engine.
- Add DUUMBI-684 integration coverage and V1 rewrite documentation.

Related to #684.

## Workflow Note
This implementation PR must leave the execution issue open for Stage 11 review and Stage 12 closure. It must not close #684 by merge automation.

## Verification
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --test integration_duumbi684_rewrite`
- `cargo test --all`
- Live CLI smoke: `rewrite list --json`, `rewrite preview --rule i64-add-zero-right --json`, `rewrite apply --rule i64-add-zero-right --match ... --yes --json`, and post-apply `duumbi check` in /private/tmp/duumbi684-smoke.5Dinhz

## Resource Policy
- External LLM calls: 0
- Estimated external LLM cost: USD 0
- New dependencies: none
- Ralph resource gate: not triggered

## Stage 11 Notes
- Please review preview/apply no-mutation guarantees, snapshot sequencing, stale-match rejection, MCP write-capable wording, and explicit-path module behavior.