### PR TITLE
Drop macOS Intel preview archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,18 +11,27 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  release-targets:
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.targets.outputs.include }}
+    steps:
+      - id: targets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_REF_NAME}" = "v0.4.0-preview" ]; then
+            echo 'include=[{"target":"aarch64-apple-darwin","os":"macos-latest"},{"target":"x86_64-unknown-linux-gnu","os":"ubuntu-latest"},{"target":"aarch64-unknown-linux-gnu","os":"ubuntu-latest"}]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'include=[{"target":"aarch64-apple-darwin","os":"macos-latest"},{"target":"x86_64-apple-darwin","os":"macos-13"},{"target":"x86_64-unknown-linux-gnu","os":"ubuntu-latest"},{"target":"aarch64-unknown-linux-gnu","os":"ubuntu-latest"}]' >> "$GITHUB_OUTPUT"
+          fi
+
   build:
+    needs: release-targets
     strategy:
       matrix:
-        include:
-          - target: aarch64-apple-darwin
-            os: macos-latest
-          - target: x86_64-apple-darwin
-            os: macos-13
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
+        include: ${{ fromJSON(needs.release-targets.outputs.include) }}
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -123,6 +132,61 @@ jobs:
           sha256sum "${archives[@]}" > checksums.txt
           cat checksums.txt
 
