### PR TITLE
Implementation for #689: scaled intent-execute eval evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ DUUMBI `v0.4.0-preview` is distributed as prebuilt GitHub Release archives for:
 macOS Intel (`x86_64-apple-darwin`) is not included in this developer preview.
 Build from source on Intel Macs if needed.
 
+Preview write-path evidence is intentionally limited. The current scaled
+intent-execute smoke notes are tracked in
+[`docs/e2e/duumbi-689-known-limitations.md`](docs/e2e/duumbi-689-known-limitations.md).
+
 Download the archive for your platform from the
 [`v0.4.0-preview` release](https://github.com/hgahub/duumbi/releases/tag/v0.4.0-preview)
 and verify it with the published checksum file:

--- a/docs/e2e/duumbi-689-known-limitations.md
+++ b/docs/e2e/duumbi-689-known-limitations.md
@@ -1,0 +1,49 @@
+# DUUMBI-689 Preview Known Limitations
+
+Related to #689.
+
+The scaled intent-execute smoke evidence from 2026-06-16 should be treated as
+preview risk evidence, not as a passing benchmark claim.
+
+Evidence source:
+
+- `docs/e2e/results/duumbi-689-scaled-smoke-20260616.md`
+- Command: `duumbi benchmark --suite scaled --smoke --provider minimax:auto:primary:MINIMAX_API_KEY --attempts 1`
+
+## What Passed
+
+- The benchmark surface now has an opt-in scaled suite.
+- The scaled smoke subset can select multi-function, cross-module, and
+  HTTP/SQLite/JSON evidence tasks.
+- The report distinguishes first-pass success, repair attempts, provider usage
+  availability, failure categories, dominant evidence signals, and process
+  evidence gaps.
+
+## What Failed
+
+- `scaled_math_pipeline` failed verifier evidence: 0/3 tests passed.
+- `scaled_cross_module_stats` failed verifier evidence: 0/3 tests passed.
+- `scaled_http_sqlite_json` was not counted as a pass because the current
+  verifier does not check HTTP JSON payload semantics.
+
+## What Preview Users Should Not Infer
+
+- Do not infer that the intent write path reliably handles application-scale
+  or service-like tasks.
+- Do not infer that cross-module generated programs pass reliably under the
+  current provider/prompt path.
+- Do not infer HTTP + SQLite + JSON generated-service reliability from the
+  scaled corpus entry alone. The repository has a flagship reference example,
+  but this smoke run did not prove generated service behavior.
+- Do not make cost claims from this run. Provider usage fields were present but
+  token/cost values were unavailable.
+
+## Top Failure Patterns To Feed Back
+
+1. Scaled i64 task verifier failures need sampled generated-workspace evidence
+   so follow-up work can distinguish wrong decomposition, missing exports,
+   cross-module call resolution, and logic mistakes.
+2. HTTP + SQLite + JSON needs a bounded process evidence checker before the
+   scaled benchmark can validate service output directly.
+3. Provider usage telemetry needs integration into benchmark results before
+   preview cost claims are supported.

--- a/docs/e2e/results/duumbi-689-scaled-smoke-20260616.md
+++ b/docs/e2e/results/duumbi-689-scaled-smoke-20260616.md
@@ -1,0 +1,88 @@
+# DUUMBI-689 Scaled Intent-Execute Smoke Report
+
+Related to #689.
+
+## Run Metadata
+
+- Date: 2026-06-16
+- DUUMBI version: `0.4.0-preview`
+- Source branch: `codex/duumbi-689-implementation`
+- Provider: `minimax`
+- Provider identifier: `minimax:auto:primary:MINIMAX_API_KEY`
+- Attempts per selected task: 1
+- Command:
+
+```bash
+repo="$(pwd)"
+tmpdir="$(mktemp -d /tmp/duumbi-689-scaled-smoke.XXXXXX)"
+"$repo/target/debug/duumbi" init "$tmpdir"
+cd "$tmpdir"
+"$repo/target/debug/duumbi" benchmark \
+  --suite scaled \
+  --smoke \
+  --provider minimax:auto:primary:MINIMAX_API_KEY \
+  --attempts 1 \
+  --output "$tmpdir/duumbi-689-scaled-smoke.json"
+```
+
+## Result Summary
+
+| Task | Tags | Result | First pass | Repair attempted | Failure category | Evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| `scaled_math_pipeline` | scaled, multi_function, single_module, i64 | fail, 0/3 tests | false | false | `logic_error` | provider-backed intent execution ran; verifier tests failed |
+| `scaled_cross_module_stats` | scaled, multi_module, cross_module, i64 | fail, 0/3 tests | false | false | `logic_error` | provider-backed intent execution ran; verifier tests failed |
+| `scaled_http_sqlite_json` | scaled, http, sqlite, json, process_evidence | fail, 0/0 verifier tests | false | false | `evidence_required` | current verifier does not check HTTP JSON payload semantics |
+
+Aggregate values:
+
+- total results: 3
+- successes: 0
+- first-pass successes: 0
+- repair attempts: 0
+- repair successes: 0
+- unrecovered failures: 3
+- usage available: 0
+- usage unavailable: 3
+- usage unavailable reasons:
+  - `provider_response_did_not_expose_usage`: 2
+  - `process_evidence_not_executed`: 1
+- dominant error codes/signals:
+  - `broader_evidence_required`: 1
+- top failure patterns:
+  - `logic_error`: 2
+  - `broader_evidence_required`: 1
+
+## Interpretation
+
+This run is intentionally not a success badge. It proves the scaled benchmark
+surface can select and report multi-function, cross-module, and
+HTTP/SQLite/JSON evidence cases under a constrained MiniMax run, and it shows
+that the current write path did not pass the selected scaled i64 verifier cases
+on the first attempt.
+
+The HTTP + SQLite + JSON row is deliberately reported as
+`evidence_required`. The current i64 verifier cannot prove loopback HTTP JSON
+payload semantics, so the benchmark records the verification gap instead of
+silently passing the task.
+
+## Known Limitations From This Run
+
+- The scaled smoke subset produced 0/3 successful task results.
+- No selected task succeeded on first pass.
+- No repair cycle was attempted in this run.
+- Provider usage and token/cost data were unavailable from the benchmark report
+  path used by this run.
+- HTTP + SQLite + JSON composition is present in the scaled corpus, but it
+  still needs automated process evidence before it can be counted as generated
+  service behavior.
+
+## Follow-Up Failure Patterns
+
+1. `logic_error`: provider-backed scaled i64 tasks completed without passing
+   verifier tests. The next implementation/research target should inspect the
+   generated temp workspaces or add sampled evidence paths to identify whether
+   failures are decomposition, cross-module exports/calls, verifier mismatch,
+   or generated graph logic.
+2. `broader_evidence_required`: the benchmark can label HTTP/SQLite/JSON
+   composition honestly, but needs a bounded process evidence checker before
+   this row can validate actual service output.

--- a/docs/testing/phase9c-benchmark.md
+++ b/docs/testing/phase9c-benchmark.md
@@ -87,7 +87,7 @@ api_key_env = "OPENAI_API_KEY"
 
 | # | Lépés | Elvárt eredmény | ✓/✗ | Megjegyzés |
 |---|-------|-----------------|-----|------------|
-| 1.1 | `$DUUMBI benchmark --help` | Help szöveg megjelenik az összes opcióval (--showcase, --provider, --attempts, --output, --ci, --baseline) | | |
+| 1.1 | `$DUUMBI benchmark --help` | Help szöveg megjelenik az összes opcióval (--suite, --smoke, --showcase, --provider, --attempts, --output, --ci, --baseline) | | |
 | 1.2 | `$DUUMBI benchmark --attempts 0` | Hiba: no .duumbi/config.toml (nincs workspace) | | |
 | 1.3 | (workspace-ből) `$DUUMBI benchmark --showcase nonexistent --attempts 1` | Hiba: "no showcases match the given filter" | | |
 | 1.4 | (workspace-ből) `$DUUMBI benchmark --provider nonexistent --attempts 1` | Hiba: "no providers match the given filter" | | |
@@ -227,21 +227,43 @@ api_key_env = "OPENAI_API_KEY"
 
 ---
 
+## T11 — Scaled Smoke Evidence (#689)
+
+> Futtatás helye: **`/tmp/duumbi-test/`**
+> **Figyelem:** Provider-backed run, API költséggel jár. A smoke subset
+> célja az alacsony költségű, őszinte preview evidence, nem success badge.
+
+| # | Lépés | Elvárt eredmény | ✓/✗ | Megjegyzés |
+|---|-------|-----------------|-----|------------|
+| 11.1 | `$DUUMBI benchmark --suite scaled --smoke --provider minimax:auto:primary:MINIMAX_API_KEY --attempts 1 --output scaled-smoke.json` | A scaled smoke subset fut: `scaled_math_pipeline`, `scaled_cross_module_stats`, `scaled_http_sqlite_json` | | |
+| 11.2 | `cat scaled-smoke.json \| jq .summary` | Summary tartalmaz first-pass, repair, retry, usage, dominant error, top failure pattern mezőket | | |
+| 11.3 | `cat scaled-smoke.json \| jq '.results[] | {task_id,success,first_pass_success,repair_attempted,error_category,provider_usage,evidence}'` | Minden task-nál látszik a pass/fail, repair és usage evidence | | |
+| 11.4 | HTTP/SQLite/JSON sor | `error_category == "evidence_required"` amíg nincs automatizált process evidence checker | | |
+
+Current committed #689 evidence:
+
+- `docs/e2e/results/duumbi-689-scaled-smoke-20260616.md`
+- `docs/e2e/duumbi-689-known-limitations.md`
+
+---
+
 ## Automated Test Verification (reference)
 
 A következő tesztek API key nélkül futnak CI-ben (repo gyökerében):
 
 ```bash
-cargo test bench::              # 14 unit test (showcases, report)
-cargo test integration_phase9c  # 26 integration test
+cargo test bench::              # unit tests for showcases and report aggregation
+cargo test --test integration_phase9c
 ```
 
-Összesen 40 automatizált teszt fedi le:
+Az automatizált tesztek lefedik:
 - ✅ Mind a 6 YAML parse-olható valid IntentSpec-be
+- ✅ Scaled corpus parse és feature coverage (#689)
+- ✅ Scaled smoke selection
 - ✅ Showcase szűrés (filter_showcases)
-- ✅ Report aggregáció (per-showcase, per-provider)
+- ✅ Report aggregáció (per-showcase, per-provider, first-pass, repair, usage, failure patterns)
 - ✅ Kill criterion: true (5/6 × 2 provider), false (4/6 vagy 1 provider)
-- ✅ Error kategorizálás (6 kategória × több minta)
+- ✅ Error kategorizálás (schema, type, provider, mutation, crash, logic, evidence-required)
 - ✅ JSON szerializáció/deszializáció roundtrip
 - ✅ Regresszió detektálás (threshold felett/alatt)
 - ✅ ErrorCategory serde snake_case

--- a/src/bench/report.rs
+++ b/src/bench/report.rs
@@ -21,24 +21,123 @@ use serde::{Deserialize, Serialize};
 pub struct BenchmarkResult {
     /// Showcase name (e.g. `"calculator"`).
     pub showcase: String,
+    /// Stable task id. Defaults to the showcase name for new reports.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+    /// Benchmark suite, such as `"core"` or `"scaled"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suite: Option<String>,
+    /// Feature tags for filtering and failure-pattern summaries.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
     /// Provider name (e.g. `"anthropic"`).
     pub provider: String,
     /// Attempt number (1-based).
     pub attempt: u32,
     /// Whether all tests passed.
     pub success: bool,
+    /// Whether verification passed before any repair cycle.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_pass_success: Option<bool>,
+    /// Whether a repair cycle was attempted.
+    #[serde(default)]
+    pub repair_attempted: bool,
+    /// Whether repair converted the run into a success.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repair_success: Option<bool>,
     /// Categorized failure reason (if `!success`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error_category: Option<ErrorCategory>,
     /// Raw error message (if `!success`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error_message: Option<String>,
+    /// Dominant DUUMBI error code or failure signal.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dominant_error_code: Option<String>,
+    /// Mutation retry count, when exposed by the execute path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mutation_retry_count: Option<u32>,
+    /// Repair retry count, when exposed by the execute path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repair_retry_count: Option<u32>,
+    /// Total retry count, when exposed by the execute path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_retry_count: Option<u32>,
+    /// Provider usage and cost summary.
+    #[serde(default)]
+    pub provider_usage: ProviderUsageSummary,
+    /// Additional evidence for non-i64 or process-level checks.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub evidence: Option<BenchmarkEvidence>,
     /// Number of test cases that passed.
     pub tests_passed: usize,
     /// Total number of test cases.
     pub tests_total: usize,
     /// Wall-clock duration in seconds.
     pub duration_secs: f64,
+}
+
+/// Provider usage and cost summary for one benchmark run.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ProviderUsageSummary {
+    /// Whether usage data is available.
+    pub available: bool,
+    /// Number of provider requests, if known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_count: Option<u32>,
+    /// Prompt/input tokens, if known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_tokens: Option<u64>,
+    /// Completion/output tokens, if known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completion_tokens: Option<u64>,
+    /// Total tokens, if known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_tokens: Option<u64>,
+    /// Estimated cost in USD, if known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub estimated_cost_usd: Option<f64>,
+    /// Specific reason usage data is unavailable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unavailable_reason: Option<String>,
+}
+
+impl ProviderUsageSummary {
+    /// Creates an unavailable usage summary with a stable reason.
+    #[must_use]
+    pub fn unavailable(reason: impl Into<String>) -> Self {
+        Self {
+            available: false,
+            unavailable_reason: Some(reason.into()),
+            ..Self::default()
+        }
+    }
+}
+
+/// Additional benchmark evidence for checks outside the current i64 verifier.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct BenchmarkEvidence {
+    /// Evidence kind, such as `loopback_http_sqlite_json`.
+    pub kind: String,
+    /// Evidence status, such as `passed`, `failed`, or `broader_evidence_required`.
+    pub status: String,
+    /// Human-readable evidence detail.
+    pub detail: String,
+    /// Command used to gather evidence, when applicable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    /// Expected HTTP route, when applicable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected_route: Option<String>,
+    /// Expected JSON fields, when applicable.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub expected_json_fields: Vec<String>,
+    /// Current verification gap, when applicable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification_gap: Option<String>,
+    /// Path to retained evidence artifact, when applicable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_path: Option<String>,
 }
 
 /// Broad failure category for error breakdown.
