### PR TITLE
fix: address PR #715 CI failures and review comments

### DIFF
--- a/examples/flagship-http-sqlite-json/README.md
+++ b/examples/flagship-http-sqlite-json/README.md
@@ -44,7 +44,20 @@ cd workspace
 
 ../../../target/debug/duumbi run > /tmp/duumbi-flagship-example.log 2>&1 &
 server_pid=$!
-curl --max-time 2 http://127.0.0.1:39388/facts
+
+for attempt in $(seq 1 50); do
+  if curl --fail --silent --show-error --max-time 2 http://127.0.0.1:39388/facts; then
+    break
+  fi
+  if [ "$attempt" -eq 50 ]; then
+    echo "server did not become ready" >&2
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" || true
+    exit 1
+  fi
+  sleep 0.1
+done
+
 wait "$server_pid"
 cat /tmp/duumbi-flagship-example.log
 ```

--- a/src/compiler/lowering.rs
+++ b/src/compiler/lowering.rs
@@ -613,6 +613,7 @@ fn make_func_signature(
 /// Returns the raw bytes of the native object file (Mach-O on macOS, ELF on
 /// Linux, COFF on Windows).
 /// For multi-module programs use [`compile_program`] instead.
+#[allow(dead_code)] // Public library API; the CLI uses compile_to_object_with_telemetry.
 #[must_use = "compilation errors should be handled"]
 pub fn compile_to_object(graph: &SemanticGraph) -> Result<Vec<u8>, CompileError> {
     compile_to_object_with_telemetry(graph, TelemetryBuildMode::Off)


### PR DESCRIPTION
### Motivation
- The Windows CI job and clippy checks were failing due to a documented startup race in the flagship example and a dead-code warning after the telemetry CLI path changed. 
- The intent is to make the example more robust for CI usage and silence an unavoidable unused-public API warning in the binary target so `cargo clippy --all-targets -- -D warnings` succeeds.

### Description
- Add a bounded readiness loop in `examples/flagship-http-sqlite-json/README.md` so the backgrounded `duumbi run` server is polled until it responds to `/facts` (prevents a startup race). 
- Mark the public function `compile_to_object` in `src/compiler/lowering.rs` with `#[allow(dead_code)]` to acknowledge it is a public library API that may be unused by the binary, which removes the clippy `dead-code` error.

### Testing
- `cargo +1.93.0 fmt --check` was run and passed. 
- `cargo +1.93.0 test --test integration_duumbi688_flagship_example` was run and the integration test passed. 
- `cargo +1.93.0 clippy --all-targets -- -D warnings` was run and completed successfully. 
- `git diff --check` was run and reported no whitespace or diff errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a300c15d0e083338d9055412fe5f89f)