### PR TITLE
Prepare v0.4.0-preview release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,11 +46,11 @@ jobs:
 
       # Build duumbi CLI (release)
       - name: Build duumbi CLI
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --locked --release --target ${{ matrix.target }}
 
       # Build studio binary (release, SSR feature)
       - name: Build duumbi-studio
-        run: cargo build --release --target ${{ matrix.target }} -p duumbi-studio --features ssr
+        run: cargo build --locked --release --target ${{ matrix.target }} -p duumbi-studio --features ssr
 
       # Package the release archive
       - name: Package
@@ -70,6 +70,25 @@ jobs:
           tar czf "${ARCHIVE}.tar.gz" "${ARCHIVE}"
           echo "ARCHIVE=${ARCHIVE}.tar.gz" >> $GITHUB_ENV
 
+      - name: Validate archive
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ARCHIVE="${ARCHIVE:?}"
+          ARCHIVE_DIR="${ARCHIVE%.tar.gz}"
+          TMP_DIR="$(mktemp -d)"
+          trap 'rm -rf "${TMP_DIR}"' EXIT
+
+          test -s "${ARCHIVE}"
+          tar xzf "${ARCHIVE}" -C "${TMP_DIR}"
+          test -x "${TMP_DIR}/${ARCHIVE_DIR}/duumbi"
+          test -x "${TMP_DIR}/${ARCHIVE_DIR}/studio"
+          test -f "${TMP_DIR}/${ARCHIVE_DIR}/runtime/duumbi_runtime.c"
+          test -f "${TMP_DIR}/${ARCHIVE_DIR}/runtime/third_party/sqlite/sqlite3.c"
+          test -f "${TMP_DIR}/${ARCHIVE_DIR}/runtime/third_party/sqlite/sqlite3.h"
+          test -f "${TMP_DIR}/${ARCHIVE_DIR}/README.md"
+
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
@@ -88,23 +107,49 @@ jobs:
           path: artifacts
           merge-multiple: true
 