@@ -57,6 +156,8 @@ pub enum ErrorCategory {
     ProviderError,
     /// Mutation pipeline failed (patch rejected, retry exhausted).
     MutationFailed,
+    /// The task requires broader evidence than the current verifier provides.
+    EvidenceRequired,
 }
 
 impl fmt::Display for ErrorCategory {
@@ -68,6 +169,7 @@ impl fmt::Display for ErrorCategory {
             Self::Crash => write!(f, "crash"),
             Self::ProviderError => write!(f, "provider_error"),
             Self::MutationFailed => write!(f, "mutation_failed"),
+            Self::EvidenceRequired => write!(f, "evidence_required"),
         }
     }
 }
@@ -111,6 +213,8 @@ pub fn categorize_error(msg: &str) -> ErrorCategory {
         || lower.contains("no such file or directory")
     {
         ErrorCategory::Crash
+    } else if lower.contains("broader evidence") || lower.contains("evidence required") {
+        ErrorCategory::EvidenceRequired
     } else {
         // Default: if the run produced wrong output it's a logic error.
         ErrorCategory::LogicError
@@ -134,10 +238,55 @@ pub struct BenchmarkReport {
     pub attempts_per_run: u32,
     /// Per-showcase aggregated stats.
     pub showcases: Vec<ShowcaseSummary>,
+    /// Scaled-eval summary across all raw results.
+    pub summary: BenchmarkSummary,
     /// Raw result entries.
     pub results: Vec<BenchmarkResult>,
     /// Whether the kill criterion is met.
     pub kill_criterion_met: bool,
+}
+
+/// Cross-result summary for first-pass, repair, usage, and failure patterns.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BenchmarkSummary {
+    /// Number of raw result entries.
+    pub total_results: u32,
+    /// Number of successful raw result entries.
+    pub successes: u32,
+    /// Number of raw entries with known first-pass status.
+    pub first_pass_attempts: u32,
+    /// Number of entries that passed before repair.
+    pub first_pass_successes: u32,
+    /// Number of entries where repair was attempted.
+    pub repair_attempts: u32,
+    /// Number of entries where repair converted the run into success.
+    pub repair_successes: u32,
+    /// Number of unrecovered failures.
+    pub unrecovered_failures: u32,
+    /// Sum of known retry counts.
+    pub total_retry_count: u32,
+    /// Entries with provider usage data.
+    pub usage_available: u32,
+    /// Entries without provider usage data.
+    pub usage_unavailable: u32,
+    /// Unavailable usage reasons and counts.
+    pub usage_unavailable_reasons: BTreeMap<String, u32>,
+    /// Total estimated cost when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_estimated_cost_usd: Option<f64>,
+    /// Dominant error codes or failure signals.
+    pub dominant_error_codes: BTreeMap<String, u32>,
+    /// Top failure patterns from this report.
+    pub top_failure_patterns: Vec<FailurePatternSummary>,
+}
+
+/// Aggregated failure pattern summary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FailurePatternSummary {
+    /// Pattern label.
+    pub pattern: String,
+    /// Number of occurrences.
+    pub count: u32,
 }
 
 /// Per-showcase summary across all providers.