+      - name: Generate release body
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          cat > artifacts/release-body.md <<'BODY'
+          ## DUUMBI ${{ github.ref_name }}
+
+          Developer preview release for early CLI and Studio testing.
+
+          ### Installation
+
+          Download the archive for your platform and verify it against `checksums.txt`:
+
+          ```bash
+          shasum -a 256 --ignore-missing -c checksums.txt
+          tar xzf duumbi-${{ github.ref_name }}-<target>.tar.gz
+          export PATH="$PWD/duumbi-${{ github.ref_name }}-<target>:$PATH"
+          duumbi --version
+          ```
+
+          Keep the extracted release directory together. The CLI expects the packaged
+          `runtime/` tree beside the executable when linking native DUUMBI programs.
+
+          ### What's included
+
+          - `duumbi` — CLI compiler, AI mutation, intent system, MCP server
+          - `studio` — Browser-based Studio (run with `duumbi studio`)
+          - `runtime/duumbi_runtime.c` — C runtime for linking compiled binaries
+          - `runtime/third_party/` — vendored native runtime sources required by the C runtime
+
+          ### Platforms
+
+          | Archive | Platform | Status |
+          |---------|----------|--------|
+          | `*-aarch64-apple-darwin.tar.gz` | macOS ARM (M1/M2/M3/M4) | Required preview target |
+          BODY
+
+          if [ "${GITHUB_REF_NAME}" != "v0.4.0-preview" ]; then
+            echo '| `*-x86_64-apple-darwin.tar.gz` | macOS Intel | Required target |' >> artifacts/release-body.md
+          fi
+
+          cat >> artifacts/release-body.md <<'BODY'
+          | `*-x86_64-unknown-linux-gnu.tar.gz` | Linux x86_64 | Required preview target |
+          | `*-aarch64-unknown-linux-gnu.tar.gz` | Linux ARM64 | Extra preview target |
+          BODY
+
+          if [ "${GITHUB_REF_NAME}" = "v0.4.0-preview" ]; then
+            cat >> artifacts/release-body.md <<'BODY'
+
+          macOS Intel (`x86_64-apple-darwin`) is not included in this
+          developer preview. Build from source on Intel Macs if needed.
+          BODY
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
@@ -132,37 +196,4 @@ jobs:
           files: |
             artifacts/*.tar.gz
             artifacts/checksums.txt
-          body: |
-            ## DUUMBI ${{ github.ref_name }}
-
-            Developer preview release for early CLI and Studio testing.
-
-            ### Installation
-
-            Download the archive for your platform and verify it against `checksums.txt`:
-
-            ```bash
-            shasum -a 256 --ignore-missing -c checksums.txt
-            tar xzf duumbi-${{ github.ref_name }}-<target>.tar.gz
-            export PATH="$PWD/duumbi-${{ github.ref_name }}-<target>:$PATH"
-            duumbi --version
-            ```
-
-            Keep the extracted release directory together. The CLI expects the packaged
-            `runtime/` tree beside the executable when linking native DUUMBI programs.
-
-            ### What's included
-
-            - `duumbi` — CLI compiler, AI mutation, intent system, MCP server
-            - `studio` — Browser-based Studio (run with `duumbi studio`)
-            - `runtime/duumbi_runtime.c` — C runtime for linking compiled binaries
-            - `runtime/third_party/` — vendored native runtime sources required by the C runtime
-
-            ### Platforms
-
-            | Archive | Platform | Status |
-            |---------|----------|--------|
-            | `*-aarch64-apple-darwin.tar.gz` | macOS ARM (M1/M2/M3/M4) | Required preview target |
-            | `*-x86_64-apple-darwin.tar.gz` | macOS Intel | Required preview target |
-            | `*-x86_64-unknown-linux-gnu.tar.gz` | Linux x86_64 | Required preview target |
-            | `*-aarch64-unknown-linux-gnu.tar.gz` | Linux ARM64 | Extra preview target |
+          body_path: artifacts/release-body.md

--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ DUUMBI `v0.4.0-preview` is distributed as prebuilt GitHub Release archives for:
 | Platform | Target | Status |
 |----------|--------|--------|
 | macOS Apple Silicon | `aarch64-apple-darwin` | Required preview target |
-| macOS Intel | `x86_64-apple-darwin` | Required preview target |
 | Linux x86_64 | `x86_64-unknown-linux-gnu` | Required preview target |
 | Linux ARM64 | `aarch64-unknown-linux-gnu` | Extra preview target |
+
+macOS Intel (`x86_64-apple-darwin`) is not included in this developer preview.
+Build from source on Intel Macs if needed.
 
 Download the archive for your platform from the
 [`v0.4.0-preview` release](https://github.com/hgahub/duumbi/releases/tag/v0.4.0-preview)


### PR DESCRIPTION
Related to #687.

Workflow note: this follow-up PR must leave the execution issue open. Do not use closing references or mark #687 done from this PR.

## Scope

- Remove `x86_64-apple-darwin` / macOS Intel from the `v0.4.0-preview` release workflow matrix only.
- Keep macOS Intel in the workflow matrix for future non-preview `v*` tags unless a later product decision removes it globally.
- Update source README and generated `v0.4.0-preview` release notes to state that macOS Intel is not included in this developer preview and should build from source if needed.

## Rationale

The tag-triggered release run for `v0.4.0-preview` stalled on `build (x86_64-apple-darwin, macos-13)` while the other preview targets completed successfully. The issue owner approved dropping macOS Intel from the preview target set because it is an older, lower-priority architecture for this developer preview.

This is a scoped product-target amendment for #687. It does not add new package channels, signing, notarization, installers, or crates.io publication.

## Verification

- `git diff --check`
- `cargo fmt --check`
- Ruby YAML parse of `.github/workflows/release.yml`
- Static `rg` review confirmed `v0.4.0-preview` dynamically omits macOS Intel, future non-preview `v*` tags still include macOS Intel, and README/release notes explicitly mark macOS Intel as not included in this preview.
- PR checks passed after the review fix: `check`, `check (ubuntu-latest)`, and `check (windows-latest)`.

## Release Operation Notes

- The old tag-triggered release workflow run was cancelled: https://github.com/hgahub/duumbi/actions/runs/27511706432
- After this PR is reviewed and merged, move/recreate `v0.4.0-preview` on the new reviewed `main` commit and rerun the release workflow.
- Verify the GitHub Release assets, `checksums.txt`, archive contents, and install smoke evidence before Stage 12 closure.