+      - name: Generate checksums
+        shell: bash
+        working-directory: artifacts
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          archives=(duumbi-${GITHUB_REF_NAME}-*.tar.gz)
+          if [ "${#archives[@]}" -eq 0 ]; then
+            echo "No release archives found for ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+
+          sha256sum "${archives[@]}" > checksums.txt
+          cat checksums.txt
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
-          files: artifacts/*.tar.gz
+          prerelease: true
+          fail_on_unmatched_files: true
+          files: |
+            artifacts/*.tar.gz
+            artifacts/checksums.txt
           body: |
             ## DUUMBI ${{ github.ref_name }}
 
+            Developer preview release for early CLI and Studio testing.
+
             ### Installation
 
-            Download the archive for your platform, extract, and add to PATH:
+            Download the archive for your platform and verify it against `checksums.txt`:
 
             ```bash
+            shasum -a 256 --ignore-missing -c checksums.txt
             tar xzf duumbi-${{ github.ref_name }}-<target>.tar.gz
-            sudo cp duumbi-${{ github.ref_name }}-<target>/duumbi /usr/local/bin/
-            sudo cp duumbi-${{ github.ref_name }}-<target>/studio /usr/local/bin/
+            export PATH="$PWD/duumbi-${{ github.ref_name }}-<target>:$PATH"
+            duumbi --version
             ```
+
+            Keep the extracted release directory together. The CLI expects the packaged
+            `runtime/` tree beside the executable when linking native DUUMBI programs.
 
             ### What's included
 
@@ -115,9 +160,9 @@ jobs:
 
             ### Platforms
 
-            | Archive | Platform |
-            |---------|----------|
-            | `*-aarch64-apple-darwin.tar.gz` | macOS ARM (M1/M2/M3/M4) |
-            | `*-x86_64-apple-darwin.tar.gz` | macOS Intel |
-            | `*-x86_64-unknown-linux-gnu.tar.gz` | Linux x86_64 |
-            | `*-aarch64-unknown-linux-gnu.tar.gz` | Linux ARM64 |
+            | Archive | Platform | Status |
+            |---------|----------|--------|
+            | `*-aarch64-apple-darwin.tar.gz` | macOS ARM (M1/M2/M3/M4) | Required preview target |
+            | `*-x86_64-apple-darwin.tar.gz` | macOS Intel | Required preview target |
+            | `*-x86_64-unknown-linux-gnu.tar.gz` | Linux x86_64 | Required preview target |
+            | `*-aarch64-unknown-linux-gnu.tar.gz` | Linux ARM64 | Extra preview target |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1202,7 +1202,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "duumbi"
-version = "0.3.3"
+version = "0.4.0-preview"
 dependencies = [
  "anyhow",
  "axum",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "duumbi-studio"
-version = "0.3.3"
+version = "0.4.0-preview"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/duumbi-studio"]
 
 [package]
 name = "duumbi"
-version = "0.3.3"
+version = "0.4.0-preview"
 edition = "2024"
 license = "MPL-2.0"
 default-run = "duumbi"

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ Download the archive for your platform from the
 [`v0.4.0-preview` release](https://github.com/hgahub/duumbi/releases/tag/v0.4.0-preview)
 and verify it with the published checksum file:
 
+For the archive install, Rust is not required to install DUUMBI itself. The
+smoke test below runs `duumbi build` and `duumbi run`, so it still needs the
+native build/link tools used when compiling DUUMBI programs: Xcode Command Line
+Tools or an equivalent C compiler/linker on macOS, and `build-essential` or an
+equivalent C compiler/linker on Linux. Linux systems also need the runtime
+linker dependencies used by the DUUMBI C runtime, including libcurl.
+
 ```bash
 DUUMBI_VERSION=v0.4.0-preview
 DUUMBI_TARGET=<target>

--- a/README.md
+++ b/README.md
@@ -20,6 +20,44 @@ Traditional compilers transform text → AST → machine code. DUUMBI skips the 
 
 ## Install
 
+### Developer preview release
+
+DUUMBI `v0.4.0-preview` is distributed as prebuilt GitHub Release archives for:
+
+| Platform | Target | Status |
+|----------|--------|--------|
+| macOS Apple Silicon | `aarch64-apple-darwin` | Required preview target |
+| macOS Intel | `x86_64-apple-darwin` | Required preview target |
+| Linux x86_64 | `x86_64-unknown-linux-gnu` | Required preview target |
+| Linux ARM64 | `aarch64-unknown-linux-gnu` | Extra preview target |
+
+Download the archive for your platform from the
+[`v0.4.0-preview` release](https://github.com/hgahub/duumbi/releases/tag/v0.4.0-preview)
+and verify it with the published checksum file:
+
+```bash
+DUUMBI_VERSION=v0.4.0-preview
+DUUMBI_TARGET=<target>
+
+curl -LO "https://github.com/hgahub/duumbi/releases/download/${DUUMBI_VERSION}/duumbi-${DUUMBI_VERSION}-${DUUMBI_TARGET}.tar.gz"
+curl -LO "https://github.com/hgahub/duumbi/releases/download/${DUUMBI_VERSION}/checksums.txt"
+shasum -a 256 --ignore-missing -c checksums.txt
+
+tar xzf "duumbi-${DUUMBI_VERSION}-${DUUMBI_TARGET}.tar.gz"
+export PATH="$PWD/duumbi-${DUUMBI_VERSION}-${DUUMBI_TARGET}:$PATH"
+
+duumbi --version
+duumbi init smoke
+cd smoke
+duumbi build
+duumbi run
+```
+
+Keep the extracted release directory together. The CLI expects the packaged
+`runtime/` tree beside the executable when linking native DUUMBI programs.
+
+### Build from source
+
 **Requirements:**
 
 - Rust stable 1.80+ through `rustup`.

--- a/crates/duumbi-studio/Cargo.toml
+++ b/crates/duumbi-studio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "duumbi-studio"
-version = "0.3.3"
+version = "0.4.0-preview"
 edition = "2024"
 license = "MPL-2.0"
 


### PR DESCRIPTION
Related to #687.

Workflow note: this implementation PR must leave the execution issue open. Do not use closing references or mark #687 done from this PR.

## Scope

- Bump DUUMBI and Studio package metadata to `0.4.0-preview`.
- Harden the tag-triggered release workflow with locked builds, archive-content validation, checksum generation, attached `checksums.txt`, and prerelease publication.
- Update the source README preview install path with artifact names, checksum verification, runtime-directory guidance, required targets, and Linux ARM64 as an extra preview target.

## Linked Artifacts

- Issue: https://github.com/hgahub/duumbi/issues/687
- Product spec: `specs/DUUMBI-687/PRODUCT.md`
- Technical spec: `specs/DUUMBI-687/TECHNICAL.md`
- Product spec PR: https://github.com/hgahub/duumbi/pull/709
- Technical spec PR: https://github.com/hgahub/duumbi/pull/710
- Docs-site PR: https://github.com/hgahub/duumbi-web/pull/8

## Ralph Cycle Evidence

### Cycle 1: source-repo release prep

Evidence: https://github.com/hgahub/duumbi/issues/687#issuecomment-4702718685

- Resource gate: clean for this source-repo slice. No DUUMBI LLM calls, paid external model calls, tag push, release publication, or new dependency.
- Files changed: `Cargo.toml`, `crates/duumbi-studio/Cargo.toml`, `Cargo.lock`, `.github/workflows/release.yml`, `README.md`.
- `cargo fmt --check` passed.
- `cargo metadata --format-version 1 --locked --no-deps` passed.
- `git diff --check` passed.
- `cargo build --locked -p duumbi --bin duumbi` passed.
- `target/debug/duumbi --version` printed `duumbi 0.4.0-preview`.

### Cycle 2: docs-site install guidance

Evidence: https://github.com/hgahub/duumbi/issues/687#issuecomment-4702884462

- Docs-site PR: https://github.com/hgahub/duumbi-web/pull/8
- Docs-site PR state: merged.
- `npm run build` from `hgahub/duumbi-web/docs` passed.
- Static `rg` review confirmed docs-site agreement on preview tag, artifact/checksum flow, target matrix, Linux ARM64 extra target, runtime guidance, source-build fallback, and no DUUMBI crates.io/package-manager install claim.

### Cycle 3: Codex review prerequisite fix

Evidence: https://github.com/hgahub/duumbi/issues/687#issuecomment-4702926371

- Addressed the `@chatgpt-codex-connector` P2 review thread about preview smoke-test prerequisites.
- Commit: `af5df60`
- File changed: `README.md`.
- `git diff --check` passed.
- `cargo fmt --check` passed.
- `cargo metadata --format-version 1 --locked --no-deps` passed.
- Targeted `rg` review confirmed the README now warns archive users that the `duumbi build` / `duumbi run` smoke path still needs native build/link tools and Linux libcurl runtime linker dependencies.
- Review thread: replied and resolved.

## Current Check State

- Latest PR #711 GitHub checks passed after commit `af5df60` and merge-from-main head `f833e3c`.
- Passing checks: Docs AI Update Request, check, check (ubuntu-latest), check (windows-latest), coverage.
- Docs-site PR #8 was merged on 2026-06-14.
- No tag was pushed and no GitHub Release was published from this PR.

## Codex Self-Review

Status: no blocking findings.

Review notes:

- The release workflow keeps the existing tag-triggered release model and does not add crates.io, package-manager, signing, notarization, installer, or auto-update behavior.
- The workflow keeps existing `contents: write` release permissions and does not introduce new secrets or dependencies.
- Archive validation checks required binaries and runtime files before upload.
- The README and merged docs-site guidance match the artifact naming and checksum flow.
- The README now documents native build/link prerequisites before the preview smoke commands.
- Expected residual risk: release URLs for `v0.4.0-preview` resolve only after the post-merge release operation creates the tag and GitHub Release.

## AI Review Plan

- Codex self-review: complete; no blocking findings.
- `@chatgpt-codex-connector` review: one P2 thread was filed and addressed in commit `af5df60`; the thread is resolved.
- Quick low-cost review: not requested; optional/advisory only.
- Greptile: not needed for Stage 10. This PR changes release automation, package metadata, and docs, but does not touch Rust source behavior, compiler lowering, runtime C code, provider/auth, registry, MCP, or intent execution.

## Remaining Work After Merge

- Push `v0.4.0-preview` from reviewed main after this release-prep PR is merged.
- Wait for the tag-triggered release workflow.
- Verify release assets, `checksums.txt`, archive contents, and install smoke evidence.
- Record release-operation evidence on #687.

## Readiness

Ready for human review / Stage 11 review. Keep #687 open.
