### PR TITLE
Embed vendored SQLite fallback for runtime compilation

### DIFF
--- a/src/compiler/linker.rs
+++ b/src/compiler/linker.rs
@@ -11,6 +11,9 @@ use crate::errors::codes;
 
 use super::CompileError;
 
+const SQLITE3_C_SOURCE: &str = include_str!("../../runtime/third_party/sqlite/sqlite3.c");
+const SQLITE3_H_SOURCE: &str = include_str!("../../runtime/third_party/sqlite/sqlite3.h");
+
 #[cfg(test)]
 static RUNTIME_COMPILE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
@@ -103,11 +106,12 @@ fn ensure_runtime_deps_present(runtime_c: &Path) -> Result<(), CompileError> {
         .join("sqlite");
     let source_c = source_dir.join("sqlite3.c");
     let source_h = source_dir.join("sqlite3.h");
+    fs::create_dir_all(&sqlite_dir).map_err(|e| CompileError::LinkFailed {
+        code: codes::E008_LINK_FAILED,
+        message: format!("Failed to create temp SQLite runtime directory: {e}"),
+    })?;
+
     if source_dir != sqlite_dir && source_c.exists() && source_h.exists() {
-        fs::create_dir_all(&sqlite_dir).map_err(|e| CompileError::LinkFailed {
-            code: codes::E008_LINK_FAILED,
-            message: format!("Failed to create temp SQLite runtime directory: {e}"),
-        })?;
         fs::copy(&source_c, &sqlite_c).map_err(|e| CompileError::LinkFailed {
             code: codes::E008_LINK_FAILED,
             message: format!("Failed to copy vendored SQLite source: {e}"),
@@ -119,15 +123,15 @@ fn ensure_runtime_deps_present(runtime_c: &Path) -> Result<(), CompileError> {
         return Ok(());
     }
 
-    Err(CompileError::LinkFailed {
+    fs::write(&sqlite_c, SQLITE3_C_SOURCE).map_err(|e| CompileError::LinkFailed {
         code: codes::E008_LINK_FAILED,
-        message: format!(
-            "Vendored SQLite runtime sources are missing beside '{}'; expected '{}' and '{}'",
-            runtime_c.display(),
-            sqlite_c.display(),
-            sqlite_h.display()
-        ),
-    })
+        message: format!("Failed to write embedded SQLite source: {e}"),
+    })?;
+    fs::write(&sqlite_h, SQLITE3_H_SOURCE).map_err(|e| CompileError::LinkFailed {
+        code: codes::E008_LINK_FAILED,
+        message: format!("Failed to write embedded SQLite header: {e}"),
+    })?;
+    Ok(())
 }
 
 /// Compiles the C runtime shim to an object file.


### PR DESCRIPTION
### Motivation
- An intent run for a non-SQL program surfaced a linker/runtime error because `duumbi_runtime.c` requires SQLite sources during C runtime compilation even when the intent does not use SQL. 
- The build path must reliably materialize `third_party/sqlite` next to temporary `duumbi_runtime.c` so runtime compilation and linking do not fail on workspaces or environments that lack a source-tree copy of SQLite.

### Description
- Added embedded SQLite sources by including `../../runtime/third_party/sqlite/sqlite3.c` and `sqlite3.h` into the linker module as `SQLITE3_C_SOURCE` and `SQLITE3_H_SOURCE` so the code can materialize them when needed. 
- Updated `ensure_runtime_deps_present` in `src/compiler/linker.rs` to always create the temporary `third_party/sqlite` tree and to copy vendored files from the source tree when present. 
- If source-tree vendored files are not available, the code now writes the embedded SQLite C and header contents into the temporary runtime tree as a fallback. 
- Preserved the existing fast path that reuses or copies runtime `third_party/sqlite` files when they already exist beside the runtime file.

### Testing
- `cargo fmt --check` ran and succeeded. 
- Attempted the unit test `cargo test compile_runtime_copies_vendored_sqlite_to_temp_runtime_tree --lib`, but the run was blocked because the local `rustc` is `1.89.0` while current dependencies require `rustc 1.93.0`, so the test could not complete in this environment. 
- Automated static/format checks (`cargo fmt --check`) passed; the runtime materialization behavior is covered by the intended unit test which needs a compatible toolchain to run successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a315157b934833388ec0abbaaf92a19)