### PR TITLE
Add Linux clipboard support and stream intent-execute progress in TUI

### DIFF
--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -371,7 +371,7 @@ fn copy_text_to_clipboard(text: &str) -> Result<(), String> {
         ("xsel", &["--clipboard", "--input"]),
     ];
     let mut errors = Vec::new();
-    for (program, args) in candidates {
+    for &(program, args) in candidates {
         match write_clipboard_command(program, args, text) {
             Ok(()) => return Ok(()),
             Err(e) => errors.push(format!("{program}: {e}")),
@@ -427,7 +427,7 @@ fn read_text_from_clipboard() -> Result<String, String> {
         ("xsel", &["--clipboard", "--output"]),
     ];
     let mut errors = Vec::new();
-    for (program, args) in candidates {
+    for &(program, args) in candidates {
         match std::process::Command::new(program).args(args).output() {
             Ok(output) if output.status.success() => {
                 return String::from_utf8(output.stdout).map_err(|e| e.to_string());

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -363,9 +363,49 @@ fn copy_text_to_clipboard(text: &str) -> Result<(), String> {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(unix, not(target_os = "macos")))]
+fn copy_text_to_clipboard(text: &str) -> Result<(), String> {
+    let candidates: &[(&str, &[&str])] = &[
+        ("wl-copy", &[]),
+        ("xclip", &["-selection", "clipboard"]),
+        ("xsel", &["--clipboard", "--input"]),
+    ];
+    let mut errors = Vec::new();
+    for (program, args) in candidates {
+        match write_clipboard_command(program, args, text) {
+            Ok(()) => return Ok(()),
+            Err(e) => errors.push(format!("{program}: {e}")),
+        }
+    }
+    Err(format!(
+        "no Linux clipboard helper succeeded; install wl-clipboard, xclip, or xsel ({})",
+        errors.join("; ")
+    ))
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn write_clipboard_command(program: &str, args: &[&str], text: &str) -> Result<(), String> {
+    let mut child = std::process::Command::new(program)
+        .args(args)
+        .stdin(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| e.to_string())?;
+    let stdin = child
+        .stdin
+        .as_mut()
+        .ok_or_else(|| "clipboard stdin closed".to_string())?;
+    std::io::Write::write_all(stdin, text.as_bytes()).map_err(|e| e.to_string())?;
+    let status = child.wait().map_err(|e| e.to_string())?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(status.to_string())
+    }
+}
+
+#[cfg(not(any(unix, target_os = "macos")))]
 fn copy_text_to_clipboard(_text: &str) -> Result<(), String> {
-    Err("Clipboard shortcut integration is only available on macOS.".to_string())
+    Err("Clipboard shortcut integration is not available on this platform.".to_string())
 }
 
 #[cfg(target_os = "macos")]
@@ -379,9 +419,32 @@ fn read_text_from_clipboard() -> Result<String, String> {
     String::from_utf8(output.stdout).map_err(|e| e.to_string())
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(unix, not(target_os = "macos")))]
 fn read_text_from_clipboard() -> Result<String, String> {
-    Err("Clipboard shortcut integration is only available on macOS.".to_string())
+    let candidates: &[(&str, &[&str])] = &[
+        ("wl-paste", &["--no-newline"]),
+        ("xclip", &["-selection", "clipboard", "-out"]),
+        ("xsel", &["--clipboard", "--output"]),
+    ];
+    let mut errors = Vec::new();
+    for (program, args) in candidates {
+        match std::process::Command::new(program).args(args).output() {
+            Ok(output) if output.status.success() => {
+                return String::from_utf8(output.stdout).map_err(|e| e.to_string());
+            }
+            Ok(output) => errors.push(format!("{program}: {}", output.status)),
+            Err(e) => errors.push(format!("{program}: {e}")),
+        }
+    }
+    Err(format!(
+        "no Linux clipboard helper succeeded; install wl-clipboard, xclip, or xsel ({})",
+        errors.join("; ")
+    ))
+}
+
+#[cfg(not(any(unix, target_os = "macos")))]
+fn read_text_from_clipboard() -> Result<String, String> {
+    Err("Clipboard shortcut integration is not available on this platform.".to_string())
 }
 
 fn is_clipboard_shortcut(modifiers: KeyModifiers) -> bool {

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -390,11 +390,12 @@ fn write_clipboard_command(program: &str, args: &[&str], text: &str) -> Result<(
         .stdin(std::process::Stdio::piped())
         .spawn()
         .map_err(|e| e.to_string())?;
-    let stdin = child
+    let mut stdin = child
         .stdin
-        .as_mut()
+        .take()
         .ok_or_else(|| "clipboard stdin closed".to_string())?;
-    std::io::Write::write_all(stdin, text.as_bytes()).map_err(|e| e.to_string())?;
+    std::io::Write::write_all(&mut stdin, text.as_bytes()).map_err(|e| e.to_string())?;
+    drop(stdin);
     let status = child.wait().map_err(|e| e.to_string())?;
     if status.success() {
         Ok(())

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -889,6 +889,54 @@ where
     result
 }
 
+async fn run_with_pending_status_and_progress<T, F>(
+    terminal: &mut ratatui::DefaultTerminal,
+    app: &mut ReplApp,
+    textarea: &mut TextArea<'_>,
+    pending_label: &str,
+    progress_rx: &mut tokio::sync::mpsc::UnboundedReceiver<String>,
+    operation: F,
+) -> T
+where
+    F: Future<Output = T>,
+{
+    let was_working = app.working;
+    app.working = true;
+    app.push_output(pending_status_text(pending_label, 0), OutputStyle::Dim);
+    let _ = terminal.draw(|frame| app.render(frame, textarea));
+
+    tokio::pin!(operation);
+    let mut tick = tokio::time::interval(std::time::Duration::from_millis(280));
+    let mut frame = 1usize;
+    let result = loop {
+        tokio::select! {
+            result = &mut operation => break result,
+            Some(line) = progress_rx.recv() => {
+                app.pop_last_output_line();
+                app.push_output(line, OutputStyle::Normal);
+                app.push_output(pending_status_text(pending_label, frame), OutputStyle::Dim);
+                let _ = terminal.draw(|frame| app.render(frame, textarea));
+            }
+            _ = tick.tick() => {
+                app.replace_last_output_line(
+                    pending_status_text(pending_label, frame),
+                    OutputStyle::Dim,
+                );
+                let _ = terminal.draw(|frame| app.render(frame, textarea));
+                frame = frame.wrapping_add(1);
+            }
+        }
+    };
+
+    app.pop_last_output_line();
+    while let Ok(line) = progress_rx.try_recv() {
+        app.push_output(line, OutputStyle::Normal);
+    }
+    app.working = was_working;
+    let _ = terminal.draw(|frame| app.render(frame, textarea));
+    result
+}
+
 fn pending_agent_label(
     role: AgentRole,
     client: &dyn crate::agents::LlmProvider,
@@ -1657,14 +1705,29 @@ async fn handle_intent_execute(
     app.push_output(format!("Executing intent '{slug}'…"), OutputStyle::Dim);
 
     let mut log = Vec::new();
+    let (progress_tx, mut progress_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    let progress = move |line: &str| {
+        let _ = progress_tx.send(line.to_string());
+    };
     let pending_label = pending_agent_label(agent_role, client.as_ref(), "is executing the intent");
-    let result = run_with_pending_status(terminal, app, textarea, &pending_label, async {
-        intent::execute::run_execute(client.as_ref(), &workspace, slug, &mut log).await
-    })
+    let result = run_with_pending_status_and_progress(
+        terminal,
+        app,
+        textarea,
+        &pending_label,
+        &mut progress_rx,
+        async {
+            intent::execute::run_execute_with_progress(
+                client.as_ref(),
+                &workspace,
+                slug,
+                &mut log,
+                &progress,
+            )
+            .await
+        },
+    )
     .await;
-    for line in &log {
-        app.push_output(line, OutputStyle::Normal);
-    }
 
     finish_intent_execute(app, slug, result);
 }

--- a/src/intent/execute.rs
+++ b/src/intent/execute.rs
@@ -5,6 +5,7 @@
 //! with 3-step retry, then verifies test cases with the Verifier Agent.
 
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 use anyhow::{Context, Result};
 
@@ -106,6 +107,26 @@ pub fn run_execute_blocking_preflight_with_progress(
     }
     emit!("Preflight blocked execution before mutation side effects.".to_string());
     Ok(true)
+}
+
+fn capture_stream_chunk(
+    chunks: &Arc<Mutex<Vec<String>>>,
+    on_progress: &(dyn Fn(&str) + Send + Sync),
+    text: &str,
+) {
+    on_progress(text);
+    chunks
+        .lock()
+        .expect("invariant: mutex not poisoned")
+        .push(text.to_string());
+}
+
+fn drain_stream_chunks(log: &mut Vec<String>, chunks: &Arc<Mutex<Vec<String>>>) {
+    if let Ok(chunks) = chunks.lock()
+        && !chunks.is_empty()
+    {
+        log.push(chunks.concat());
+    }
 }
 
 /// Like [`run_execute`] but with a real-time progress callback.
@@ -261,14 +282,15 @@ pub async fn run_execute_with_progress(
             }
         }
 
-        // Streaming callback collects LLM text chunks into the log buffer.
+        // Streaming callback emits LLM text chunks immediately and collects
+        // them into the log buffer for the final execution transcript.
         // AI-AGENT: Arc<Mutex<>> is intentional here — the closure passed to
-        // mutate_streaming() must be 'static + Send + Sync, so we cannot borrow
-        // `log` directly. The Mutex guards the chunk buffer; it is drained once
-        // after the await returns. Do NOT replace with a channel: we need the
-        // chunks collected in order AND accessible after the future completes.
-        let log_clone = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        // mutate_streaming() runs while the LLM future is active, so we cannot
+        // borrow `log` directly. The Mutex guards the chunk buffer; it is
+        // drained once after the await returns.
+        let log_clone = Arc::new(Mutex::new(Vec::<String>::new()));
         let log_tx = log_clone.clone();
+        let progress = on_progress;
         let result = orchestrator::mutate_streaming_with_timeout(
             client,
             &source,
@@ -277,20 +299,12 @@ pub async fn run_execute_with_progress(
             agent_policy.mutation_timeout_secs,
             skip_call_validation,
             move |text| {
-                log_tx
-                    .lock()
-                    .expect("invariant: mutex not poisoned")
-                    .push(text.to_string());
+                capture_stream_chunk(&log_tx, progress, text);
             },
         )
         .await;
 
-        // Drain streamed chunks into log.
-        if let Ok(chunks) = log_clone.lock()
-            && !chunks.is_empty()
-        {
-            emit!(chunks.concat());
-        }
+        drain_stream_chunks(log, &log_clone);
 
         match result {
             Ok(orchestrator::MutationOutcome::NeedsClarification(question)) => {
@@ -343,9 +357,9 @@ pub async fn run_execute_with_progress(
                             prompt,
                             missing.join(", ")
                         );
-                        let retry_log =
-                            std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+                        let retry_log = Arc::new(Mutex::new(Vec::<String>::new()));
                         let retry_tx = retry_log.clone();
+                        let progress = on_progress;
                         let retry_result = orchestrator::mutate_streaming_with_timeout(
                             client,
                             &mutation_result.patched,
@@ -354,19 +368,12 @@ pub async fn run_execute_with_progress(
                             agent_policy.mutation_timeout_secs,
                             skip_call_validation,
                             move |text| {
-                                retry_tx
-                                    .lock()
-                                    .expect("invariant: mutex not poisoned")
-                                    .push(text.to_string());
+                                capture_stream_chunk(&retry_tx, progress, text);
                             },
                         )
                         .await;
 
-                        if let Ok(chunks) = retry_log.lock()
-                            && !chunks.is_empty()
-                        {
-                            emit!(chunks.concat());
-                        }
+                        drain_stream_chunks(log, &retry_log);
 
                         if let Ok(orchestrator::MutationOutcome::Success(mut retry_mr)) =
                             retry_result
@@ -529,8 +536,9 @@ pub async fn run_execute_with_progress(
                     .context("Failed to parse module for repair")?;
 
             // AI-AGENT: Same Arc<Mutex> pattern as the main streaming callback above.
-            let repair_log = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+            let repair_log = Arc::new(Mutex::new(Vec::<String>::new()));
             let repair_tx = repair_log.clone();
+            let progress = on_progress;
             let repair_result = orchestrator::mutate_streaming_with_timeout(
                 client,
                 &module_source,
@@ -539,19 +547,12 @@ pub async fn run_execute_with_progress(
                 agent_policy.mutation_timeout_secs,
                 true, // skip call validation
                 move |text| {
-                    repair_tx
-                        .lock()
-                        .expect("invariant: mutex not poisoned")
-                        .push(text.to_string());
+                    capture_stream_chunk(&repair_tx, progress, text);
                 },
             )
             .await;
 
-            if let Ok(chunks) = repair_log.lock()
-                && !chunks.is_empty()
-            {
-                emit!(chunks.concat());
-            }
+            drain_stream_chunks(log, &repair_log);
 
             if let Ok(orchestrator::MutationOutcome::Success(mut mr)) = repair_result {
                 cleanup_repaired_module_output(&mut mr.patched, &graph_dir, &path, &spec);
@@ -1210,7 +1211,7 @@ mod tests {
     use std::future::Future;
     use std::pin::Pin;
     use std::sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
     };
 
@@ -1248,6 +1249,32 @@ mod tests {
             self.calls.fetch_add(1, Ordering::SeqCst);
             Box::pin(async { Err(AgentError::NoToolCalls) })
         }
+    }
+
+    #[test]
+    fn streamed_chunks_emit_progress_immediately_and_log_once() {
+        let chunks = Arc::new(Mutex::new(Vec::<String>::new()));
+        let progress_lines = Arc::new(Mutex::new(Vec::<String>::new()));
+        let progress_sink = progress_lines.clone();
+        let on_progress = move |line: &str| {
+            progress_sink
+                .lock()
+                .expect("progress mutex")
+                .push(line.to_string());
+        };
+
+        capture_stream_chunk(&chunks, &on_progress, "chunk one");
+        capture_stream_chunk(&chunks, &on_progress, "chunk two");
+
+        assert_eq!(
+            progress_lines.lock().expect("progress mutex").as_slice(),
+            ["chunk one", "chunk two"]
+        );
+
+        let mut log = Vec::new();
+        drain_stream_chunks(&mut log, &chunks);
+
+        assert_eq!(log, vec!["chunk onechunk two".to_string()]);
     }
 
     fn executable_spec() -> IntentSpec {


### PR DESCRIPTION
### Motivation
- Fix Linux TUI UX where mouse-selection copy/paste was blocked by an unwarranted macOS-only clipboard error. 
- Make Intent `execute` show real-time progress (preflight, LLM streaming, analysis, tests) instead of only updating the UI after the run finishes.

### Description
- Implement cross-Unix clipboard copy using `wl-copy`, `xclip`, or `xsel` and a helper `write_clipboard_command`, and update error text for unsupported platforms in `src/cli/app.rs`.
- Implement cross-Unix clipboard paste using `wl-paste`, `xclip`, or `xsel` and return a helpful installation hint if none succeed in `src/cli/app.rs`.
- Add `run_with_pending_status_and_progress` helper to `src/cli/repl.rs` that keeps the pending spinner active while draining a `tokio::mpsc::UnboundedReceiver` of progress lines and rendering those lines immediately.
- Update `handle_intent_execute` to create a progress channel and call `intent::execute::run_execute_with_progress` so preflight, LLM streaming chunks, analysis, and test/status lines are pushed into the REPL output as they occur (instead of waiting until completion) in `src/cli/repl.rs`.

### Testing
- `cargo fmt --check` ran and passed locally.
- `git diff --check` ran and reported no issues.
- `cargo test` / focused `cargo test -q cli::repl::tests:: --lib` was attempted but could not complete because the environment `rustc` (1.89.0) is older than required by some dependencies (Cranelift/Wasmtime require >= 1.93.0), so unit test execution is blocked by toolchain constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a315885661c8333bf8a8f380b6f4626)