@@ -195,6 +344,7 @@ impl BenchmarkReport {
         finished_at: String,
     ) -> Self {
         let showcases = aggregate_showcases(&results);
+        let summary = aggregate_summary(&results);
         let kill_criterion_met = check_kill_criterion(&showcases);
 
         Self {
@@ -203,6 +353,7 @@ impl BenchmarkReport {
             duumbi_version: env!("CARGO_PKG_VERSION").to_string(),
             attempts_per_run,
             showcases,
+            summary,
             results,
             kill_criterion_met,
         }
@@ -466,6 +617,89 @@ fn aggregate_showcases(results: &[BenchmarkResult]) -> Vec<ShowcaseSummary> {
         .collect()
 }
 
+fn aggregate_summary(results: &[BenchmarkResult]) -> BenchmarkSummary {
+    let total_results = results.len() as u32;
+    let successes = results.iter().filter(|r| r.success).count() as u32;
+    let first_pass_attempts = results
+        .iter()
+        .filter(|r| r.first_pass_success.is_some())
+        .count() as u32;
+    let first_pass_successes = results
+        .iter()
+        .filter(|r| r.first_pass_success == Some(true))
+        .count() as u32;
+    let repair_attempts = results.iter().filter(|r| r.repair_attempted).count() as u32;
+    let repair_successes = results
+        .iter()
+        .filter(|r| r.repair_success == Some(true))
+        .count() as u32;
+    let unrecovered_failures = results.iter().filter(|r| !r.success).count() as u32;
+    let total_retry_count = results.iter().filter_map(|r| r.total_retry_count).sum();
+    let usage_available = results
+        .iter()
+        .filter(|r| r.provider_usage.available)
+        .count() as u32;
+    let usage_unavailable = total_results.saturating_sub(usage_available);
+    let mut usage_unavailable_reasons = BTreeMap::new();
+    let mut total_cost = 0.0;
+    let mut cost_seen = false;
+    let mut dominant_error_codes = BTreeMap::new();
+    let mut failure_patterns = BTreeMap::new();
+
+    for result in results {
+        if !result.provider_usage.available
+            && let Some(reason) = result.provider_usage.unavailable_reason.as_deref()
+        {
+            *usage_unavailable_reasons
+                .entry(reason.to_string())
+                .or_insert(0) += 1;
+        }
+        if let Some(cost) = result.provider_usage.estimated_cost_usd {
+            total_cost += cost;
+            cost_seen = true;
+        }
+        if let Some(code) = result.dominant_error_code.as_deref() {
+            *dominant_error_codes.entry(code.to_string()).or_insert(0) += 1;
+        }
+        if !result.success {
+            let pattern = result
+                .dominant_error_code
+                .clone()
+                .or_else(|| result.error_category.as_ref().map(ToString::to_string))
+                .unwrap_or_else(|| "unknown_failure".to_string());
+            *failure_patterns.entry(pattern).or_insert(0) += 1;
+        }
+    }
+
+    let mut top_failure_patterns: Vec<FailurePatternSummary> = failure_patterns
+        .into_iter()
+        .map(|(pattern, count)| FailurePatternSummary { pattern, count })
+        .collect();
+    top_failure_patterns.sort_by(|a, b| {
+        b.count
+            .cmp(&a.count)
+            .then_with(|| a.pattern.cmp(&b.pattern))
+    });
+    top_failure_patterns.truncate(3);
+
+    BenchmarkSummary {
+        total_results,
+        successes,
+        first_pass_attempts,
+        first_pass_successes,
+        repair_attempts,
+        repair_successes,
+        unrecovered_failures,
+        total_retry_count,
+        usage_available,
+        usage_unavailable,
+        usage_unavailable_reasons,
+        total_estimated_cost_usd: cost_seen.then_some(total_cost),
+        dominant_error_codes,
+        top_failure_patterns,
+    }
+}
+
 /// Truncates a string to `max_len`, appending `…` if needed.
 fn truncate(s: &str, max_len: usize) -> String {
     if s.len() <= max_len {
@@ -494,9 +728,15 @@ mod tests {
     fn make_result(showcase: &str, provider: &str, success: bool) -> BenchmarkResult {
         BenchmarkResult {
             showcase: showcase.to_string(),
+            task_id: Some(showcase.to_string()),
+            suite: Some("core".to_string()),
+            tags: Vec::new(),
             provider: provider.to_string(),
             attempt: 1,
             success,
+            first_pass_success: Some(success),
+            repair_attempted: false,
+            repair_success: None,
             error_category: if success {
                 None
             } else {
@@ -507,6 +747,14 @@ mod tests {
             } else {
                 Some("wrong output".to_string())
             },
+            dominant_error_code: None,
+            mutation_retry_count: None,
+            repair_retry_count: None,
+            total_retry_count: Some(0),
+            provider_usage: ProviderUsageSummary::unavailable(
+                "provider_response_did_not_expose_usage",
+            ),
+            evidence: None,
             tests_passed: if success { 4 } else { 2 },
             tests_total: 4,
             duration_secs: 5.0,

--- a/src/bench/report.rs
+++ b/src/bench/report.rs
@@ -239,6 +239,7 @@ pub struct BenchmarkReport {
     /// Per-showcase aggregated stats.
     pub showcases: Vec<ShowcaseSummary>,
     /// Scaled-eval summary across all raw results.
+    #[serde(default)]
     pub summary: BenchmarkSummary,
     /// Raw result entries.
     pub results: Vec<BenchmarkResult>,
@@ -894,6 +895,63 @@ mod tests {
         assert_eq!(parsed.showcases.len(), 1);
         assert_eq!(parsed.results.len(), 1);
         assert!(parsed.results[0].success);
+    }
+
+    #[test]
+    fn old_baseline_without_summary_loads() {
+        let old_report_json = r#"{
+          "started_at": "2026-03-18T00:00:00Z",
+          "finished_at": "2026-03-18T00:01:00Z",
+          "duumbi_version": "0.4.0-preview",
+          "attempts_per_run": 1,
+          "showcases": [
+            {
+              "name": "calculator",
+              "total_attempts": 1,
+              "successes": 1,
+              "success_rate": 1.0,
+              "providers": [
+                {
+                  "name": "anthropic",
+                  "attempts": 1,
+                  "successes": 1,
+                  "success_rate": 1.0,
+                  "error_categories": {}
+                }
+              ]
+            }
+          ],
+          "results": [
+            {
+              "showcase": "calculator",
+              "provider": "anthropic",
+              "attempt": 1,
+              "success": true,
+              "error_category": null,
+              "error_message": null,
+              "tests_passed": 4,
+              "tests_total": 4,
+              "duration_secs": 5.0
+            }
+          ],
+          "kill_criterion_met": false
+        }"#;
+        let path = std::env::temp_dir().join(format!(
+            "duumbi-old-baseline-{}-{}.json",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock before unix epoch")
+                .as_nanos()
+        ));
+        std::fs::write(&path, old_report_json).expect("failed to write old baseline fixture");
+
+        let report = load_baseline(&path).expect("old baseline should load");
+        let _ = std::fs::remove_file(&path);
+
+        assert_eq!(report.showcases.len(), 1);
+        assert_eq!(report.results.len(), 1);
+        assert_eq!(report.summary.total_results, 0);
     }
 
     #[test]

--- a/src/bench/runner.rs
+++ b/src/bench/runner.rs
@@ -15,8 +15,10 @@ use std::time::Instant;
 
 use crate::agents::LlmProvider;
 use crate::agents::factory;
-use crate::bench::report::{BenchmarkResult, ErrorCategory, categorize_error};
-use crate::bench::showcases::{self, Showcase};
+use crate::bench::report::{
+    BenchmarkEvidence, BenchmarkResult, ErrorCategory, ProviderUsageSummary, categorize_error,
+};
+use crate::bench::showcases::{self, Showcase, ShowcaseSuite, ShowcaseVerification};
 use crate::config::ProviderConfig;
 use crate::intent;
 use crate::intent::spec::IntentStatus;
@@ -32,6 +34,10 @@ pub struct BenchmarkConfig {
     pub showcase_filter: Option<Vec<String>>,
     /// Optional provider name filter.
     pub provider_filter: Option<Vec<String>>,
+    /// Optional benchmark suite filter.
+    pub suite_filter: Option<ShowcaseSuite>,
+    /// Whether to run only the selected suite's low-budget smoke subset.
+    pub smoke: bool,
 }
 
 /// Runs the full benchmark suite.
@@ -53,8 +59,15 @@ pub async fn run_benchmark<F>(
 where
     F: Fn(&Path) -> Result<(), anyhow::Error> + Send + Sync + 'static,
 {
-    let showcase_refs: Vec<&Showcase> =
-        showcases::filter_showcases(config.showcase_filter.as_deref());
+    let showcase_refs: Vec<&Showcase> = if config.suite_filter.is_none() && !config.smoke {
+        showcases::filter_showcases(config.showcase_filter.as_deref())
+    } else {
+        showcases::filter_showcases_with_options(
+            config.showcase_filter.as_deref(),
+            config.suite_filter,
+            config.smoke,
+        )
+    };
 
     if showcase_refs.is_empty() {
         return Err("no showcases match the given filter".to_string());
@@ -81,7 +94,7 @@ where
 
     let mut all_results: Vec<BenchmarkResult> = Vec::with_capacity(total_runs);
 
-    for showcase in &showcase_refs {
+    for showcase in showcase_refs {
         let spec =
             showcases::parse_showcase(showcase).map_err(|e| format!("invalid showcase: {e}"))?;
 
@@ -110,7 +123,7 @@ where
                     eprintln!("  [{showcase_name} / {prov_name}] attempt {attempt}/{attempts}",);
 
                     let result = run_single(
-                        showcase_name,
+                        showcase,
                         provider.as_ref(),
                         &spec_clone,
                         attempt,
@@ -164,7 +177,7 @@ where
 
 /// Runs a single benchmark attempt in an isolated temp workspace.
 async fn run_single<F>(
-    showcase_name: &str,
+    showcase: &Showcase,
     provider: &dyn LlmProvider,
     spec: &crate::intent::spec::IntentSpec,
     attempt: u32,
@@ -175,39 +188,115 @@ where
 {
     let start = Instant::now();
 
+    if let ShowcaseVerification::ProcessEvidence {
+        evidence_kind,
+        expected_route,
+        expected_json_fields,
+        verification_gap,
+    } = showcase.verification
+    {
+        return BenchmarkResult {
+            showcase: showcase.name.to_string(),
+            task_id: Some(showcase.name.to_string()),
+            suite: Some(showcase.suite.as_str().to_string()),
+            tags: showcase.tags.iter().map(|tag| (*tag).to_string()).collect(),
+            provider: provider.name().to_string(),
+            attempt,
+            success: false,
+            first_pass_success: Some(false),
+            repair_attempted: false,
+            repair_success: None,
+            error_category: Some(ErrorCategory::EvidenceRequired),
+            error_message: Some(verification_gap.to_string()),
+            dominant_error_code: Some("broader_evidence_required".to_string()),
+            mutation_retry_count: None,
+            repair_retry_count: None,
+            total_retry_count: None,
+            provider_usage: ProviderUsageSummary::unavailable("process_evidence_not_executed"),
+            evidence: Some(BenchmarkEvidence {
+                kind: evidence_kind.to_string(),
+                status: "broader_evidence_required".to_string(),
+                detail: verification_gap.to_string(),
+                command: None,
+                expected_route: Some(expected_route.to_string()),
+                expected_json_fields: expected_json_fields
+                    .iter()
+                    .map(|field| (*field).to_string())
+                    .collect(),
+                verification_gap: Some(verification_gap.to_string()),
+                artifact_path: None,
+            }),
+            tests_passed: 0,
+            tests_total: spec.test_cases.len(),
+            duration_secs: start.elapsed().as_secs_f64(),
+        };
+    }
+
     let result = run_in_temp_workspace(provider, spec, init_workspace).await;
 
     let duration_secs = start.elapsed().as_secs_f64();
 
     match result {
-        Ok((tests_passed, tests_total)) => BenchmarkResult {
-            showcase: showcase_name.to_string(),
+        Ok(outcome) => BenchmarkResult {
+            showcase: showcase.name.to_string(),
+            task_id: Some(showcase.name.to_string()),
+            suite: Some(showcase.suite.as_str().to_string()),
+            tags: showcase.tags.iter().map(|tag| (*tag).to_string()).collect(),
             provider: provider.name().to_string(),
             attempt,
-            success: tests_passed == tests_total,
-            error_category: if tests_passed < tests_total {
+            success: outcome.tests_passed == outcome.tests_total,
+            first_pass_success: Some(outcome.first_pass_success),
+            repair_attempted: outcome.repair_attempted,
+            repair_success: outcome.repair_success,
+            error_category: if outcome.tests_passed < outcome.tests_total {
                 Some(ErrorCategory::LogicError)
             } else {
                 None
             },
-            error_message: if tests_passed < tests_total {
-                Some(format!("only {tests_passed}/{tests_total} tests passed"))
+            error_message: if outcome.tests_passed < outcome.tests_total {
+                Some(format!(
+                    "only {}/{} tests passed",
+                    outcome.tests_passed, outcome.tests_total
+                ))
             } else {
                 None
             },
-            tests_passed,
-            tests_total,
+            dominant_error_code: outcome.dominant_error_code,
+            mutation_retry_count: outcome.mutation_retry_count,
+            repair_retry_count: outcome.repair_retry_count,
+            total_retry_count: outcome.total_retry_count,
+            provider_usage: ProviderUsageSummary::unavailable(
+                "provider_response_did_not_expose_usage",
+            ),
+            evidence: None,
+            tests_passed: outcome.tests_passed,
+            tests_total: outcome.tests_total,
             duration_secs,
         },
         Err(msg) => {
             let category = categorize_error(&msg);
+            let error_codes = extract_error_codes(&msg);
             BenchmarkResult {
-                showcase: showcase_name.to_string(),
+                showcase: showcase.name.to_string(),
+                task_id: Some(showcase.name.to_string()),
+                suite: Some(showcase.suite.as_str().to_string()),
+                tags: showcase.tags.iter().map(|tag| (*tag).to_string()).collect(),
                 provider: provider.name().to_string(),
                 attempt,
                 success: false,
+                first_pass_success: Some(false),
+                repair_attempted: msg.contains("[Repair] Attempting repair"),
+                repair_success: None,
                 error_category: Some(category),
                 error_message: Some(msg),
+                dominant_error_code: error_codes.first().cloned(),
+                mutation_retry_count: None,
+                repair_retry_count: None,
+                total_retry_count: None,
+                provider_usage: ProviderUsageSummary::unavailable(
+                    "provider_response_did_not_expose_usage",
+                ),
+                evidence: None,
                 tests_passed: 0,
                 tests_total: spec.test_cases.len(),
                 duration_secs,
@@ -218,12 +307,12 @@ where
 
 /// Creates an isolated workspace, saves the intent, and runs `run_execute`.
 ///
-/// Returns `(tests_passed, tests_total)` on success.
+/// Returns structured test and repair metrics on success.
 async fn run_in_temp_workspace<F>(
     provider: &dyn LlmProvider,
     spec: &crate::intent::spec::IntentSpec,
     init_workspace: &F,
-) -> Result<(usize, usize), String>
+) -> Result<IntentExecutionMetrics, String>
 where
     F: Fn(&Path) -> Result<(), anyhow::Error>,
 {
@@ -253,15 +342,67 @@ where
 
     let tests_total = spec.test_cases.len();
     let tests_passed = final_spec.execution.as_ref().map_or(0, |e| e.tests_passed);
+    let repair_attempted = log
+        .iter()
+        .any(|line| line.contains("[Repair] Attempting repair"));
+    let error_codes = extract_error_codes(&log.join("\n"));
 
     if ok {
-        Ok((tests_passed, tests_total))
+        Ok(IntentExecutionMetrics {
+            tests_passed,
+            tests_total,
+            first_pass_success: !repair_attempted,
+            repair_attempted,
+            repair_success: repair_attempted.then_some(true),
+            dominant_error_code: error_codes.first().cloned(),
+            mutation_retry_count: None,
+            repair_retry_count: None,
+            total_retry_count: None,
+        })
     } else {
         // The intent pipeline returned false (failure)
         Err(format!(
             "intent execution failed: {tests_passed}/{tests_total} tests passed"
         ))
     }
+}
+
+/// Metrics inferred from an intent execution run.
+struct IntentExecutionMetrics {
+    /// Number of verifier tests that passed.
+    tests_passed: usize,
+    /// Number of verifier tests selected.
+    tests_total: usize,
+    /// Whether verification passed before any repair cycle.
+    first_pass_success: bool,
+    /// Whether a repair cycle was attempted.
+    repair_attempted: bool,
+    /// Whether repair converted the run into a success.
+    repair_success: Option<bool>,
+    /// Dominant DUUMBI error code, when one is visible in logs.
+    dominant_error_code: Option<String>,
+    /// Mutation retry count, when exposed by the execute path.
+    mutation_retry_count: Option<u32>,
+    /// Repair retry count, when exposed by the execute path.
+    repair_retry_count: Option<u32>,
+    /// Total retry count, when exposed by the execute path.
+    total_retry_count: Option<u32>,
+}
+
+fn extract_error_codes(text: &str) -> Vec<String> {
+    let mut codes: Vec<String> = text
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|word| {
+            word.len() == 4
+                && word.starts_with('E')
+                && word[1..].chars().all(|c| c.is_ascii_digit())
+        })
+        .map(ToString::to_string)
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .collect();
+    codes.sort();
+    codes
 }
 
 /// Tries to load an archived intent (moved to history/ after execution).

--- a/src/bench/showcases.rs
+++ b/src/bench/showcases.rs
@@ -5,6 +5,44 @@
 
 use crate::intent::spec::IntentSpec;
 
+/// Benchmark suite classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShowcaseSuite {
+    /// Existing six-showcase benchmark suite.
+    Core,
+    /// Scaled multi-function and multi-module benchmark suite.
+    Scaled,
+}
+
+impl ShowcaseSuite {
+    /// Returns the stable report string for the suite.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Core => "core",
+            Self::Scaled => "scaled",
+        }
+    }
+}
+
+/// Verification strategy expected for a benchmark showcase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShowcaseVerification {
+    /// Verify with existing i64 intent test cases.
+    I64Tests,
+    /// Requires broader process evidence beyond the current i64 verifier.
+    ProcessEvidence {
+        /// Evidence kind written to benchmark reports.
+        evidence_kind: &'static str,
+        /// Loopback route expected for process evidence.
+        expected_route: &'static str,
+        /// JSON fields expected in process evidence.
+        expected_json_fields: &'static [&'static str],
+        /// Current verification gap to report until automated process checks exist.
+        verification_gap: &'static str,
+    },
+}
+
 /// Calculator: add, sub, mul, div on i64.
 pub const CALCULATOR_YAML: &str = include_str!("showcases/calculator.yaml");
 
@@ -23,13 +61,39 @@ pub const MULTI_MODULE_YAML: &str = include_str!("showcases/multi_module.yaml");
 /// String operations: length_of_hello, hello_contains_ell.
 pub const STRING_OPS_YAML: &str = include_str!("showcases/string_ops.yaml");
 
+/// Scaled multi-function math pipeline.
+pub const SCALED_MATH_PIPELINE_YAML: &str = include_str!("showcases/scaled_math_pipeline.yaml");
+
+/// Scaled cross-module stats library.
+pub const SCALED_CROSS_MODULE_STATS_YAML: &str =
+    include_str!("showcases/scaled_cross_module_stats.yaml");
+
+/// Scaled branch/recursion showcase.
+pub const SCALED_BRANCH_RECURSION_YAML: &str =
+    include_str!("showcases/scaled_branch_recursion.yaml");
+
+/// Scaled string/array-style module showcase.
+pub const SCALED_STRING_ARRAY_YAML: &str = include_str!("showcases/scaled_string_array.yaml");
+
+/// Scaled HTTP + SQLite + JSON composition showcase.
+pub const SCALED_HTTP_SQLITE_JSON_YAML: &str =
+    include_str!("showcases/scaled_http_sqlite_json.yaml");
+
 /// A showcase entry with its name and embedded YAML source.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct Showcase {
     /// Short identifier (e.g. `"calculator"`).
     pub name: &'static str,
     /// Raw YAML source.
     pub yaml: &'static str,
+    /// Benchmark suite this showcase belongs to.
+    pub suite: ShowcaseSuite,
+    /// Whether the showcase is part of the low-budget smoke subset.
+    pub smoke: bool,
+    /// Feature tags used in scaled benchmark reports.
+    pub tags: &'static [&'static str],
+    /// Verification strategy for the showcase.
+    pub verification: ShowcaseVerification,
 }
 
 /// All available showcases, in canonical order.
@@ -37,26 +101,99 @@ pub const ALL_SHOWCASES: &[Showcase] = &[
     Showcase {
         name: "calculator",
         yaml: CALCULATOR_YAML,
+        suite: ShowcaseSuite::Core,
+        smoke: true,
+        tags: &["single_module", "multi_function", "i64"],
+        verification: ShowcaseVerification::I64Tests,
     },
     Showcase {
         name: "fibonacci",
         yaml: FIBONACCI_YAML,
+        suite: ShowcaseSuite::Core,
+        smoke: false,
+        tags: &["recursion", "i64"],
+        verification: ShowcaseVerification::I64Tests,
     },
     Showcase {
         name: "sorting",
         yaml: SORTING_YAML,
+        suite: ShowcaseSuite::Core,
+        smoke: false,
+        tags: &["branch", "i64"],
+        verification: ShowcaseVerification::I64Tests,
     },
     Showcase {
         name: "state_machine",
         yaml: STATE_MACHINE_YAML,
+        suite: ShowcaseSuite::Core,
+        smoke: false,
+        tags: &["branch", "i64"],
+        verification: ShowcaseVerification::I64Tests,
     },
     Showcase {
         name: "multi_module",
         yaml: MULTI_MODULE_YAML,
+        suite: ShowcaseSuite::Core,
+        smoke: true,
+        tags: &["multi_module", "cross_module", "i64"],
+        verification: ShowcaseVerification::I64Tests,
     },
     Showcase {
         name: "string_ops",
         yaml: STRING_OPS_YAML,
+        suite: ShowcaseSuite::Core,
+        smoke: false,
+        tags: &["string", "i64"],
+        verification: ShowcaseVerification::I64Tests,
+    },
+];
+
+/// Scaled showcases for DUUMBI-689, in canonical order.
+pub const SCALED_SHOWCASES: &[Showcase] = &[
+    Showcase {
+        name: "scaled_math_pipeline",
+        yaml: SCALED_MATH_PIPELINE_YAML,
+        suite: ShowcaseSuite::Scaled,
+        smoke: true,
+        tags: &["scaled", "multi_function", "single_module", "i64"],
+        verification: ShowcaseVerification::I64Tests,
+    },
+    Showcase {
+        name: "scaled_cross_module_stats",
+        yaml: SCALED_CROSS_MODULE_STATS_YAML,
+        suite: ShowcaseSuite::Scaled,
+        smoke: true,
+        tags: &["scaled", "multi_module", "cross_module", "i64"],
+        verification: ShowcaseVerification::I64Tests,
+    },
+    Showcase {
+        name: "scaled_branch_recursion",
+        yaml: SCALED_BRANCH_RECURSION_YAML,
+        suite: ShowcaseSuite::Scaled,
+        smoke: false,
+        tags: &["scaled", "branch", "recursion", "i64"],
+        verification: ShowcaseVerification::I64Tests,
+    },
+    Showcase {
+        name: "scaled_string_array",
+        yaml: SCALED_STRING_ARRAY_YAML,
+        suite: ShowcaseSuite::Scaled,
+        smoke: false,
+        tags: &["scaled", "string", "array_like", "i64"],
+        verification: ShowcaseVerification::I64Tests,
+    },
+    Showcase {
+        name: "scaled_http_sqlite_json",
+        yaml: SCALED_HTTP_SQLITE_JSON_YAML,
+        suite: ShowcaseSuite::Scaled,
+        smoke: true,
+        tags: &["scaled", "http", "sqlite", "json", "process_evidence"],
+        verification: ShowcaseVerification::ProcessEvidence {
+            evidence_kind: "loopback_http_sqlite_json",
+            expected_route: "/facts",
+            expected_json_fields: &["service", "route", "count", "first_fact", "storage"],
+            verification_gap: "current verifier does not check HTTP JSON payload semantics",
+        },
     },
 ];
 
@@ -74,13 +211,42 @@ pub fn parse_showcase(showcase: &Showcase) -> Result<IntentSpec, String> {
 /// If `filter` is `None`, returns all showcases.
 #[must_use]
 pub fn filter_showcases(filter: Option<&[String]>) -> Vec<&'static Showcase> {
-    match filter {
-        None => ALL_SHOWCASES.iter().collect(),
-        Some(names) => ALL_SHOWCASES
+    filter_showcases_with_options(filter, None, false)
+}
+
+/// Returns showcases matching optional names, suite, and smoke selection.
+///
+/// The default with no suite and no explicit names remains the historical core
+/// suite. Explicit names can target either core or scaled showcases.
+#[must_use]
+pub fn filter_showcases_with_options(
+    filter: Option<&[String]>,
+    suite: Option<ShowcaseSuite>,
+    smoke: bool,
+) -> Vec<&'static Showcase> {
+    let candidates: Vec<&Showcase> = if filter.is_some() {
+        ALL_SHOWCASES
             .iter()
+            .chain(SCALED_SHOWCASES.iter())
+            .collect()
+    } else {
+        match suite {
+            None | Some(ShowcaseSuite::Core) => ALL_SHOWCASES.iter().collect(),
+            Some(ShowcaseSuite::Scaled) => SCALED_SHOWCASES.iter().collect(),
+        }
+    };
+
+    match filter {
+        None => candidates,
+        Some(names) => candidates
+            .into_iter()
             .filter(|s| names.iter().any(|n| n == s.name))
             .collect(),
     }
+    .into_iter()
+    .filter(|s| !smoke || s.smoke)
+    .filter(|s| suite.is_none_or(|expected| s.suite == expected))
+    .collect()
 }
 
 #[cfg(test)]
@@ -106,6 +272,48 @@ mod tests {
     }
 
     #[test]
+    fn scaled_showcases_parse_and_include_required_features() {
+        let mut has_cross_module = false;
+        let mut has_http_sqlite_json = false;
+
+        for showcase in SCALED_SHOWCASES {
+            let spec = parse_showcase(showcase)
+                .unwrap_or_else(|e| panic!("showcase '{}' failed to parse: {e}", showcase.name));
+            assert!(
+                !spec.intent.is_empty(),
+                "showcase '{}' has empty intent",
+                showcase.name
+            );
+            assert!(
+                !showcase.tags.is_empty(),
+                "showcase '{}' has no feature tags",
+                showcase.name
+            );
+            has_cross_module |= showcase.tags.contains(&"cross_module");
+            has_http_sqlite_json |= showcase.tags.contains(&"http")
+                && showcase.tags.contains(&"sqlite")
+                && showcase.tags.contains(&"json");
+
+            if matches!(showcase.verification, ShowcaseVerification::I64Tests) {
+                assert!(
+                    !spec.test_cases.is_empty(),
+                    "showcase '{}' has no verifier test cases",
+                    showcase.name
+                );
+            }
+        }
+
+        assert!(
+            has_cross_module,
+            "scaled suite must include cross-module behavior"
+        );
+        assert!(
+            has_http_sqlite_json,
+            "scaled suite must include HTTP + SQLite + JSON behavior"
+        );
+    }
+
+    #[test]
     fn filter_showcases_returns_subset() {
         let names = vec!["calculator".to_string(), "fibonacci".to_string()];
         let filtered = filter_showcases(Some(&names));
@@ -118,5 +326,18 @@ mod tests {
     fn filter_showcases_none_returns_all() {
         let all = filter_showcases(None);
         assert_eq!(all.len(), ALL_SHOWCASES.len());
+    }
+
+    #[test]
+    fn scaled_smoke_filter_includes_process_evidence_case() {
+        let filtered = filter_showcases_with_options(None, Some(ShowcaseSuite::Scaled), true);
+        assert!(filtered.iter().any(|s| s.name == "scaled_math_pipeline"));
+        assert!(
+            filtered
+                .iter()
+                .any(|s| s.name == "scaled_cross_module_stats")
+        );
+        assert!(filtered.iter().any(|s| s.name == "scaled_http_sqlite_json"));
+        assert!(filtered.iter().all(|s| s.smoke));
     }
 }

--- a/src/bench/showcases/scaled_branch_recursion.yaml
+++ b/src/bench/showcases/scaled_branch_recursion.yaml
@@ -1,0 +1,28 @@
+intent: "Build a branch-heavy recurrence module with tribonacci(n) returning the nth tribonacci number for i64 input"
+version: 1
+status: pending
+acceptance_criteria:
+  - "tribonacci(0) returns 0"
+  - "tribonacci(1) returns 1"
+  - "tribonacci(2) returns 1"
+  - "tribonacci(n) returns tribonacci(n-1) + tribonacci(n-2) + tribonacci(n-3) for n >= 3"
+  - "The implementation handles multiple branch base cases"
+modules:
+  create:
+    - "math/tribonacci"
+  modify:
+    - "app/main"
+test_cases:
+  - name: "base_zero"
+    function: "tribonacci"
+    args: [0]
+    expected_return: 0
+  - name: "base_two"
+    function: "tribonacci"
+    args: [2]
+    expected_return: 1
+  - name: "six"
+    function: "tribonacci"
+    args: [6]
+    expected_return: 13
+dependencies: []

--- a/src/bench/showcases/scaled_cross_module_stats.yaml
+++ b/src/bench/showcases/scaled_cross_module_stats.yaml
@@ -1,0 +1,28 @@
+intent: "Build a cross-module stats program where stats/core exports sum3 and average3 and stats/report computes spread_score using those exported helpers"
+version: 1
+status: pending
+acceptance_criteria:
+  - "stats/core defines sum3(a, b, c) and average3(a, b, c)"
+  - "stats/report defines spread_score(a, b, c) using stats/core helpers"
+  - "spread_score(a, b, c) returns sum3(a, b, c) - average3(a, b, c)"
+  - "The report module calls exported functions from the core module instead of duplicating them"
+modules:
+  create:
+    - "stats/core"
+    - "stats/report"
+  modify:
+    - "app/main"
+test_cases:
+  - name: "balanced_values"
+    function: "spread_score"
+    args: [3, 6, 9]
+    expected_return: 12
+  - name: "small_values"
+    function: "spread_score"
+    args: [1, 2, 3]
+    expected_return: 4
+  - name: "mixed_values"
+    function: "spread_score"
+    args: [10, 5, 0]
+    expected_return: 10
+dependencies: []

--- a/src/bench/showcases/scaled_http_sqlite_json.yaml
+++ b/src/bench/showcases/scaled_http_sqlite_json.yaml
@@ -1,0 +1,19 @@
+intent: "Build a bounded loopback HTTP JSON facts endpoint backed by in-memory SQLite using the accepted DUUMBI stdlib HTTP, DB, and JSON modules"
+version: 1
+status: pending
+acceptance_criteria:
+  - "The program binds only to loopback"
+  - "The program uses in-memory SQLite to store a deterministic fact"
+  - "The program returns JSON with service, route, count, first_fact, and storage fields"
+  - "The program serves one bounded request on /facts"
+  - "The eval report records process evidence or an explicit verification gap until HTTP JSON verification is automated"
+modules:
+  create:
+    - "services/facts"
+  modify:
+    - "app/main"
+test_cases: []
+dependencies:
+  - "@duumbi/stdlib-db"
+  - "@duumbi/stdlib-json"
+  - "@duumbi/stdlib-server"

--- a/src/bench/showcases/scaled_math_pipeline.yaml
+++ b/src/bench/showcases/scaled_math_pipeline.yaml
@@ -1,0 +1,27 @@
+intent: "Build a score pipeline module with normalize_delta, weighted_score, and final_score functions on i64 values"
+version: 1
+status: pending
+acceptance_criteria:
+  - "normalize_delta(current, previous) returns current - previous"
+  - "weighted_score(delta, weight) returns delta * weight"
+  - "final_score(current, previous, weight, offset) returns weighted_score(normalize_delta(current, previous), weight) + offset"
+  - "The functions are implemented as separate callable functions in one module"
+modules:
+  create:
+    - "metrics/pipeline"
+  modify:
+    - "app/main"
+test_cases:
+  - name: "positive_delta"
+    function: "final_score"
+    args: [15, 10, 3, 2]
+    expected_return: 17
+  - name: "negative_delta"
+    function: "final_score"
+    args: [7, 12, 2, 4]
+    expected_return: -6
+  - name: "zero_delta"
+    function: "final_score"
+    args: [9, 9, 5, 11]
+    expected_return: 11
+dependencies: []

--- a/src/bench/showcases/scaled_string_array.yaml
+++ b/src/bench/showcases/scaled_string_array.yaml
@@ -1,0 +1,27 @@
+intent: "Build a small utility module with constant string and array-like aggregate functions that return i64 evidence values"
+version: 1
+status: pending
+acceptance_criteria:
+  - "hello_world_length() returns the length of the concatenated string 'hello' + 'world'"
+  - "fixed_window_total() returns the sum of a fixed three-value window 4 + 5 + 6"
+  - "combined_text_and_window_score() returns hello_world_length() + fixed_window_total()"
+  - "The functions are separate and reusable inside one module"
+modules:
+  create:
+    - "util/scaled"
+  modify:
+    - "app/main"
+test_cases:
+  - name: "hello_world_length"
+    function: "hello_world_length"
+    args: []
+    expected_return: 10
+  - name: "fixed_window_total"
+    function: "fixed_window_total"
+    args: []
+    expected_return: 15
+  - name: "combined_score"
+    function: "combined_text_and_window_score"
+    args: []
+    expected_return: 25
+dependencies: []

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -101,6 +101,15 @@ pub enum CliLogMode {
     Rewrite,
 }
 
+/// Benchmark suite selected by `duumbi benchmark`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum BenchmarkSuiteArg {
+    /// Existing six-showcase benchmark suite.
+    Core,
+    /// Scaled intent-execute suite for multi-function and multi-module evidence.
+    Scaled,
+}
+
 impl From<CliLogMode> for crate::config::LogMode {
     fn from(value: CliLogMode) -> Self {
         match value {
@@ -248,6 +257,14 @@ pub enum Commands {
 
     /// Run benchmark showcases against configured LLM providers.
     Benchmark {
+        /// Benchmark suite to run. Defaults to the existing core suite.
+        #[arg(long, value_enum)]
+        suite: Option<BenchmarkSuiteArg>,
+
+        /// Run only the low-budget smoke subset of the selected suite.
+        #[arg(long)]
+        smoke: bool,
+
         /// Run only the named showcase(s) (comma-separated).
         #[arg(long, value_delimiter = ',')]
         showcase: Option<Vec<String>>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -471,13 +471,27 @@ async fn run(cli: Cli) -> Result<i32> {
             success_exit(run_knowledge(subcommand, workspace))
         }
         Commands::Benchmark {
+            suite,
+            smoke,
             showcase,
             provider,
             attempts,
             output,
             ci,
             baseline,
-        } => run_benchmark(showcase, provider, attempts, output, ci, baseline).await,
+        } => {
+            run_benchmark(BenchmarkRunArgs {
+                suite,
+                smoke,
+                showcase,
+                provider_filter: provider,
+                attempts,
+                output,
+                ci,
+                baseline,
+            })
+            .await
+        }
         Commands::Phase15E2e {
             task,
             provider,
@@ -1082,14 +1096,28 @@ async fn studio(port: u16, _dev: bool) -> Result<i32> {
 }
 
 /// Runs the benchmark suite against configured LLM providers.
-async fn run_benchmark(
+struct BenchmarkRunArgs {
+    suite: Option<cli::BenchmarkSuiteArg>,
+    smoke: bool,
     showcase: Option<Vec<String>>,
     provider_filter: Option<Vec<String>>,
-    explicit_attempts: Option<u32>,
+    attempts: Option<u32>,
     output: Option<PathBuf>,
     ci: bool,
     baseline: Option<PathBuf>,
-) -> Result<i32> {
+}
+
+async fn run_benchmark(args: BenchmarkRunArgs) -> Result<i32> {
+    let BenchmarkRunArgs {
+        suite,
+        smoke,
+        showcase,
+        provider_filter,
+        attempts: explicit_attempts,
+        output,
+        ci,
+        baseline,
+    } = args;
     let workspace = PathBuf::from(".");
     let cfg = config::load_effective_config(&workspace)?.config;
 
@@ -1108,6 +1136,11 @@ async fn run_benchmark(
         providers,
         showcase_filter: showcase,
         provider_filter,
+        suite_filter: suite.map(|suite| match suite {
+            cli::BenchmarkSuiteArg::Core => bench::showcases::ShowcaseSuite::Core,
+            cli::BenchmarkSuiteArg::Scaled => bench::showcases::ShowcaseSuite::Scaled,
+        }),
+        smoke,
     };
 
     let started_at = iso8601_now();

--- a/tests/integration_phase9c.rs
+++ b/tests/integration_phase9c.rs
@@ -6,10 +6,12 @@
 //! regression detection.
 
 use duumbi::bench::report::{
-    BenchmarkReport, BenchmarkResult, ErrorCategory, ProviderStats, ShowcaseSummary,
-    categorize_error, check_kill_criterion, detect_regressions,
+    BenchmarkReport, BenchmarkResult, ErrorCategory, ProviderStats, ProviderUsageSummary,
+    ShowcaseSummary, categorize_error, check_kill_criterion, detect_regressions,
 };
-use duumbi::bench::showcases::{self, ALL_SHOWCASES, parse_showcase};
+use duumbi::bench::showcases::{
+    self, ALL_SHOWCASES, SCALED_SHOWCASES, ShowcaseSuite, parse_showcase,
+};
 
 // ---------------------------------------------------------------------------
 // Showcase YAML parsing
@@ -134,6 +136,45 @@ fn filter_showcases_returns_empty_for_unknown_name() {
     assert!(filtered.is_empty());
 }
 
+#[test]
+fn scaled_showcases_parse_and_cover_required_features() {
+    assert!(
+        SCALED_SHOWCASES.len() >= 5,
+        "expected at least five scaled showcases"
+    );
+
+    let mut has_multi_function = false;
+    let mut has_cross_module = false;
+    let mut has_http_sqlite_json = false;
+
+    for showcase in SCALED_SHOWCASES {
+        let spec = parse_showcase(showcase)
+            .unwrap_or_else(|e| panic!("showcase '{}' failed to parse: {e}", showcase.name));
+        assert_eq!(showcase.suite, ShowcaseSuite::Scaled);
+        assert!(!spec.intent.is_empty());
+        has_multi_function |= showcase.tags.contains(&"multi_function");
+        has_cross_module |= showcase.tags.contains(&"cross_module");
+        has_http_sqlite_json |= showcase.tags.contains(&"http")
+            && showcase.tags.contains(&"sqlite")
+            && showcase.tags.contains(&"json");
+    }
+
+    assert!(has_multi_function);
+    assert!(has_cross_module);
+    assert!(has_http_sqlite_json);
+}
+
+#[test]
+fn scaled_smoke_subset_is_low_budget_and_includes_process_evidence() {
+    let smoke = showcases::filter_showcases_with_options(None, Some(ShowcaseSuite::Scaled), true);
+    let names: Vec<&str> = smoke.iter().map(|showcase| showcase.name).collect();
+
+    assert!(names.contains(&"scaled_math_pipeline"));
+    assert!(names.contains(&"scaled_cross_module_stats"));
+    assert!(names.contains(&"scaled_http_sqlite_json"));
+    assert!(smoke.iter().all(|showcase| showcase.smoke));
+}
+
 // ---------------------------------------------------------------------------
 // Error categorization
 // ---------------------------------------------------------------------------
@@ -253,9 +294,15 @@ fn categorize_error_logic_default() {
 fn make_result(showcase: &str, provider: &str, attempt: u32, success: bool) -> BenchmarkResult {
     BenchmarkResult {
         showcase: showcase.to_string(),
+        task_id: Some(showcase.to_string()),
+        suite: Some("core".to_string()),
+        tags: Vec::new(),
         provider: provider.to_string(),
         attempt,
         success,
+        first_pass_success: Some(success),
+        repair_attempted: false,
+        repair_success: None,
         error_category: if success {
             None
         } else {
@@ -266,6 +313,12 @@ fn make_result(showcase: &str, provider: &str, attempt: u32, success: bool) -> B
         } else {
             Some("test failed".to_string())
         },
+        dominant_error_code: None,
+        mutation_retry_count: None,
+        repair_retry_count: None,
+        total_retry_count: Some(0),
+        provider_usage: ProviderUsageSummary::unavailable("provider_response_did_not_expose_usage"),
+        evidence: None,
         tests_passed: if success { 4 } else { 2 },
         tests_total: 4,
         duration_secs: 3.5,
@@ -293,6 +346,11 @@ fn report_from_results_aggregates_correctly() {
     assert_eq!(calc.name, "calculator");
     assert_eq!(calc.total_attempts, 4);
     assert_eq!(calc.successes, 3);
+    assert_eq!(report.summary.total_results, 4);
+    assert_eq!(report.summary.successes, 3);
+    assert_eq!(report.summary.first_pass_attempts, 4);
+    assert_eq!(report.summary.first_pass_successes, 3);
+    assert_eq!(report.summary.usage_unavailable, 4);
 
     // Anthropic: 2/2 = 100%
     let anthropic = calc
@@ -311,6 +369,58 @@ fn report_from_results_aggregates_correctly() {
         .expect("openai");
     assert_eq!(openai.successes, 1);
     assert!((openai.success_rate - 0.5).abs() < f64::EPSILON);
+}
+
+#[test]
+fn report_summary_tracks_repair_usage_and_failure_patterns() {
+    let mut first_pass = make_result("scaled_math_pipeline", "minimax", 1, true);
+    first_pass.suite = Some("scaled".to_string());
+    first_pass.first_pass_success = Some(true);
+
+    let mut repaired = make_result("scaled_cross_module_stats", "minimax", 1, true);
+    repaired.suite = Some("scaled".to_string());
+    repaired.first_pass_success = Some(false);
+    repaired.repair_attempted = true;
+    repaired.repair_success = Some(true);
+    repaired.total_retry_count = Some(2);
+    repaired.provider_usage = ProviderUsageSummary {
+        available: true,
+        request_count: Some(3),
+        prompt_tokens: Some(1000),
+        completion_tokens: Some(250),
+        total_tokens: Some(1250),
+        estimated_cost_usd: Some(0.02),
+        unavailable_reason: None,
+    };
+
+    let mut failed = make_result("scaled_http_sqlite_json", "minimax", 1, false);
+    failed.suite = Some("scaled".to_string());
+    failed.error_category = Some(ErrorCategory::EvidenceRequired);
+    failed.dominant_error_code = Some("broader_evidence_required".to_string());
+
+    let report = BenchmarkReport::from_results(
+        vec![first_pass, repaired, failed],
+        1,
+        "2026-06-16T00:00:00Z".to_string(),
+        "2026-06-16T00:01:00Z".to_string(),
+    );
+
+    assert_eq!(report.summary.total_results, 3);
+    assert_eq!(report.summary.first_pass_successes, 1);
+    assert_eq!(report.summary.repair_attempts, 1);
+    assert_eq!(report.summary.repair_successes, 1);
+    assert_eq!(report.summary.total_retry_count, 2);
+    assert_eq!(report.summary.usage_available, 1);
+    assert_eq!(report.summary.usage_unavailable, 2);
+    assert_eq!(report.summary.total_estimated_cost_usd, Some(0.02));
+    assert_eq!(
+        report.summary.dominant_error_codes["broader_evidence_required"],
+        1
+    );
+    assert_eq!(
+        report.summary.top_failure_patterns[0].pattern,
+        "broader_evidence_required"
+    );
 }
 
 #[test]
@@ -579,6 +689,9 @@ fn error_category_serializes_as_snake_case() {
 
     let json = serde_json::to_string(&ErrorCategory::MutationFailed).expect("serialize");
     assert_eq!(json, "\"mutation_failed\"");
+
+    let json = serde_json::to_string(&ErrorCategory::EvidenceRequired).expect("serialize");
+    assert_eq!(json, "\"evidence_required\"");
 }
 
 #[test]
@@ -590,6 +703,7 @@ fn error_category_roundtrip() {
         ErrorCategory::Crash,
         ErrorCategory::ProviderError,
         ErrorCategory::MutationFailed,
+        ErrorCategory::EvidenceRequired,
     ] {
         let json = serde_json::to_string(&cat).expect("serialize");
         let parsed: ErrorCategory = serde_json::from_str(&json).expect("deserialize");


### PR DESCRIPTION
## Stage 10 Implementation

Related to #689.
Product spec artifact: #721.
Technical spec artifact: #722.

Workflow note: this implementation PR must leave the execution issue open for Stage 11 review and Stage 12 closure.

## Scope

- Adds `duumbi benchmark --suite <core|scaled>` and `--smoke` without changing the default core benchmark behavior.
- Adds the DUUMBI-689 scaled showcase corpus for multi-function, cross-module, branch/recursion, string/array-style, and HTTP + SQLite + JSON process-evidence coverage.
- Extends benchmark reports with task ids, suite/tags, first-pass and repair signals, retry placeholders, provider usage availability, dominant error codes, and top failure-pattern aggregation.
- Records live scaled smoke evidence and preview limitations under `docs/e2e/`.

## Ralph Cycle Evidence

Cycle: Resource-permitted Ralph cycle, no external code-edit agent.
Resource policy: no human approval required; live provider smoke was bounded to the scaled smoke subset, one provider, one attempt, expected cost below USD 1.

Local checks run:

- `target/debug/duumbi benchmark --help` passed and showed `--suite` / `--smoke`.
- `cargo build` passed.
- `cargo fmt --check` passed.
- `cargo test --test integration_phase9c` passed.
- `cargo test bench::` passed.
- `cargo clippy --all-targets -- -D warnings` passed.
- `cargo test --all` passed.
- `git diff --check` passed.

Live E2E smoke:

- Command shape: `duumbi benchmark --suite scaled --smoke --provider minimax:auto:primary:MINIMAX_API_KEY --attempts 1` in an isolated temporary workspace.
- Result: 3 scaled smoke rows executed; 0 success rows.
- Expected preview failures were captured honestly: two `logic_error` i64 rows and one `evidence_required` HTTP/SQLite/JSON row.
- Retained report: `docs/e2e/results/duumbi-689-scaled-smoke-20260616.md`.
- Known limitations: `docs/e2e/duumbi-689-known-limitations.md`.

## Self-Review

Codex self-review: clean. The implementation stays inside the approved specs and does not claim unsupported HTTP/SQLite/JSON semantic validation. Provider usage is reported as unavailable when not exposed by the current execution path.

AI review plan: request Stage 11 implementation review through `.github/workflows/implementation-review-request.yml`. Greptile was not invoked from Stage 10.
