### PR TITLE
Implement #720 determinism replay harness

### DIFF
--- a/docs/e2e/results/duumbi-720-determinism-replay-20260619.md
+++ b/docs/e2e/results/duumbi-720-determinism-replay-20260619.md
@@ -1,0 +1,80 @@
+# DUUMBI-720 Determinism Replay E2E Evidence
+
+Related to #720.
+
+Date: 2026-06-19
+
+## Command
+
+Run from a temporary workspace with a workspace-local `.duumbi/config.toml`
+containing only:
+
+```toml
+[[providers]]
+provider = "minimax"
+role = "primary"
+api_key_env = "MINIMAX_API_KEY"
+timeout_secs = 120
+```
+
+Replay command:
+
+```bash
+/Users/heizergabor/.codex/worktrees/bf92/duumbi/target/debug/duumbi determinism replay \
+  --suite core \
+  --showcase calculator \
+  --provider minimax:auto:primary:MINIMAX_API_KEY \
+  --attempts 2 \
+  --artifact-dir /private/tmp/duumbi-720-live-output/replays \
+  --output /private/tmp/duumbi-720-live-output/duumbi-720-replay.json \
+  --markdown-output /private/tmp/duumbi-720-live-output/duumbi-720-replay.md
+```
+
+Exit status: 0.
+
+## Report Evidence
+
+- Schema: `duumbi.determinism.replay_report.v1`
+- Run id: `duumbi-720-2026-06-19T07-03-49Z-core-full`
+- Provider source: `workspace`
+- Provider route: `minimax:auto:primary:MINIMAX_API_KEY`
+- Model identity: `minimax/MiniMax-M2.7-highspeed`
+- Attempts: 2
+- Attempt 1: success, 4/4 tests passed
+- Attempt 2: success, 4/4 tests passed
+- Prompt hashes: `partial`, with `intent_spec`, `bdd_context`, and `context_pack`
+- Provider usage: unavailable, reason `provider_response_did_not_expose_usage`
+- Rewrite comparison: `not_yet_comparable`
+
+## Metrics
+
+| Metric | Status | Rate | Comparable Attempts |
+| --- | --- | ---: | ---: |
+| Exact graph agreement | available | 0.500 | 2 |
+| Semantic graph agreement | available | 0.500 | 2 |
+| Behavioral agreement | available | 1.000 | 2 |
+| Failure category agreement | unavailable | n/a | 0 |
+
+## Ledger Evidence
+
+The final run ledger had 7 JSONL events:
+
+- `run_started`
+- `task_selected`
+- `attempt_started`
+- `attempt_completed`
+- `attempt_started`
+- `attempt_completed`
+- `run_completed`
+
+## Safety Check
+
+Secret scan command:
+
+```bash
+grep -R "sk-\|Bearer \|MINIMAX_API_KEY=.*\|api_key =" /private/tmp/duumbi-720-live-output || true
+```
+
+Result: no matches.
+
+Raw replay bundles and provider logs were not committed.

--- a/src/bench/runner.rs
+++ b/src/bench/runner.rs
@@ -389,7 +389,7 @@ struct IntentExecutionMetrics {
     total_retry_count: Option<u32>,
 }
 
-fn extract_error_codes(text: &str) -> Vec<String> {
+pub(crate) fn extract_error_codes(text: &str) -> Vec<String> {
     let mut codes: Vec<String> = text
         .split(|c: char| !c.is_ascii_alphanumeric())
         .filter(|word| {
@@ -406,7 +406,7 @@ fn extract_error_codes(text: &str) -> Vec<String> {
 }
 
 /// Tries to load an archived intent (moved to history/ after execution).
-fn load_archived_intent(
+pub(crate) fn load_archived_intent(
     workspace: &Path,
     slug: &str,
 ) -> Result<crate::intent::spec::IntentSpec, crate::intent::IntentError> {
@@ -435,7 +435,7 @@ fn load_archived_intent(
 }
 
 /// Filters provider configs by name.
-fn filter_providers<'a>(
+pub(crate) fn filter_providers<'a>(
     providers: &'a [ProviderConfig],
     filter: Option<&[String]>,
 ) -> Vec<&'a ProviderConfig> {
@@ -456,7 +456,7 @@ fn filter_providers<'a>(
 /// Legacy configs with an explicit model keep the historical `provider:model`
 /// identifier. Provider-only configs include role, credential env, and base URL
 /// so multiple entries for the same provider remain filterable.
-fn provider_name(config: &ProviderConfig) -> String {
+pub(crate) fn provider_name(config: &ProviderConfig) -> String {
     if let Some(model) = config.model.as_deref() {
         return format!("{}:{model}", config.provider);
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -307,6 +307,13 @@ pub enum Commands {
         baseline: Option<std::path::PathBuf>,
     },
 
+    /// Measure determinism of provider-backed intent replay.
+    Determinism {
+        /// Determinism subcommand.
+        #[command(subcommand)]
+        subcommand: DeterminismSubcommand,
+    },
+
     /// Run the Phase 15 E2E validation harness.
     #[command(name = "phase15-e2e", hide = true)]
     Phase15E2e {
@@ -445,6 +452,65 @@ pub enum TelemetrySubcommand {
         /// Optional path for writing the repair validation evidence JSON.
         #[arg(long)]
         output: Option<PathBuf>,
+    },
+}
+
+/// Subcommands for `duumbi determinism`.
+#[derive(Subcommand, Debug)]
+pub enum DeterminismSubcommand {
+    /// Replay selected benchmark showcases and report agreement metrics.
+    Replay {
+        /// Benchmark suite to replay. Defaults to the existing core suite.
+        #[arg(long, value_enum)]
+        suite: Option<BenchmarkSuiteArg>,
+
+        /// Run only the low-budget smoke subset of the selected suite.
+        #[arg(long)]
+        smoke: bool,
+
+        /// Replay only the named showcase(s) (comma-separated).
+        #[arg(long, value_delimiter = ',')]
+        showcase: Option<Vec<String>>,
+
+        /// Replay only the named provider route(s) (comma-separated).
+        #[arg(long, value_delimiter = ',')]
+        provider: Option<Vec<String>>,
+
+        /// Number of attempts per selected showcase/provider pair.
+        #[arg(long, value_parser = clap::value_parser!(u32).range(2..))]
+        attempts: Option<u32>,
+
+        /// Write JSON report to this file instead of stdout.
+        #[arg(long)]
+        output: Option<PathBuf>,
+
+        /// Root directory for replay bundles.
+        #[arg(long, default_value = ".duumbi/determinism/replays")]
+        artifact_dir: PathBuf,
+
+        /// Optional Markdown summary output path.
+        #[arg(long)]
+        markdown_output: Option<PathBuf>,
+
+        /// CI mode: explicit thresholds determine the process exit code.
+        #[arg(long)]
+        ci: bool,
+
+        /// Minimum exact graph agreement rate for CI mode.
+        #[arg(long)]
+        min_exact_agreement: Option<f64>,
+
+        /// Minimum semantic graph agreement rate for CI mode.
+        #[arg(long)]
+        min_semantic_agreement: Option<f64>,
+
+        /// Minimum behavioral agreement rate for CI mode.
+        #[arg(long)]
+        min_behavioral_agreement: Option<f64>,
+
+        /// Retain isolated attempt workspaces inside the replay bundle.
+        #[arg(long)]
+        keep_workspaces: bool,
     },
 }
 

--- a/src/determinism/digest.rs
+++ b/src/determinism/digest.rs
@@ -173,6 +173,12 @@ pub fn combined_registry_state_hash(lockfile_hash: &str, dependency_config_hash:
     hex_encode(hasher.finalize())
 }
 
+/// Hashes arbitrary replay evidence bytes as lowercase SHA-256 hex.
+#[must_use]
+pub fn sha256_hex_bytes(bytes: &[u8]) -> String {
+    hex_encode(Sha256::digest(bytes))
+}
+
 fn collect_jsonld_files(
     graph_root: &Path,
     dir: &Path,

--- a/src/determinism/digest.rs
+++ b/src/determinism/digest.rs
@@ -1,0 +1,294 @@
+//! Deterministic digest and artifact-key helpers for replay evidence.
+
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+/// Marker used when an optional replay state input is missing.
+pub const ABSENT_STATE_HASH: &str = "absent";
+
+/// Errors produced while computing replay digests.
+#[derive(Debug, Error)]
+pub enum DigestError {
+    /// A filesystem operation failed.
+    #[error("{context} at {path}: {source}")]
+    Io {
+        /// Human-readable operation.
+        context: &'static str,
+        /// Path involved in the failure.
+        path: String,
+        /// Underlying filesystem error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// A path could not be represented safely in replay evidence.
+    #[error("path is not valid UTF-8 for replay evidence: {0}")]
+    NonUtf8Path(String),
+    /// A graph file was outside the expected graph directory.
+    #[error("graph file is outside graph root: {0}")]
+    OutsideGraphRoot(String),
+}
+
+/// Hashes recorded for local dependency and registry state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceStateHashes {
+    /// Hash of `.duumbi/deps.lock`, or `absent`.
+    pub lockfile_hash: String,
+    /// Hash of `.duumbi/config.toml`, or `absent`.
+    pub workspace_dependency_config_hash: String,
+    /// Combined hash over the bounded local registry/dependency state fields.
+    pub registry_state_hash: String,
+}
+
+/// Computes an exact SHA-256 digest for all `.jsonld` graph files.
+///
+/// This is intentionally different from semantic hashing: it includes sorted
+/// workspace-relative paths and exact file bytes, so `@id` differences and
+/// serialization differences remain visible.
+///
+/// # Errors
+///
+/// Returns [`DigestError`] when graph files cannot be listed, read, or
+/// represented as safe UTF-8 relative paths.
+#[must_use = "exact graph digest evidence should be used"]
+pub fn exact_graph_digest(graph_dir: &Path) -> Result<String, DigestError> {
+    let mut files = BTreeSet::new();
+    collect_jsonld_files(graph_dir, graph_dir, &mut files)?;
+
+    let mut hasher = Sha256::new();
+    for relative_path in files {
+        let absolute_path = graph_dir.join(&relative_path);
+        let bytes = fs::read(&absolute_path).map_err(|source| DigestError::Io {
+            context: "failed to read graph file",
+            path: absolute_path.display().to_string(),
+            source,
+        })?;
+        let normalized_path = normalize_relative_path(&relative_path)?;
+        hasher.update(b"path\0");
+        hasher.update(normalized_path.as_bytes());
+        hasher.update(b"\0len\0");
+        hasher.update(bytes.len().to_string().as_bytes());
+        hasher.update(b"\0bytes\0");
+        hasher.update(&bytes);
+        hasher.update(b"\0end\0");
+    }
+
+    Ok(hex_encode(hasher.finalize()))
+}
+
+/// Produces a filesystem-safe artifact key for a raw task or provider value.
+///
+/// The returned key keeps a readable slug prefix and appends a short stable
+/// hash of the raw value. Raw provider routes may contain URLs or `..`; those
+/// bytes are never used directly as path components.
+#[must_use]
+pub fn safe_artifact_key(raw: &str, fallback_prefix: &str) -> String {
+    let mut slug = String::new();
+    let mut previous_dash = false;
+    for ch in raw.chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch);
+            previous_dash = false;
+        } else if !previous_dash && !slug.is_empty() {
+            slug.push('-');
+            previous_dash = true;
+        }
+    }
+    while slug.ends_with('-') {
+        slug.pop();
+    }
+    if slug.is_empty() || slug == "." || slug == ".." {
+        slug = fallback_prefix
+            .chars()
+            .filter(|ch| ch.is_ascii_alphanumeric() || *ch == '-')
+            .collect();
+    }
+    if slug.is_empty() {
+        slug = "value".to_string();
+    }
+    if slug.len() > 48 {
+        slug.truncate(48);
+        while slug.ends_with('-') {
+            slug.pop();
+        }
+    }
+
+    format!("{slug}-{}", short_hash(raw))
+}
+
+/// Hashes a file when present, otherwise returns [`ABSENT_STATE_HASH`].
+///
+/// # Errors
+///
+/// Returns [`DigestError`] if the file exists but cannot be read.
+#[must_use = "state hash evidence should be used"]
+pub fn file_hash_or_absent(path: &Path) -> Result<String, DigestError> {
+    if !path.exists() {
+        return Ok(ABSENT_STATE_HASH.to_string());
+    }
+    let bytes = fs::read(path).map_err(|source| DigestError::Io {
+        context: "failed to read state file",
+        path: path.display().to_string(),
+        source,
+    })?;
+    Ok(hex_encode(Sha256::digest(&bytes)))
+}
+
+/// Computes bounded local workspace state hashes for replay reports.
+///
+/// The first implementation hashes local lockfile/config evidence only and does
+/// not query remote registries.
+///
+/// # Errors
+///
+/// Returns [`DigestError`] if a present state file cannot be read.
+#[must_use = "workspace state hashes should be recorded"]
+pub fn workspace_state_hashes(workspace_root: &Path) -> Result<WorkspaceStateHashes, DigestError> {
+    let lockfile_hash = file_hash_or_absent(&workspace_root.join(".duumbi/deps.lock"))?;
+    let workspace_dependency_config_hash =
+        file_hash_or_absent(&workspace_root.join(".duumbi/config.toml"))?;
+    let registry_state_hash =
+        combined_registry_state_hash(&lockfile_hash, &workspace_dependency_config_hash);
+    Ok(WorkspaceStateHashes {
+        lockfile_hash,
+        workspace_dependency_config_hash,
+        registry_state_hash,
+    })
+}
+
+/// Combines bounded local registry/dependency state fields into one hash.
+#[must_use]
+pub fn combined_registry_state_hash(lockfile_hash: &str, dependency_config_hash: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"duumbi-determinism-registry-state-v1\0");
+    hasher.update(b"lockfile\0");
+    hasher.update(lockfile_hash.as_bytes());
+    hasher.update(b"\0dependency-config\0");
+    hasher.update(dependency_config_hash.as_bytes());
+    hex_encode(hasher.finalize())
+}
+
+fn collect_jsonld_files(
+    graph_root: &Path,
+    dir: &Path,
+    files: &mut BTreeSet<PathBuf>,
+) -> Result<(), DigestError> {
+    let entries = fs::read_dir(dir).map_err(|source| DigestError::Io {
+        context: "failed to read graph directory",
+        path: dir.display().to_string(),
+        source,
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|source| DigestError::Io {
+            context: "failed to read graph directory entry",
+            path: dir.display().to_string(),
+            source,
+        })?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_jsonld_files(graph_root, &path, files)?;
+        } else if path.extension().and_then(|extension| extension.to_str()) == Some("jsonld") {
+            let relative = path
+                .strip_prefix(graph_root)
+                .map_err(|_| DigestError::OutsideGraphRoot(path.display().to_string()))?;
+            files.insert(relative.to_path_buf());
+        }
+    }
+    Ok(())
+}
+
+fn normalize_relative_path(path: &Path) -> Result<String, DigestError> {
+    let mut parts = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => {
+                let part = part
+                    .to_str()
+                    .ok_or_else(|| DigestError::NonUtf8Path(path.display().to_string()))?;
+                parts.push(part.to_string());
+            }
+            _ => return Err(DigestError::OutsideGraphRoot(path.display().to_string())),
+        }
+    }
+    Ok(parts.join("/"))
+}
+
+fn short_hash(raw: &str) -> String {
+    let hash = hex_encode(Sha256::digest(raw.as_bytes()));
+    hash.chars().take(12).collect()
+}
+
+fn hex_encode(bytes: impl AsRef<[u8]>) -> String {
+    let bytes = bytes.as_ref();
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        write!(output, "{byte:02x}").expect("invariant: writing to String cannot fail");
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn exact_graph_digest_changes_when_exact_bytes_change() {
+        let dir = TempDir::new().expect("temp dir");
+        let graph_dir = dir.path().join(".duumbi/graph");
+        fs::create_dir_all(&graph_dir).expect("graph dir");
+        fs::write(graph_dir.join("main.jsonld"), r#"{"@id":"a","value":1}"#).expect("write");
+        let first = exact_graph_digest(&graph_dir).expect("digest");
+
+        fs::write(graph_dir.join("main.jsonld"), r#"{"@id":"b","value":1}"#).expect("write");
+        let second = exact_graph_digest(&graph_dir).expect("digest");
+
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn exact_graph_digest_sorts_nested_paths() {
+        let dir = TempDir::new().expect("temp dir");
+        let graph_dir = dir.path().join(".duumbi/graph");
+        fs::create_dir_all(graph_dir.join("nested")).expect("graph dir");
+        fs::write(graph_dir.join("z.jsonld"), "{}").expect("write");
+        fs::write(graph_dir.join("nested/a.jsonld"), "{}").expect("write");
+
+        let first = exact_graph_digest(&graph_dir).expect("digest");
+        let second = exact_graph_digest(&graph_dir).expect("digest");
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn artifact_key_sanitizes_urls_and_path_traversal() {
+        let key = safe_artifact_key("minimax:http://localhost:8080/v1/../../key", "provider");
+
+        assert!(!key.contains('/'));
+        assert!(!key.contains(".."));
+        assert!(key.starts_with("minimax-http-localhost-8080-v1-key-"));
+    }
+
+    #[test]
+    fn missing_state_file_is_absent() {
+        let dir = TempDir::new().expect("temp dir");
+        let hash = file_hash_or_absent(&dir.path().join(".duumbi/deps.lock")).expect("state hash");
+
+        assert_eq!(hash, ABSENT_STATE_HASH);
+    }
+
+    #[test]
+    fn workspace_state_hash_combines_absent_markers() {
+        let dir = TempDir::new().expect("temp dir");
+        let state = workspace_state_hashes(dir.path()).expect("state hashes");
+
+        assert_eq!(state.lockfile_hash, ABSENT_STATE_HASH);
+        assert_eq!(state.workspace_dependency_config_hash, ABSENT_STATE_HASH);
+        assert_ne!(state.registry_state_hash, ABSENT_STATE_HASH);
+    }
+}

--- a/src/determinism/evidence.rs
+++ b/src/determinism/evidence.rs
@@ -360,32 +360,78 @@ impl ReplayMetrics {
         Self {
             attempts_total: attempts.len() as u32,
             attempts_completed: attempts.len() as u32,
-            exact_graph_agreement_rate: largest_group_agreement(
-                attempts
-                    .iter()
-                    .map(|attempt| attempt.final_graph_exact_hash.as_deref()),
+            exact_graph_agreement_rate: task_provider_grouped_agreement(
+                attempts,
+                |attempt| attempt.final_graph_exact_hash.clone(),
                 "no comparable attempts produced final graph evidence",
             ),
-            semantic_graph_agreement_rate: largest_group_agreement(
-                attempts
-                    .iter()
-                    .map(|attempt| attempt.final_graph_semantic_hash.as_deref()),
+            semantic_graph_agreement_rate: task_provider_grouped_agreement(
+                attempts,
+                |attempt| attempt.final_graph_semantic_hash.clone(),
                 "no comparable attempts produced semantic graph evidence",
             ),
-            behavioral_agreement_rate: largest_group_agreement(
-                attempts
-                    .iter()
-                    .map(|attempt| attempt.behavior_signature.as_deref()),
+            behavioral_agreement_rate: task_provider_grouped_agreement(
+                attempts,
+                |attempt| attempt.behavior_signature.clone(),
                 "no comparable attempts produced behavior evidence",
             ),
-            failure_category_agreement_rate: largest_group_agreement(
-                attempts
-                    .iter()
-                    .map(|attempt| attempt.error_category.map(|category| category.to_string())),
+            failure_category_agreement_rate: task_provider_grouped_agreement(
+                attempts,
+                |attempt| attempt.error_category.map(|category| category.to_string()),
                 "no comparable attempts produced failure category evidence",
             ),
             divergence_examples: Vec::new(),
         }
+    }
+}
+
+fn task_provider_grouped_agreement<F>(
+    attempts: &[ReplayAttempt],
+    value_for: F,
+    unavailable_reason: &str,
+) -> AgreementRate
+where
+    F: Fn(&ReplayAttempt) -> Option<String>,
+{
+    let mut groups: BTreeMap<(String, String), Vec<Option<String>>> = BTreeMap::new();
+    for attempt in attempts {
+        groups
+            .entry((attempt.task_id.clone(), attempt.provider.clone()))
+            .or_default()
+            .push(value_for(attempt));
+    }
+
+    let mut comparable_attempt_count = 0usize;
+    let mut largest_equivalence_group_count = 0usize;
+    let mut comparable_group_count = 0usize;
+
+    for values in groups.values() {
+        if let AgreementRate::Available {
+            comparable_attempt_count: group_comparable,
+            largest_equivalence_group_count: group_largest,
+            ..
+        } = largest_group_agreement(
+            values.iter().map(|value| value.as_deref()),
+            unavailable_reason,
+        ) {
+            comparable_attempt_count += group_comparable;
+            largest_equivalence_group_count += group_largest;
+            comparable_group_count += 1;
+        }
+    }
+
+    if comparable_attempt_count == 0 {
+        return AgreementRate::Unavailable {
+            reason: unavailable_reason.to_string(),
+            comparable_attempt_count,
+        };
+    }
+
+    AgreementRate::Available {
+        rate: largest_equivalence_group_count as f64 / comparable_attempt_count as f64,
+        comparable_attempt_count,
+        largest_equivalence_group_count,
+        dominant_key: format!("grouped_by=task_id/provider;groups={comparable_group_count}"),
     }
 }
 
@@ -533,6 +579,47 @@ fn metric_row(name: &str, metric: &AgreementRate) -> String {
 mod tests {
     use super::*;
 
+    fn replay_attempt(
+        task_id: &str,
+        provider: &str,
+        attempt: u32,
+        exact_hash: Option<&str>,
+        semantic_hash: Option<&str>,
+        behavior_signature: Option<&str>,
+    ) -> ReplayAttempt {
+        ReplayAttempt {
+            task_id: task_id.to_string(),
+            suite: "core".to_string(),
+            tags: Vec::new(),
+            provider: provider.to_string(),
+            model_identity: ModelIdentity::unavailable("not exposed"),
+            attempt,
+            workspace_strategy: "tempdir".to_string(),
+            initial_graph_exact_hash: None,
+            initial_graph_semantic_hash: None,
+            final_graph_exact_hash: exact_hash.map(ToString::to_string),
+            final_graph_semantic_hash: semantic_hash.map(ToString::to_string),
+            intent_spec_hash: None,
+            bdd_context_hash: None,
+            context_pack_hash: None,
+            prompt_hashes: PromptHashes::Unavailable {
+                reason: "not captured".to_string(),
+            },
+            success: true,
+            tests_passed: 1,
+            tests_total: 1,
+            bdd_readiness: None,
+            bdd_coverage: Vec::new(),
+            behavior_signature: behavior_signature.map(ToString::to_string),
+            error_category: None,
+            dominant_error_code: None,
+            provider_usage: ProviderUsageSummary::unavailable("not exposed"),
+            benchmark_evidence: None,
+            artifact_paths: Vec::new(),
+            duration_secs: 0.1,
+        }
+    }
+
     #[test]
     fn report_serializes_schema_and_rewrite_status() {
         let report = ReplayReport::new(
@@ -665,6 +752,74 @@ mod tests {
         assert!(matches!(
             metrics.semantic_graph_agreement_rate,
             AgreementRate::Available { rate, .. } if rate == 1.0
+        ));
+    }
+
+    #[test]
+    fn metrics_compute_agreement_within_task_provider_pairs() {
+        let attempts = vec![
+            replay_attempt(
+                "calculator",
+                "mock",
+                1,
+                Some("calculator-exact"),
+                Some("calculator-semantic"),
+                Some("calculator-behavior"),
+            ),
+            replay_attempt(
+                "calculator",
+                "mock",
+                2,
+                Some("calculator-exact"),
+                Some("calculator-semantic"),
+                Some("calculator-behavior"),
+            ),
+            replay_attempt(
+                "strings",
+                "mock",
+                1,
+                Some("strings-exact"),
+                Some("strings-semantic"),
+                Some("strings-behavior"),
+            ),
+            replay_attempt(
+                "strings",
+                "mock",
+                2,
+                Some("strings-exact"),
+                Some("strings-semantic"),
+                Some("strings-behavior"),
+            ),
+        ];
+
+        let metrics = ReplayMetrics::from_attempts(&attempts);
+
+        assert!(matches!(
+            metrics.exact_graph_agreement_rate,
+            AgreementRate::Available {
+                rate,
+                comparable_attempt_count: 4,
+                largest_equivalence_group_count: 4,
+                ..
+            } if rate == 1.0
+        ));
+        assert!(matches!(
+            metrics.semantic_graph_agreement_rate,
+            AgreementRate::Available {
+                rate,
+                comparable_attempt_count: 4,
+                largest_equivalence_group_count: 4,
+                ..
+            } if rate == 1.0
+        ));
+        assert!(matches!(
+            metrics.behavioral_agreement_rate,
+            AgreementRate::Available {
+                rate,
+                comparable_attempt_count: 4,
+                largest_equivalence_group_count: 4,
+                ..
+            } if rate == 1.0
         ));
     }
 

--- a/src/determinism/evidence.rs
+++ b/src/determinism/evidence.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::bench::report::{BenchmarkEvidence, ErrorCategory, ProviderUsageSummary};
 
-use super::metrics::AgreementRate;
+use super::metrics::{AgreementRate, largest_group_agreement};
 
 /// Replay report schema version.
 pub const REPLAY_REPORT_SCHEMA_VERSION: &str = "duumbi.determinism.replay_report.v1";
@@ -74,6 +74,90 @@ impl ReplayReport {
             ),
             warnings: Vec::new(),
         }
+    }
+
+    /// Renders a compact deterministic Markdown summary for review evidence.
+    #[must_use]
+    pub fn to_markdown_summary(&self) -> String {
+        let mut output = String::new();
+        output.push_str("# DUUMBI Determinism Replay Report\n\n");
+        output.push_str(&format!("- Run: {}\n", self.run_id));
+        output.push_str(&format!("- Started: {}\n", self.started_at));
+        output.push_str(&format!("- Finished: {}\n", self.finished_at));
+        output.push_str(&format!("- DUUMBI version: {}\n", self.duumbi_version));
+        output.push_str(&format!("- Source commit: {}\n", self.source_commit));
+        output.push_str(&format!("- Suite: {}\n", self.inputs.suite));
+        output.push_str(&format!("- Smoke: {}\n", self.inputs.smoke));
+        output.push_str(&format!(
+            "- Showcases: {}\n",
+            self.inputs.showcases.join(", ")
+        ));
+        output.push_str(&format!(
+            "- Providers: {}\n",
+            self.inputs.providers.join(", ")
+        ));
+        output.push_str(&format!("- Attempts: {}\n\n", self.inputs.attempts));
+
+        output.push_str("## Metrics\n\n");
+        output.push_str("| Metric | Status | Detail |\n");
+        output.push_str("| --- | --- | --- |\n");
+        output.push_str(&metric_row(
+            "Exact graph",
+            &self.metrics.exact_graph_agreement_rate,
+        ));
+        output.push_str(&metric_row(
+            "Semantic graph",
+            &self.metrics.semantic_graph_agreement_rate,
+        ));
+        output.push_str(&metric_row(
+            "Behavioral",
+            &self.metrics.behavioral_agreement_rate,
+        ));
+        output.push_str(&metric_row(
+            "Failure category",
+            &self.metrics.failure_category_agreement_rate,
+        ));
+
+        output.push_str("\n## Attempts\n\n");
+        output.push_str("| Task | Provider | Model | Attempt | Success | Tests | Error |\n");
+        output.push_str("| --- | --- | --- | ---: | --- | ---: | --- |\n");
+        for attempt in &self.attempts {
+            let model = match &attempt.model_identity {
+                ModelIdentity::Available { label } => label.as_str(),
+                ModelIdentity::Unavailable { reason } => reason.as_str(),
+            };
+            let error = if let Some(code) = &attempt.dominant_error_code {
+                code.clone()
+            } else if let Some(category) = attempt.error_category {
+                category.to_string()
+            } else {
+                "none".to_string()
+            };
+            output.push_str(&format!(
+                "| {} | {} | {} | {} | {} | {}/{} | {} |\n",
+                attempt.task_id,
+                attempt.provider,
+                model,
+                attempt.attempt,
+                attempt.success,
+                attempt.tests_passed,
+                attempt.tests_total,
+                error
+            ));
+        }
+
+        output.push_str("\n## Rewrite Comparison\n\n");
+        output.push_str(&format!(
+            "- Status: {:?}\n- Reason: {}\n",
+            self.rewrite_comparison.status, self.rewrite_comparison.reason
+        ));
+        if !self.warnings.is_empty() {
+            output.push_str("\n## Warnings\n\n");
+            for warning in &self.warnings {
+                output.push_str(&format!("- {warning}\n"));
+            }
+        }
+        output
     }
 }
 
@@ -269,6 +353,42 @@ impl Default for ReplayMetrics {
     }
 }
 
+impl ReplayMetrics {
+    /// Derives aggregate metrics from attempt evidence.
+    #[must_use]
+    pub fn from_attempts(attempts: &[ReplayAttempt]) -> Self {
+        Self {
+            attempts_total: attempts.len() as u32,
+            attempts_completed: attempts.len() as u32,
+            exact_graph_agreement_rate: largest_group_agreement(
+                attempts
+                    .iter()
+                    .map(|attempt| attempt.final_graph_exact_hash.as_deref()),
+                "no comparable attempts produced final graph evidence",
+            ),
+            semantic_graph_agreement_rate: largest_group_agreement(
+                attempts
+                    .iter()
+                    .map(|attempt| attempt.final_graph_semantic_hash.as_deref()),
+                "no comparable attempts produced semantic graph evidence",
+            ),
+            behavioral_agreement_rate: largest_group_agreement(
+                attempts
+                    .iter()
+                    .map(|attempt| attempt.behavior_signature.as_deref()),
+                "no comparable attempts produced behavior evidence",
+            ),
+            failure_category_agreement_rate: largest_group_agreement(
+                attempts
+                    .iter()
+                    .map(|attempt| attempt.error_category.map(|category| category.to_string())),
+                "no comparable attempts produced failure category evidence",
+            ),
+            divergence_examples: Vec::new(),
+        }
+    }
+}
+
 /// One divergence example for human inspection.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DivergenceExample {
@@ -387,6 +507,26 @@ pub enum LedgerEventKind {
     RunInterrupted,
 }
 
+fn metric_row(name: &str, metric: &AgreementRate) -> String {
+    match metric {
+        AgreementRate::Available {
+            rate,
+            comparable_attempt_count,
+            largest_equivalence_group_count,
+            dominant_key,
+        } => format!(
+            "| {name} | available | rate {:.3}; {largest_equivalence_group_count}/{comparable_attempt_count}; dominant `{dominant_key}` |\n",
+            rate
+        ),
+        AgreementRate::Unavailable {
+            reason,
+            comparable_attempt_count,
+        } => format!(
+            "| {name} | unavailable | {reason}; comparable attempts {comparable_attempt_count} |\n"
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -444,5 +584,115 @@ mod tests {
         assert_eq!(event.schema_version, REPLAY_LEDGER_SCHEMA_VERSION);
         let json = serde_json::to_string(&event).expect("ledger event serializes");
         assert!(json.contains("\"event\":\"run_started\""));
+    }
+
+    #[test]
+    fn metrics_derive_from_attempt_rows() {
+        let attempts = vec![
+            ReplayAttempt {
+                task_id: "calculator".to_string(),
+                suite: "core".to_string(),
+                tags: Vec::new(),
+                provider: "mock".to_string(),
+                model_identity: ModelIdentity::unavailable("not exposed"),
+                attempt: 1,
+                workspace_strategy: "tempdir".to_string(),
+                initial_graph_exact_hash: None,
+                initial_graph_semantic_hash: None,
+                final_graph_exact_hash: Some("exact-a".to_string()),
+                final_graph_semantic_hash: Some("semantic-a".to_string()),
+                intent_spec_hash: None,
+                bdd_context_hash: None,
+                context_pack_hash: None,
+                prompt_hashes: PromptHashes::Unavailable {
+                    reason: "not captured".to_string(),
+                },
+                success: true,
+                tests_passed: 1,
+                tests_total: 1,
+                bdd_readiness: None,
+                bdd_coverage: Vec::new(),
+                behavior_signature: Some("behavior-a".to_string()),
+                error_category: None,
+                dominant_error_code: None,
+                provider_usage: ProviderUsageSummary::unavailable("not exposed"),
+                benchmark_evidence: None,
+                artifact_paths: Vec::new(),
+                duration_secs: 0.1,
+            },
+            ReplayAttempt {
+                task_id: "calculator".to_string(),
+                suite: "core".to_string(),
+                tags: Vec::new(),
+                provider: "mock".to_string(),
+                model_identity: ModelIdentity::unavailable("not exposed"),
+                attempt: 2,
+                workspace_strategy: "tempdir".to_string(),
+                initial_graph_exact_hash: None,
+                initial_graph_semantic_hash: None,
+                final_graph_exact_hash: Some("exact-b".to_string()),
+                final_graph_semantic_hash: Some("semantic-a".to_string()),
+                intent_spec_hash: None,
+                bdd_context_hash: None,
+                context_pack_hash: None,
+                prompt_hashes: PromptHashes::Unavailable {
+                    reason: "not captured".to_string(),
+                },
+                success: true,
+                tests_passed: 1,
+                tests_total: 1,
+                bdd_readiness: None,
+                bdd_coverage: Vec::new(),
+                behavior_signature: Some("behavior-a".to_string()),
+                error_category: None,
+                dominant_error_code: None,
+                provider_usage: ProviderUsageSummary::unavailable("not exposed"),
+                benchmark_evidence: None,
+                artifact_paths: Vec::new(),
+                duration_secs: 0.1,
+            },
+        ];
+
+        let metrics = ReplayMetrics::from_attempts(&attempts);
+
+        assert_eq!(metrics.attempts_total, 2);
+        assert!(matches!(
+            metrics.exact_graph_agreement_rate,
+            AgreementRate::Available { rate, .. } if rate == 0.5
+        ));
+        assert!(matches!(
+            metrics.semantic_graph_agreement_rate,
+            AgreementRate::Available { rate, .. } if rate == 1.0
+        ));
+    }
+
+    #[test]
+    fn markdown_summary_contains_metric_table() {
+        let mut report = ReplayReport::new(
+            "run-1",
+            "2026-06-17T00:00:00Z",
+            "2026-06-17T00:00:01Z",
+            "0.4.0-preview",
+            "abc123",
+            ReplayInputs {
+                suite: "core".to_string(),
+                smoke: false,
+                showcases: vec!["calculator".to_string()],
+                providers: vec!["mock".to_string()],
+                attempts: 2,
+            },
+            ReplayEnvironment {
+                provider_source: "test".to_string(),
+                registry_state_hash: "state".to_string(),
+                lockfile_hash: "absent".to_string(),
+                workspace_dependency_config_hash: "absent".to_string(),
+            },
+        );
+        report.metrics = ReplayMetrics::from_attempts(&[]);
+
+        let markdown = report.to_markdown_summary();
+
+        assert!(markdown.contains("# DUUMBI Determinism Replay Report"));
+        assert!(markdown.contains("| Exact graph | unavailable |"));
     }
 }

--- a/src/determinism/evidence.rs
+++ b/src/determinism/evidence.rs
@@ -495,7 +495,8 @@ pub enum LedgerEventKind {
     TaskSelected,
     /// Attempt started.
     AttemptStarted,
-    /// Context was locked.
+    /// Reserved for future context lock emission once replay context capture
+    /// can write the ledger at the exact lock point.
     ContextLocked,
     /// Attempt completed.
     AttemptCompleted,
@@ -503,7 +504,8 @@ pub enum LedgerEventKind {
     AttemptFailed,
     /// Run completed.
     RunCompleted,
-    /// Run interrupted.
+    /// Reserved for future interrupted-run recovery. The current runner
+    /// returns errors before producing a partial run ledger.
     RunInterrupted,
 }
 

--- a/src/determinism/evidence.rs
+++ b/src/determinism/evidence.rs
@@ -1,0 +1,448 @@
+//! Schema-versioned replay evidence records.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::bench::report::{BenchmarkEvidence, ErrorCategory, ProviderUsageSummary};
+
+use super::metrics::AgreementRate;
+
+/// Replay report schema version.
+pub const REPLAY_REPORT_SCHEMA_VERSION: &str = "duumbi.determinism.replay_report.v1";
+
+/// Append-only replay ledger event schema version.
+pub const REPLAY_LEDGER_SCHEMA_VERSION: &str = "duumbi.determinism.ledger_event.v1";
+
+/// Complete determinism replay report.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReplayReport {
+    /// Replay report schema version.
+    pub schema_version: String,
+    /// Stable run identifier.
+    pub run_id: String,
+    /// UTC start timestamp as RFC3339 text.
+    pub started_at: String,
+    /// UTC finish timestamp as RFC3339 text.
+    pub finished_at: String,
+    /// DUUMBI package version.
+    pub duumbi_version: String,
+    /// Source commit used for the replay run.
+    pub source_commit: String,
+    /// Locked replay inputs.
+    pub inputs: ReplayInputs,
+    /// Bounded local environment state.
+    pub environment: ReplayEnvironment,
+    /// Selected replay tasks.
+    pub tasks: Vec<ReplayTask>,
+    /// Per-attempt evidence.
+    pub attempts: Vec<ReplayAttempt>,
+    /// Aggregate equivalence metrics.
+    pub metrics: ReplayMetrics,
+    /// Rewrite comparison status.
+    pub rewrite_comparison: RewriteComparison,
+    /// Non-fatal warnings.
+    pub warnings: Vec<String>,
+}
+
+impl ReplayReport {
+    /// Creates an empty replay report with schema defaults.
+    #[must_use]
+    pub fn new(
+        run_id: impl Into<String>,
+        started_at: impl Into<String>,
+        finished_at: impl Into<String>,
+        duumbi_version: impl Into<String>,
+        source_commit: impl Into<String>,
+        inputs: ReplayInputs,
+        environment: ReplayEnvironment,
+    ) -> Self {
+        Self {
+            schema_version: REPLAY_REPORT_SCHEMA_VERSION.to_string(),
+            run_id: run_id.into(),
+            started_at: started_at.into(),
+            finished_at: finished_at.into(),
+            duumbi_version: duumbi_version.into(),
+            source_commit: source_commit.into(),
+            inputs,
+            environment,
+            tasks: Vec::new(),
+            attempts: Vec::new(),
+            metrics: ReplayMetrics::default(),
+            rewrite_comparison: RewriteComparison::not_yet_comparable(
+                "no constrained LLM rewrite mutation strategy for this task",
+            ),
+            warnings: Vec::new(),
+        }
+    }
+}
+
+/// Replay input selection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplayInputs {
+    /// Selected benchmark suite.
+    pub suite: String,
+    /// Whether smoke filtering was enabled.
+    pub smoke: bool,
+    /// Selected showcase names.
+    pub showcases: Vec<String>,
+    /// Requested provider routes.
+    pub providers: Vec<String>,
+    /// Attempts per selected task/provider pair.
+    pub attempts: u32,
+}
+
+/// Replay environment hash evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplayEnvironment {
+    /// Source of provider configuration, such as `user`.
+    pub provider_source: String,
+    /// Combined local registry/dependency state hash.
+    pub registry_state_hash: String,
+    /// `.duumbi/deps.lock` hash or `absent`.
+    pub lockfile_hash: String,
+    /// `.duumbi/config.toml` hash or `absent`.
+    pub workspace_dependency_config_hash: String,
+}
+
+/// Selected replay task metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplayTask {
+    /// Stable task identifier.
+    pub task_id: String,
+    /// Benchmark suite.
+    pub suite: String,
+    /// Task tags.
+    pub tags: Vec<String>,
+}
+
+/// Evidence for the resolved model used by one attempt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum ModelIdentity {
+    /// Model identity was resolved.
+    Available {
+        /// Resolved model or catalog label.
+        label: String,
+    },
+    /// Model identity was unavailable.
+    Unavailable {
+        /// Stable unavailable reason.
+        reason: String,
+    },
+}
+
+impl ModelIdentity {
+    /// Creates unavailable model identity evidence.
+    #[must_use]
+    pub fn unavailable(reason: impl Into<String>) -> Self {
+        Self::Unavailable {
+            reason: reason.into(),
+        }
+    }
+}
+
+/// Prompt hash evidence for one attempt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum PromptHashes {
+    /// Full prompt hashes are available.
+    Full {
+        /// Final mutation prompt hash per task or step.
+        hashes: BTreeMap<String, String>,
+    },
+    /// Only partial context-pack hashing is available.
+    Partial {
+        /// Stable partial-hashing reason.
+        reason: String,
+        /// Hashes that were available.
+        hashes: BTreeMap<String, String>,
+    },
+    /// No prompt/context hash evidence is available.
+    Unavailable {
+        /// Stable unavailable reason.
+        reason: String,
+    },
+}
+
+/// One replay attempt evidence row.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReplayAttempt {
+    /// Stable task identifier.
+    pub task_id: String,
+    /// Benchmark suite.
+    pub suite: String,
+    /// Task tags.
+    pub tags: Vec<String>,
+    /// Requested provider route.
+    pub provider: String,
+    /// Resolved model identity evidence.
+    pub model_identity: ModelIdentity,
+    /// One-based attempt number.
+    pub attempt: u32,
+    /// Workspace isolation strategy.
+    pub workspace_strategy: String,
+    /// Initial exact graph digest.
+    pub initial_graph_exact_hash: Option<String>,
+    /// Initial semantic graph hash.
+    pub initial_graph_semantic_hash: Option<String>,
+    /// Final exact graph digest.
+    pub final_graph_exact_hash: Option<String>,
+    /// Final semantic graph hash.
+    pub final_graph_semantic_hash: Option<String>,
+    /// Intent specification hash.
+    pub intent_spec_hash: Option<String>,
+    /// BDD context hash.
+    pub bdd_context_hash: Option<String>,
+    /// Context pack hash.
+    pub context_pack_hash: Option<String>,
+    /// Prompt hash evidence.
+    pub prompt_hashes: PromptHashes,
+    /// Whether the attempt succeeded.
+    pub success: bool,
+    /// Number of tests passed.
+    pub tests_passed: usize,
+    /// Number of tests total.
+    pub tests_total: usize,
+    /// BDD readiness label.
+    pub bdd_readiness: Option<String>,
+    /// BDD coverage labels.
+    pub bdd_coverage: Vec<String>,
+    /// Behavior signature hash or key.
+    pub behavior_signature: Option<String>,
+    /// Failure category.
+    pub error_category: Option<ErrorCategory>,
+    /// Dominant error code or signal.
+    pub dominant_error_code: Option<String>,
+    /// Provider usage evidence.
+    pub provider_usage: ProviderUsageSummary,
+    /// Additional benchmark evidence.
+    pub benchmark_evidence: Option<BenchmarkEvidence>,
+    /// Relative artifact paths retained for this attempt.
+    pub artifact_paths: Vec<String>,
+    /// Wall-clock duration in seconds.
+    pub duration_secs: f64,
+}
+
+/// Aggregate replay metrics.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReplayMetrics {
+    /// Total selected attempts.
+    pub attempts_total: u32,
+    /// Attempts that reached terminal attempt evidence.
+    pub attempts_completed: u32,
+    /// Exact graph agreement.
+    pub exact_graph_agreement_rate: AgreementRate,
+    /// Semantic graph agreement.
+    pub semantic_graph_agreement_rate: AgreementRate,
+    /// Behavior agreement.
+    pub behavioral_agreement_rate: AgreementRate,
+    /// Failure category agreement.
+    pub failure_category_agreement_rate: AgreementRate,
+    /// Divergence examples keyed by metric or task.
+    pub divergence_examples: Vec<DivergenceExample>,
+}
+
+impl Default for ReplayMetrics {
+    fn default() -> Self {
+        Self {
+            attempts_total: 0,
+            attempts_completed: 0,
+            exact_graph_agreement_rate: AgreementRate::Unavailable {
+                reason: "no comparable attempts produced final graph evidence".to_string(),
+                comparable_attempt_count: 0,
+            },
+            semantic_graph_agreement_rate: AgreementRate::Unavailable {
+                reason: "no comparable attempts produced semantic graph evidence".to_string(),
+                comparable_attempt_count: 0,
+            },
+            behavioral_agreement_rate: AgreementRate::Unavailable {
+                reason: "no comparable attempts produced behavior evidence".to_string(),
+                comparable_attempt_count: 0,
+            },
+            failure_category_agreement_rate: AgreementRate::Unavailable {
+                reason: "no comparable attempts produced failure category evidence".to_string(),
+                comparable_attempt_count: 0,
+            },
+            divergence_examples: Vec::new(),
+        }
+    }
+}
+
+/// One divergence example for human inspection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DivergenceExample {
+    /// Task identifier.
+    pub task_id: String,
+    /// Provider route.
+    pub provider: String,
+    /// Attempt numbers involved in the divergence.
+    pub attempts: Vec<u32>,
+    /// Divergence kind.
+    pub kind: String,
+    /// Human-readable detail.
+    pub detail: String,
+}
+
+/// Rewrite comparison status.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RewriteComparisonStatus {
+    /// Rewrite comparison is not relevant for the selected task.
+    NotApplicable,
+    /// No comparable constrained rewrite mutation strategy exists yet.
+    NotYetComparable,
+    /// Only metadata can be reported.
+    MetadataOnly,
+    /// Same-task comparison evidence exists.
+    Comparable,
+}
+
+/// Rewrite comparison evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RewriteComparison {
+    /// Comparison status.
+    pub status: RewriteComparisonStatus,
+    /// Stable reason or summary.
+    pub reason: String,
+}
+
+impl RewriteComparison {
+    /// Creates a conservative not-yet-comparable rewrite comparison.
+    #[must_use]
+    pub fn not_yet_comparable(reason: impl Into<String>) -> Self {
+        Self {
+            status: RewriteComparisonStatus::NotYetComparable,
+            reason: reason.into(),
+        }
+    }
+}
+
+/// Append-only replay ledger event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LedgerEvent {
+    /// Ledger event schema version.
+    pub schema_version: String,
+    /// Stable run identifier.
+    pub run_id: String,
+    /// Event kind.
+    pub event: LedgerEventKind,
+    /// Monotonic event sequence.
+    pub sequence: u64,
+    /// UTC event timestamp as RFC3339 text.
+    pub timestamp: String,
+    /// Task identifier, when applicable.
+    pub task_id: Option<String>,
+    /// Provider route, when applicable.
+    pub provider: Option<String>,
+    /// Attempt number, when applicable.
+    pub attempt: Option<u32>,
+    /// Event payload.
+    pub payload: serde_json::Value,
+}
+
+impl LedgerEvent {
+    /// Creates a ledger event with the v1 schema version.
+    #[must_use]
+    pub fn new(
+        run_id: impl Into<String>,
+        event: LedgerEventKind,
+        sequence: u64,
+        timestamp: impl Into<String>,
+        payload: serde_json::Value,
+    ) -> Self {
+        Self {
+            schema_version: REPLAY_LEDGER_SCHEMA_VERSION.to_string(),
+            run_id: run_id.into(),
+            event,
+            sequence,
+            timestamp: timestamp.into(),
+            task_id: None,
+            provider: None,
+            attempt: None,
+            payload,
+        }
+    }
+}
+
+/// Replay ledger event kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LedgerEventKind {
+    /// Run started.
+    RunStarted,
+    /// Task was selected.
+    TaskSelected,
+    /// Attempt started.
+    AttemptStarted,
+    /// Context was locked.
+    ContextLocked,
+    /// Attempt completed.
+    AttemptCompleted,
+    /// Attempt failed.
+    AttemptFailed,
+    /// Run completed.
+    RunCompleted,
+    /// Run interrupted.
+    RunInterrupted,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn report_serializes_schema_and_rewrite_status() {
+        let report = ReplayReport::new(
+            "run-1",
+            "2026-06-17T00:00:00Z",
+            "2026-06-17T00:00:01Z",
+            "0.4.0-preview",
+            "abc123",
+            ReplayInputs {
+                suite: "core".to_string(),
+                smoke: false,
+                showcases: vec!["calculator".to_string()],
+                providers: vec!["minimax:auto:primary:MINIMAX_API_KEY".to_string()],
+                attempts: 2,
+            },
+            ReplayEnvironment {
+                provider_source: "user".to_string(),
+                registry_state_hash: "state".to_string(),
+                lockfile_hash: "absent".to_string(),
+                workspace_dependency_config_hash: "absent".to_string(),
+            },
+        );
+
+        let json = serde_json::to_string(&report).expect("report serializes");
+        assert!(json.contains("\"schema_version\":\"duumbi.determinism.replay_report.v1\""));
+        assert!(json.contains("\"status\":\"not_yet_comparable\""));
+        assert!(!json.contains("api_key"));
+    }
+
+    #[test]
+    fn model_identity_unavailable_is_explicit() {
+        let model = ModelIdentity::unavailable("provider did not expose resolved model");
+
+        let json = serde_json::to_string(&model).expect("model identity serializes");
+        assert_eq!(
+            json,
+            r#"{"status":"unavailable","reason":"provider did not expose resolved model"}"#
+        );
+    }
+
+    #[test]
+    fn ledger_event_uses_schema_version() {
+        let event = LedgerEvent::new(
+            "run-1",
+            LedgerEventKind::RunStarted,
+            1,
+            "2026-06-17T00:00:00Z",
+            serde_json::json!({"ok": true}),
+        );
+
+        assert_eq!(event.schema_version, REPLAY_LEDGER_SCHEMA_VERSION);
+        let json = serde_json::to_string(&event).expect("ledger event serializes");
+        assert!(json.contains("\"event\":\"run_started\""));
+    }
+}

--- a/src/determinism/ledger.rs
+++ b/src/determinism/ledger.rs
@@ -1,0 +1,135 @@
+//! Append-only replay ledger writer.
+
+use std::fs::{File, OpenOptions};
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+use super::evidence::LedgerEvent;
+
+/// Errors produced while writing replay ledger events.
+#[derive(Debug, Error)]
+pub enum LedgerError {
+    /// Ledger file open failed.
+    #[error("failed to open replay ledger at {path}: {source}")]
+    Open {
+        /// Ledger path.
+        path: String,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// Ledger event serialization failed.
+    #[error("failed to serialize replay ledger event: {0}")]
+    Serialize(#[source] serde_json::Error),
+    /// Ledger event write failed.
+    #[error("failed to write replay ledger event at {path}: {source}")]
+    Write {
+        /// Ledger path.
+        path: String,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// Ledger event flush failed.
+    #[error("failed to flush replay ledger at {path}: {source}")]
+    Flush {
+        /// Ledger path.
+        path: String,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// Append-only JSONL writer for replay ledger events.
+pub struct LedgerWriter {
+    path: PathBuf,
+    writer: BufWriter<File>,
+}
+
+impl LedgerWriter {
+    /// Opens a ledger writer in append-only mode.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LedgerError`] if the ledger file cannot be opened.
+    #[must_use = "ledger writer must be used to record events"]
+    pub fn open(path: &Path) -> Result<Self, LedgerError> {
+        let file = OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(path)
+            .map_err(|source| LedgerError::Open {
+                path: path.display().to_string(),
+                source,
+            })?;
+        Ok(Self {
+            path: path.to_path_buf(),
+            writer: BufWriter::new(file),
+        })
+    }
+
+    /// Appends one event as a JSON line and flushes it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LedgerError`] if serialization, writing, or flushing fails.
+    #[must_use = "ledger append result must be handled"]
+    pub fn append(&mut self, event: &LedgerEvent) -> Result<(), LedgerError> {
+        serde_json::to_writer(&mut self.writer, event).map_err(LedgerError::Serialize)?;
+        self.writer
+            .write_all(b"\n")
+            .map_err(|source| LedgerError::Write {
+                path: self.path.display().to_string(),
+                source,
+            })?;
+        self.writer.flush().map_err(|source| LedgerError::Flush {
+            path: self.path.display().to_string(),
+            source,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::determinism::evidence::{LedgerEventKind, REPLAY_LEDGER_SCHEMA_VERSION};
+
+    #[test]
+    fn ledger_writer_appends_json_lines() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("ledger.jsonl");
+        let mut writer = LedgerWriter::open(&path).expect("ledger opens");
+
+        writer
+            .append(&LedgerEvent::new(
+                "run-1",
+                LedgerEventKind::RunStarted,
+                1,
+                "2026-06-17T00:00:00Z",
+                serde_json::json!({"ok": true}),
+            ))
+            .expect("event writes");
+        writer
+            .append(&LedgerEvent::new(
+                "run-1",
+                LedgerEventKind::RunCompleted,
+                2,
+                "2026-06-17T00:00:01Z",
+                serde_json::json!({"ok": true}),
+            ))
+            .expect("event writes");
+
+        let contents = fs::read_to_string(path).expect("ledger reads");
+        let lines: Vec<_> = contents.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains(REPLAY_LEDGER_SCHEMA_VERSION));
+        assert!(lines[1].contains("\"event\":\"run_completed\""));
+    }
+}

--- a/src/determinism/metrics.rs
+++ b/src/determinism/metrics.rs
@@ -28,14 +28,6 @@ pub enum AgreementRate {
     },
 }
 
-impl AgreementRate {
-    /// Returns true when the metric is available.
-    #[must_use]
-    pub fn is_available(&self) -> bool {
-        matches!(self, Self::Available { .. })
-    }
-}
-
 /// Computes largest-group agreement for optional equivalence keys.
 ///
 /// `None` values are treated as non-comparable attempts. When no comparable

--- a/src/determinism/metrics.rs
+++ b/src/determinism/metrics.rs
@@ -14,9 +14,10 @@ pub enum AgreementRate {
         rate: f64,
         /// Number of attempts with comparable evidence.
         comparable_attempt_count: usize,
-        /// Size of the dominant equivalence group.
+        /// Size of the dominant equivalence group, or the sum of dominant
+        /// groups when aggregating independent task/provider replay pairs.
         largest_equivalence_group_count: usize,
-        /// Dominant equivalence key.
+        /// Dominant equivalence key, or an aggregate grouping label.
         dominant_key: String,
     },
     /// Agreement could not be computed.

--- a/src/determinism/metrics.rs
+++ b/src/determinism/metrics.rs
@@ -78,6 +78,21 @@ pub fn threshold_passes(metric: &AgreementRate, threshold: Option<f64>) -> bool 
     }
 }
 
+/// Evaluates the determinism replay CI gate against optional thresholds.
+#[must_use]
+pub fn replay_ci_thresholds_pass(
+    exact_graph_agreement_rate: &AgreementRate,
+    semantic_graph_agreement_rate: &AgreementRate,
+    behavioral_agreement_rate: &AgreementRate,
+    min_exact_agreement: Option<f64>,
+    min_semantic_agreement: Option<f64>,
+    min_behavioral_agreement: Option<f64>,
+) -> bool {
+    threshold_passes(exact_graph_agreement_rate, min_exact_agreement)
+        && threshold_passes(semantic_graph_agreement_rate, min_semantic_agreement)
+        && threshold_passes(behavioral_agreement_rate, min_behavioral_agreement)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -127,5 +142,50 @@ mod tests {
 
         assert!(threshold_passes(&metric, None));
         assert!(!threshold_passes(&metric, Some(1.0)));
+    }
+
+    #[test]
+    fn replay_ci_thresholds_require_only_requested_metrics() {
+        let exact = AgreementRate::Available {
+            rate: 0.5,
+            comparable_attempt_count: 2,
+            largest_equivalence_group_count: 1,
+            dominant_key: "exact-a".to_string(),
+        };
+        let semantic = AgreementRate::Available {
+            rate: 1.0,
+            comparable_attempt_count: 2,
+            largest_equivalence_group_count: 2,
+            dominant_key: "semantic-a".to_string(),
+        };
+        let behavior = AgreementRate::Unavailable {
+            reason: "no behavior evidence".to_string(),
+            comparable_attempt_count: 0,
+        };
+
+        assert!(replay_ci_thresholds_pass(
+            &exact,
+            &semantic,
+            &behavior,
+            Some(0.5),
+            Some(1.0),
+            None
+        ));
+        assert!(!replay_ci_thresholds_pass(
+            &exact,
+            &semantic,
+            &behavior,
+            Some(1.0),
+            Some(1.0),
+            None
+        ));
+        assert!(!replay_ci_thresholds_pass(
+            &exact,
+            &semantic,
+            &behavior,
+            None,
+            None,
+            Some(1.0)
+        ));
     }
 }

--- a/src/determinism/metrics.rs
+++ b/src/determinism/metrics.rs
@@ -1,0 +1,139 @@
+//! Equivalence grouping and replay agreement metrics.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Agreement metric for one equivalence tier.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum AgreementRate {
+    /// Agreement could be computed from one or more comparable attempts.
+    Available {
+        /// Largest equivalence group divided by comparable attempts.
+        rate: f64,
+        /// Number of attempts with comparable evidence.
+        comparable_attempt_count: usize,
+        /// Size of the dominant equivalence group.
+        largest_equivalence_group_count: usize,
+        /// Dominant equivalence key.
+        dominant_key: String,
+    },
+    /// Agreement could not be computed.
+    Unavailable {
+        /// Stable reason why no metric was available.
+        reason: String,
+        /// Number of attempts with comparable evidence.
+        comparable_attempt_count: usize,
+    },
+}
+
+impl AgreementRate {
+    /// Returns true when the metric is available.
+    #[must_use]
+    pub fn is_available(&self) -> bool {
+        matches!(self, Self::Available { .. })
+    }
+}
+
+/// Computes largest-group agreement for optional equivalence keys.
+///
+/// `None` values are treated as non-comparable attempts. When no comparable
+/// attempts exist, the function returns [`AgreementRate::Unavailable`] rather
+/// than NaN or infinity.
+#[must_use]
+pub fn largest_group_agreement<I, S>(values: I, unavailable_reason: &str) -> AgreementRate
+where
+    I: IntoIterator<Item = Option<S>>,
+    S: AsRef<str>,
+{
+    let mut groups: BTreeMap<String, usize> = BTreeMap::new();
+    for value in values.into_iter().flatten() {
+        *groups.entry(value.as_ref().to_string()).or_default() += 1;
+    }
+
+    let comparable_attempt_count = groups.values().sum();
+    if comparable_attempt_count == 0 {
+        return AgreementRate::Unavailable {
+            reason: unavailable_reason.to_string(),
+            comparable_attempt_count,
+        };
+    }
+
+    let (dominant_key, largest_equivalence_group_count) = groups
+        .into_iter()
+        .max_by(|left, right| left.1.cmp(&right.1).then_with(|| right.0.cmp(&left.0)))
+        .expect("invariant: comparable_attempt_count > 0 means groups is non-empty");
+    let rate = largest_equivalence_group_count as f64 / comparable_attempt_count as f64;
+
+    AgreementRate::Available {
+        rate,
+        comparable_attempt_count,
+        largest_equivalence_group_count,
+        dominant_key,
+    }
+}
+
+/// Evaluates an optional CI threshold against one agreement metric.
+#[must_use]
+pub fn threshold_passes(metric: &AgreementRate, threshold: Option<f64>) -> bool {
+    let Some(threshold) = threshold else {
+        return true;
+    };
+    match metric {
+        AgreementRate::Available { rate, .. } => *rate >= threshold,
+        AgreementRate::Unavailable { .. } => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn largest_group_agreement_uses_dominant_group() {
+        let metric = largest_group_agreement(
+            [Some("a"), Some("b"), Some("a"), None],
+            "no comparable graph evidence",
+        );
+
+        assert_eq!(
+            metric,
+            AgreementRate::Available {
+                rate: 2.0 / 3.0,
+                comparable_attempt_count: 3,
+                largest_equivalence_group_count: 2,
+                dominant_key: "a".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn zero_comparable_attempts_are_unavailable() {
+        let metric =
+            largest_group_agreement([Option::<&str>::None], "no comparable graph evidence");
+
+        assert_eq!(
+            metric,
+            AgreementRate::Unavailable {
+                reason: "no comparable graph evidence".to_string(),
+                comparable_attempt_count: 0,
+            }
+        );
+        let json = serde_json::to_string(&metric).expect("metric serializes");
+        assert!(json.contains("\"status\":\"unavailable\""));
+        assert!(!json.contains("NaN"));
+        assert!(!json.contains("inf"));
+    }
+
+    #[test]
+    fn unavailable_metric_fails_explicit_threshold_only() {
+        let metric = AgreementRate::Unavailable {
+            reason: "no comparable graph evidence".to_string(),
+            comparable_attempt_count: 0,
+        };
+
+        assert!(threshold_passes(&metric, None));
+        assert!(!threshold_passes(&metric, Some(1.0)));
+    }
+}

--- a/src/determinism/mod.rs
+++ b/src/determinism/mod.rs
@@ -1,0 +1,9 @@
+//! Determinism replay evidence, digests, and metrics.
+//!
+//! The first determinism slice is CLI-first replay measurement. This module
+//! keeps the schema and low-level deterministic helpers separate from the later
+//! provider-backed runner and CLI dispatch code.
+
+pub mod digest;
+pub mod evidence;
+pub mod metrics;

--- a/src/determinism/mod.rs
+++ b/src/determinism/mod.rs
@@ -8,3 +8,4 @@ pub mod digest;
 pub mod evidence;
 pub mod ledger;
 pub mod metrics;
+pub mod runner;

--- a/src/determinism/mod.rs
+++ b/src/determinism/mod.rs
@@ -6,4 +6,5 @@
 
 pub mod digest;
 pub mod evidence;
+pub mod ledger;
 pub mod metrics;

--- a/src/determinism/runner.rs
+++ b/src/determinism/runner.rs
@@ -1,0 +1,599 @@
+//! Provider-backed determinism replay runner.
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use crate::agents::LlmProvider;
+use crate::agents::factory;
+use crate::bench::report::{
+    BenchmarkEvidence, ErrorCategory, ProviderUsageSummary, categorize_error,
+};
+use crate::bench::runner::{
+    extract_error_codes, filter_providers, load_archived_intent, provider_name,
+};
+use crate::bench::showcases::{self, Showcase, ShowcaseSuite, ShowcaseVerification};
+use crate::config::ProviderConfig;
+use crate::hash;
+use crate::intent;
+use crate::intent::spec::{IntentSpec, IntentStatus};
+
+use super::digest::{exact_graph_digest, safe_artifact_key, workspace_state_hashes};
+use super::evidence::{
+    LedgerEvent, LedgerEventKind, ModelIdentity, PromptHashes, ReplayAttempt, ReplayEnvironment,
+    ReplayInputs, ReplayMetrics, ReplayReport, ReplayTask,
+};
+use super::ledger::LedgerWriter;
+
+/// Configuration for one determinism replay run.
+#[derive(Debug, Clone)]
+pub struct ReplayConfig {
+    /// Stable run identifier.
+    pub run_id: String,
+    /// Number of attempts per selected task/provider pair.
+    pub attempts: u32,
+    /// Provider configs to replay.
+    pub providers: Vec<ProviderConfig>,
+    /// Optional showcase name filter.
+    pub showcase_filter: Option<Vec<String>>,
+    /// Optional provider route filter.
+    pub provider_filter: Option<Vec<String>>,
+    /// Optional benchmark suite filter.
+    pub suite_filter: Option<ShowcaseSuite>,
+    /// Whether to select only the low-budget smoke subset.
+    pub smoke: bool,
+    /// Replay artifact bundle root.
+    pub artifact_dir: PathBuf,
+    /// UTC start timestamp as RFC3339 text.
+    pub started_at: String,
+    /// UTC finish timestamp as RFC3339 text supplied by the caller.
+    pub finished_at: String,
+    /// Source commit used for report metadata.
+    pub source_commit: String,
+    /// Provider configuration source label.
+    pub provider_source: String,
+}
+
+/// Runs determinism replay for selected benchmark showcases.
+///
+/// # Errors
+///
+/// Returns an error string when selection, provider creation, artifact writing,
+/// or workspace initialization fails before a report can be produced.
+#[must_use = "determinism replay report should be inspected or written"]
+pub async fn run_replay<F>(config: &ReplayConfig, init_workspace: F) -> Result<ReplayReport, String>
+where
+    F: Fn(&Path) -> Result<(), anyhow::Error> + Send + Sync,
+{
+    let showcase_refs = showcases::filter_showcases_with_options(
+        config.showcase_filter.as_deref(),
+        config.suite_filter,
+        config.smoke,
+    );
+    if showcase_refs.is_empty() {
+        return Err("no showcases match the given filter".to_string());
+    }
+
+    let provider_configs = filter_providers(&config.providers, config.provider_filter.as_deref());
+    if provider_configs.is_empty() {
+        return Err("no providers match the given filter".to_string());
+    }
+
+    let run_dir = config.artifact_dir.join(&config.run_id);
+    std::fs::create_dir_all(&run_dir).map_err(|source| {
+        format!(
+            "failed to create replay run dir '{}': {source}",
+            run_dir.display()
+        )
+    })?;
+    let mut ledger =
+        LedgerWriter::open(&run_dir.join("ledger.jsonl")).map_err(|error| format!("{error}"))?;
+    append_ledger(
+        &mut ledger,
+        LedgerEvent::new(
+            &config.run_id,
+            LedgerEventKind::RunStarted,
+            1,
+            &config.started_at,
+            serde_json::json!({"artifact_dir": run_dir.display().to_string()}),
+        ),
+    )?;
+
+    let workspace_state =
+        workspace_state_hashes(Path::new(".")).map_err(|error| format!("{error}"))?;
+    let inputs = ReplayInputs {
+        suite: config
+            .suite_filter
+            .map_or_else(|| "core".to_string(), |suite| suite.as_str().to_string()),
+        smoke: config.smoke,
+        showcases: showcase_refs
+            .iter()
+            .map(|showcase| showcase.name.to_string())
+            .collect(),
+        providers: provider_configs
+            .iter()
+            .map(|provider| provider_name(provider))
+            .collect(),
+        attempts: config.attempts,
+    };
+    let environment = ReplayEnvironment {
+        provider_source: config.provider_source.clone(),
+        registry_state_hash: workspace_state.registry_state_hash,
+        lockfile_hash: workspace_state.lockfile_hash,
+        workspace_dependency_config_hash: workspace_state.workspace_dependency_config_hash,
+    };
+
+    let mut report = ReplayReport::new(
+        &config.run_id,
+        &config.started_at,
+        &config.finished_at,
+        env!("CARGO_PKG_VERSION"),
+        &config.source_commit,
+        inputs,
+        environment,
+    );
+
+    let mut sequence = 2u64;
+    for showcase in showcase_refs {
+        let spec = showcases::parse_showcase(showcase)?;
+        report.tasks.push(ReplayTask {
+            task_id: showcase.name.to_string(),
+            suite: showcase.suite.as_str().to_string(),
+            tags: showcase.tags.iter().map(|tag| (*tag).to_string()).collect(),
+        });
+        append_ledger(
+            &mut ledger,
+            event_with_task(
+                &config.run_id,
+                LedgerEventKind::TaskSelected,
+                sequence,
+                &config.started_at,
+                showcase.name,
+                serde_json::json!({"suite": showcase.suite.as_str(), "tags": showcase.tags}),
+            ),
+        )?;
+        sequence += 1;
+
+        for provider_config in &provider_configs {
+            let provider = factory::create_provider(provider_config).map_err(|error| {
+                format!(
+                    "failed to create provider '{}': {error}",
+                    provider_name(provider_config)
+                )
+            })?;
+            let provider_route = provider_name(provider_config);
+            let provider_key = safe_artifact_key(&provider_route, "provider");
+            let model_identity = ModelIdentity::Available {
+                label: provider.model_label(),
+            };
+            for attempt in 1..=config.attempts {
+                let attempt_dir = run_dir
+                    .join("attempts")
+                    .join(safe_artifact_key(showcase.name, "task"))
+                    .join(&provider_key)
+                    .join(attempt.to_string());
+                std::fs::create_dir_all(&attempt_dir).map_err(|source| {
+                    format!(
+                        "failed to create replay attempt dir '{}': {source}",
+                        attempt_dir.display()
+                    )
+                })?;
+                append_ledger(
+                    &mut ledger,
+                    event_with_attempt(
+                        &config.run_id,
+                        LedgerEventKind::AttemptStarted,
+                        sequence,
+                        &config.started_at,
+                        showcase.name,
+                        &provider_route,
+                        attempt,
+                        serde_json::json!({"artifact_dir": attempt_dir.display().to_string()}),
+                    ),
+                )?;
+                sequence += 1;
+
+                let replay_attempt = run_single_replay(
+                    showcase,
+                    provider.as_ref(),
+                    model_identity.clone(),
+                    &provider_route,
+                    &spec,
+                    attempt,
+                    &attempt_dir,
+                    &init_workspace,
+                )
+                .await;
+
+                append_ledger(
+                    &mut ledger,
+                    event_with_attempt(
+                        &config.run_id,
+                        if replay_attempt.success {
+                            LedgerEventKind::AttemptCompleted
+                        } else {
+                            LedgerEventKind::AttemptFailed
+                        },
+                        sequence,
+                        &config.finished_at,
+                        showcase.name,
+                        &provider_route,
+                        attempt,
+                        serde_json::json!({
+                            "success": replay_attempt.success,
+                            "tests_passed": replay_attempt.tests_passed,
+                            "tests_total": replay_attempt.tests_total,
+                            "error": replay_attempt.dominant_error_code,
+                        }),
+                    ),
+                )?;
+                sequence += 1;
+                report.attempts.push(replay_attempt);
+            }
+        }
+    }
+
+    report.metrics = ReplayMetrics::from_attempts(&report.attempts);
+    append_ledger(
+        &mut ledger,
+        LedgerEvent::new(
+            &config.run_id,
+            LedgerEventKind::RunCompleted,
+            sequence,
+            &config.finished_at,
+            serde_json::json!({
+                "attempts_total": report.metrics.attempts_total,
+                "attempts_completed": report.metrics.attempts_completed,
+            }),
+        ),
+    )?;
+
+    Ok(report)
+}
+
+async fn run_single_replay<F>(
+    showcase: &Showcase,
+    provider: &dyn LlmProvider,
+    model_identity: ModelIdentity,
+    provider_route: &str,
+    spec: &IntentSpec,
+    attempt: u32,
+    attempt_dir: &Path,
+    init_workspace: &F,
+) -> ReplayAttempt
+where
+    F: Fn(&Path) -> Result<(), anyhow::Error>,
+{
+    let start = Instant::now();
+    if let ShowcaseVerification::ProcessEvidence {
+        evidence_kind,
+        expected_route,
+        expected_json_fields,
+        verification_gap,
+    } = showcase.verification
+    {
+        return replay_attempt_from_parts(ReplayAttemptParts {
+            success: false,
+            tests_passed: 0,
+            tests_total: spec.test_cases.len(),
+            error_category: Some(ErrorCategory::EvidenceRequired),
+            dominant_error_code: Some("broader_evidence_required".to_string()),
+            benchmark_evidence: Some(BenchmarkEvidence {
+                kind: evidence_kind.to_string(),
+                status: "broader_evidence_required".to_string(),
+                detail: verification_gap.to_string(),
+                command: None,
+                expected_route: Some(expected_route.to_string()),
+                expected_json_fields: expected_json_fields
+                    .iter()
+                    .map(|field| (*field).to_string())
+                    .collect(),
+                verification_gap: Some(verification_gap.to_string()),
+                artifact_path: None,
+            }),
+            duration_secs: start.elapsed().as_secs_f64(),
+            ..ReplayAttemptParts::new(showcase, provider_route, model_identity, attempt)
+        });
+    }
+
+    let tmp = match tempfile::TempDir::new() {
+        Ok(tmp) => tmp,
+        Err(error) => {
+            return replay_attempt_from_error(
+                showcase,
+                provider_route,
+                model_identity,
+                attempt,
+                spec.test_cases.len(),
+                format!("tempdir creation failed: {error}"),
+                start.elapsed().as_secs_f64(),
+            );
+        }
+    };
+    let workspace = tmp.path();
+    if let Err(error) = init_workspace(workspace) {
+        return replay_attempt_from_error(
+            showcase,
+            provider_route,
+            model_identity,
+            attempt,
+            spec.test_cases.len(),
+            format!("init failed: {error}"),
+            start.elapsed().as_secs_f64(),
+        );
+    }
+
+    let graph_dir = workspace.join(".duumbi/graph");
+    let initial_graph_exact_hash = exact_graph_digest(&graph_dir).ok();
+    let initial_graph_semantic_hash = hash::semantic_hash(&graph_dir).ok();
+
+    let slug = "determinism-replay";
+    let mut run_spec = spec.clone();
+    run_spec.status = IntentStatus::Pending;
+    if let Err(error) = intent::save_intent(workspace, slug, &run_spec) {
+        return replay_attempt_from_error(
+            showcase,
+            provider_route,
+            model_identity,
+            attempt,
+            spec.test_cases.len(),
+            format!("failed to save intent: {error}"),
+            start.elapsed().as_secs_f64(),
+        );
+    }
+
+    let mut log = Vec::new();
+    let execute_result = intent::execute::run_execute(provider, workspace, slug, &mut log).await;
+    let final_spec = intent::load_intent(workspace, slug)
+        .or_else(|_| load_archived_intent(workspace, slug))
+        .ok();
+    let tests_total = spec.test_cases.len();
+    let tests_passed = final_spec
+        .as_ref()
+        .and_then(|loaded| loaded.execution.as_ref())
+        .map_or(0, |execution| execution.tests_passed);
+    let final_graph_exact_hash = exact_graph_digest(&graph_dir).ok();
+    let final_graph_semantic_hash = hash::semantic_hash(&graph_dir).ok();
+    let error_text = execute_result.as_ref().err().map(ToString::to_string);
+    let dominant_error_code = extract_error_codes(&log.join("\n"))
+        .into_iter()
+        .next()
+        .or_else(|| {
+            error_text
+                .as_ref()
+                .and_then(|text| extract_error_codes(text).into_iter().next())
+        });
+    let success = execute_result.unwrap_or(false) && tests_passed == tests_total;
+    let error_category = if success {
+        None
+    } else {
+        Some(
+            error_text
+                .as_deref()
+                .map_or(ErrorCategory::LogicError, categorize_error),
+        )
+    };
+    let artifact_paths = retain_attempt_log(attempt_dir, &log);
+    let behavior_signature = Some(format!(
+        "success={success};tests={tests_passed}/{tests_total};error={}",
+        error_category
+            .map(|category| category.to_string())
+            .unwrap_or_else(|| "none".to_string())
+    ));
+
+    ReplayAttempt {
+        task_id: showcase.name.to_string(),
+        suite: showcase.suite.as_str().to_string(),
+        tags: showcase.tags.iter().map(|tag| (*tag).to_string()).collect(),
+        provider: provider_route.to_string(),
+        model_identity,
+        attempt,
+        workspace_strategy: "isolated_tempdir".to_string(),
+        initial_graph_exact_hash,
+        initial_graph_semantic_hash,
+        final_graph_exact_hash,
+        final_graph_semantic_hash,
+        intent_spec_hash: None,
+        bdd_context_hash: None,
+        context_pack_hash: None,
+        prompt_hashes: PromptHashes::Unavailable {
+            reason: "execution_evidence_sink_not_implemented".to_string(),
+        },
+        success,
+        tests_passed,
+        tests_total,
+        bdd_readiness: None,
+        bdd_coverage: Vec::new(),
+        behavior_signature,
+        error_category,
+        dominant_error_code,
+        provider_usage: ProviderUsageSummary::unavailable("provider_response_did_not_expose_usage"),
+        benchmark_evidence: None,
+        artifact_paths,
+        duration_secs: start.elapsed().as_secs_f64(),
+    }
+}
+
+struct ReplayAttemptParts<'a> {
+    showcase: &'a Showcase,
+    provider_route: &'a str,
+    model_identity: ModelIdentity,
+    attempt: u32,
+    success: bool,
+    tests_passed: usize,
+    tests_total: usize,
+    error_category: Option<ErrorCategory>,
+    dominant_error_code: Option<String>,
+    benchmark_evidence: Option<BenchmarkEvidence>,
+    duration_secs: f64,
+}
+
+impl<'a> ReplayAttemptParts<'a> {
+    fn new(
+        showcase: &'a Showcase,
+        provider_route: &'a str,
+        model_identity: ModelIdentity,
+        attempt: u32,
+    ) -> Self {
+        Self {
+            showcase,
+            provider_route,
+            model_identity,
+            attempt,
+            success: false,
+            tests_passed: 0,
+            tests_total: 0,
+            error_category: None,
+            dominant_error_code: None,
+            benchmark_evidence: None,
+            duration_secs: 0.0,
+        }
+    }
+}
+
+fn replay_attempt_from_parts(parts: ReplayAttemptParts<'_>) -> ReplayAttempt {
+    ReplayAttempt {
+        task_id: parts.showcase.name.to_string(),
+        suite: parts.showcase.suite.as_str().to_string(),
+        tags: parts
+            .showcase
+            .tags
+            .iter()
+            .map(|tag| (*tag).to_string())
+            .collect(),
+        provider: parts.provider_route.to_string(),
+        model_identity: parts.model_identity,
+        attempt: parts.attempt,
+        workspace_strategy: "not_applicable".to_string(),
+        initial_graph_exact_hash: None,
+        initial_graph_semantic_hash: None,
+        final_graph_exact_hash: None,
+        final_graph_semantic_hash: None,
+        intent_spec_hash: None,
+        bdd_context_hash: None,
+        context_pack_hash: None,
+        prompt_hashes: PromptHashes::Unavailable {
+            reason: "no provider mutation prompt for broader-evidence placeholder".to_string(),
+        },
+        success: parts.success,
+        tests_passed: parts.tests_passed,
+        tests_total: parts.tests_total,
+        bdd_readiness: None,
+        bdd_coverage: Vec::new(),
+        behavior_signature: Some(format!(
+            "success={};tests={}/{};error={}",
+            parts.success,
+            parts.tests_passed,
+            parts.tests_total,
+            parts
+                .error_category
+                .map(|category| category.to_string())
+                .unwrap_or_else(|| "none".to_string())
+        )),
+        error_category: parts.error_category,
+        dominant_error_code: parts.dominant_error_code,
+        provider_usage: ProviderUsageSummary::unavailable("process_evidence_not_executed"),
+        benchmark_evidence: parts.benchmark_evidence,
+        artifact_paths: Vec::new(),
+        duration_secs: parts.duration_secs,
+    }
+}
+
+fn replay_attempt_from_error(
+    showcase: &Showcase,
+    provider_route: &str,
+    model_identity: ModelIdentity,
+    attempt: u32,
+    tests_total: usize,
+    message: String,
+    duration_secs: f64,
+) -> ReplayAttempt {
+    let category = categorize_error(&message);
+    replay_attempt_from_parts(ReplayAttemptParts {
+        showcase,
+        provider_route,
+        model_identity,
+        attempt,
+        tests_total,
+        error_category: Some(category),
+        dominant_error_code: extract_error_codes(&message).into_iter().next(),
+        duration_secs,
+        ..ReplayAttemptParts::new(
+            showcase,
+            provider_route,
+            ModelIdentity::unavailable("unused"),
+            attempt,
+        )
+    })
+}
+
+fn retain_attempt_log(attempt_dir: &Path, log: &[String]) -> Vec<String> {
+    if log.is_empty() {
+        return Vec::new();
+    }
+    let path = attempt_dir.join("execute.log");
+    if std::fs::write(&path, log.join("\n")).is_ok() {
+        vec![path.display().to_string()]
+    } else {
+        Vec::new()
+    }
+}
+
+fn append_ledger(writer: &mut LedgerWriter, event: LedgerEvent) -> Result<(), String> {
+    writer.append(&event).map_err(|error| format!("{error}"))
+}
+
+fn event_with_task(
+    run_id: &str,
+    event: LedgerEventKind,
+    sequence: u64,
+    timestamp: &str,
+    task_id: &str,
+    payload: serde_json::Value,
+) -> LedgerEvent {
+    let mut event = LedgerEvent::new(run_id, event, sequence, timestamp, payload);
+    event.task_id = Some(task_id.to_string());
+    event
+}
+
+fn event_with_attempt(
+    run_id: &str,
+    event: LedgerEventKind,
+    sequence: u64,
+    timestamp: &str,
+    task_id: &str,
+    provider: &str,
+    attempt: u32,
+    payload: serde_json::Value,
+) -> LedgerEvent {
+    let mut event = event_with_task(run_id, event, sequence, timestamp, task_id, payload);
+    event.provider = Some(provider.to_string());
+    event.attempt = Some(attempt);
+    event
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{ProviderKind, ProviderRole};
+
+    fn provider_config(model: Option<&str>) -> ProviderConfig {
+        ProviderConfig {
+            provider: ProviderKind::OpenAI,
+            role: ProviderRole::Primary,
+            model: model.map(ToString::to_string),
+            api_key_env: "OPENAI_API_KEY".to_string(),
+            base_url: None,
+            timeout_secs: None,
+            key_storage: None,
+            auth_token_env: None,
+        }
+    }
+
+    #[test]
+    fn replay_inputs_use_benchmark_provider_routes() {
+        let providers = vec![provider_config(Some("gpt-test"))];
+        let filtered = filter_providers(&providers, None);
+
+        assert_eq!(provider_name(filtered[0]), "openai:gpt-test");
+    }
+}

--- a/src/determinism/runner.rs
+++ b/src/determinism/runner.rs
@@ -1,5 +1,6 @@
 //! Provider-backed determinism replay runner.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
@@ -15,9 +16,12 @@ use crate::bench::showcases::{self, Showcase, ShowcaseSuite, ShowcaseVerificatio
 use crate::config::ProviderConfig;
 use crate::hash;
 use crate::intent;
+use crate::intent::bdd::{DEFAULT_BDD_CONTEXT_LIMIT, load_bdd_report, render_bdd_prompt_context};
 use crate::intent::spec::{IntentSpec, IntentStatus};
 
-use super::digest::{exact_graph_digest, safe_artifact_key, workspace_state_hashes};
+use super::digest::{
+    exact_graph_digest, safe_artifact_key, sha256_hex_bytes, workspace_state_hashes,
+};
 use super::evidence::{
     LedgerEvent, LedgerEventKind, ModelIdentity, PromptHashes, ReplayAttempt, ReplayEnvironment,
     ReplayInputs, ReplayMetrics, ReplayReport, ReplayTask,
@@ -63,6 +67,26 @@ pub struct ReplayConfig {
 pub async fn run_replay<F>(config: &ReplayConfig, init_workspace: F) -> Result<ReplayReport, String>
 where
     F: Fn(&Path) -> Result<(), anyhow::Error> + Send + Sync,
+{
+    run_replay_with_provider_factory(config, init_workspace, |provider_config| {
+        factory::create_provider(provider_config).map_err(|error| {
+            format!(
+                "failed to create provider '{}': {error}",
+                provider_name(provider_config)
+            )
+        })
+    })
+    .await
+}
+
+async fn run_replay_with_provider_factory<F, P>(
+    config: &ReplayConfig,
+    init_workspace: F,
+    create_provider: P,
+) -> Result<ReplayReport, String>
+where
+    F: Fn(&Path) -> Result<(), anyhow::Error> + Send + Sync,
+    P: Fn(&ProviderConfig) -> Result<Box<dyn LlmProvider>, String>,
 {
     let showcase_refs = showcases::filter_showcases_with_options(
         config.showcase_filter.as_deref(),
@@ -154,12 +178,7 @@ where
         sequence += 1;
 
         for provider_config in &provider_configs {
-            let provider = factory::create_provider(provider_config).map_err(|error| {
-                format!(
-                    "failed to create provider '{}': {error}",
-                    provider_name(provider_config)
-                )
-            })?;
+            let provider = create_provider(provider_config)?;
             let provider_route = provider_name(provider_config);
             let provider_key = safe_artifact_key(&provider_route, "provider");
             let model_identity = ModelIdentity::Available {
@@ -179,53 +198,53 @@ where
                 })?;
                 append_ledger(
                     &mut ledger,
-                    event_with_attempt(
-                        &config.run_id,
-                        LedgerEventKind::AttemptStarted,
+                    event_with_attempt(AttemptEvent {
+                        run_id: &config.run_id,
+                        event: LedgerEventKind::AttemptStarted,
                         sequence,
-                        &config.started_at,
-                        showcase.name,
-                        &provider_route,
+                        timestamp: &config.started_at,
+                        task_id: showcase.name,
+                        provider: &provider_route,
                         attempt,
-                        serde_json::json!({"artifact_dir": attempt_dir.display().to_string()}),
-                    ),
+                        payload: serde_json::json!({"artifact_dir": attempt_dir.display().to_string()}),
+                    }),
                 )?;
                 sequence += 1;
 
-                let replay_attempt = run_single_replay(
+                let replay_attempt = run_single_replay(SingleReplayRequest {
                     showcase,
-                    provider.as_ref(),
-                    model_identity.clone(),
-                    &provider_route,
-                    &spec,
+                    provider: provider.as_ref(),
+                    model_identity: model_identity.clone(),
+                    provider_route: &provider_route,
+                    spec: &spec,
                     attempt,
-                    &attempt_dir,
-                    config.keep_workspaces,
-                    &init_workspace,
-                )
+                    attempt_dir: &attempt_dir,
+                    keep_workspace: config.keep_workspaces,
+                    init_workspace: &init_workspace,
+                })
                 .await;
 
                 append_ledger(
                     &mut ledger,
-                    event_with_attempt(
-                        &config.run_id,
-                        if replay_attempt.success {
+                    event_with_attempt(AttemptEvent {
+                        run_id: &config.run_id,
+                        event: if replay_attempt.success {
                             LedgerEventKind::AttemptCompleted
                         } else {
                             LedgerEventKind::AttemptFailed
                         },
                         sequence,
-                        &utc_now(),
-                        showcase.name,
-                        &provider_route,
+                        timestamp: &utc_now(),
+                        task_id: showcase.name,
+                        provider: &provider_route,
                         attempt,
-                        serde_json::json!({
+                        payload: serde_json::json!({
                             "success": replay_attempt.success,
                             "tests_passed": replay_attempt.tests_passed,
                             "tests_total": replay_attempt.tests_total,
                             "error": replay_attempt.dominant_error_code,
                         }),
-                    ),
+                    }),
                 )?;
                 sequence += 1;
                 report.attempts.push(replay_attempt);
@@ -252,20 +271,37 @@ where
     Ok(report)
 }
 
-async fn run_single_replay<F>(
-    showcase: &Showcase,
-    provider: &dyn LlmProvider,
-    model_identity: ModelIdentity,
-    provider_route: &str,
-    spec: &IntentSpec,
-    attempt: u32,
-    attempt_dir: &Path,
-    keep_workspace: bool,
-    init_workspace: &F,
-) -> ReplayAttempt
+struct SingleReplayRequest<'a, F>
 where
     F: Fn(&Path) -> Result<(), anyhow::Error>,
 {
+    showcase: &'a Showcase,
+    provider: &'a dyn LlmProvider,
+    model_identity: ModelIdentity,
+    provider_route: &'a str,
+    spec: &'a IntentSpec,
+    attempt: u32,
+    attempt_dir: &'a Path,
+    keep_workspace: bool,
+    init_workspace: &'a F,
+}
+
+async fn run_single_replay<F>(request: SingleReplayRequest<'_, F>) -> ReplayAttempt
+where
+    F: Fn(&Path) -> Result<(), anyhow::Error>,
+{
+    let SingleReplayRequest {
+        showcase,
+        provider,
+        model_identity,
+        provider_route,
+        spec,
+        attempt,
+        attempt_dir,
+        keep_workspace,
+        init_workspace,
+    } = request;
+
     let start = Instant::now();
     if let ShowcaseVerification::ProcessEvidence {
         evidence_kind,
@@ -343,6 +379,8 @@ where
             start.elapsed().as_secs_f64(),
         );
     }
+    let context_hashes =
+        replay_context_hashes(showcase, provider_route, &run_spec, workspace, slug);
 
     let mut log = Vec::new();
     let execute_result = intent::execute::run_execute(provider, workspace, slug, &mut log).await;
@@ -398,17 +436,15 @@ where
         initial_graph_semantic_hash,
         final_graph_exact_hash,
         final_graph_semantic_hash,
-        intent_spec_hash: None,
-        bdd_context_hash: None,
-        context_pack_hash: None,
-        prompt_hashes: PromptHashes::Unavailable {
-            reason: "execution_evidence_sink_not_implemented".to_string(),
-        },
+        intent_spec_hash: context_hashes.intent_spec_hash,
+        bdd_context_hash: context_hashes.bdd_context_hash,
+        context_pack_hash: context_hashes.context_pack_hash,
+        prompt_hashes: context_hashes.prompt_hashes,
         success,
         tests_passed,
         tests_total,
-        bdd_readiness: None,
-        bdd_coverage: Vec::new(),
+        bdd_readiness: context_hashes.bdd_readiness,
+        bdd_coverage: context_hashes.bdd_coverage,
         behavior_signature,
         error_category,
         dominant_error_code,
@@ -417,6 +453,107 @@ where
         artifact_paths,
         duration_secs: start.elapsed().as_secs_f64(),
     }
+}
+
+struct ReplayContextHashes {
+    intent_spec_hash: Option<String>,
+    bdd_context_hash: Option<String>,
+    context_pack_hash: Option<String>,
+    prompt_hashes: PromptHashes,
+    bdd_readiness: Option<String>,
+    bdd_coverage: Vec<String>,
+}
+
+fn replay_context_hashes(
+    showcase: &Showcase,
+    provider_route: &str,
+    spec: &IntentSpec,
+    workspace: &Path,
+    slug: &str,
+) -> ReplayContextHashes {
+    let intent_spec_hash = stable_yaml_hash(spec);
+    let bdd_report = load_bdd_report(spec, workspace, slug);
+    let bdd_prompt_context = render_bdd_prompt_context(&bdd_report, DEFAULT_BDD_CONTEXT_LIMIT);
+    let bdd_context_hash = Some(hash_lines(
+        "duumbi-determinism-bdd-context-v1",
+        &bdd_prompt_context,
+    ));
+    let context_pack_hash = stable_json_hash(&serde_json::json!({
+        "schema": "duumbi-determinism-context-pack-v1",
+        "task_id": showcase.name,
+        "suite": showcase.suite.as_str(),
+        "tags": showcase.tags,
+        "provider": provider_route,
+        "intent_spec_hash": intent_spec_hash,
+        "bdd_context_hash": bdd_context_hash,
+        "acceptance_criteria_count": spec.acceptance_criteria.len(),
+        "test_cases_count": spec.test_cases.len(),
+    }));
+
+    let mut hashes = BTreeMap::new();
+    if let Some(hash) = &intent_spec_hash {
+        hashes.insert("intent_spec".to_string(), hash.clone());
+    }
+    if let Some(hash) = &bdd_context_hash {
+        hashes.insert("bdd_context".to_string(), hash.clone());
+    }
+    if let Some(hash) = &context_pack_hash {
+        hashes.insert("context_pack".to_string(), hash.clone());
+    }
+
+    let prompt_hashes = if hashes.is_empty() {
+        PromptHashes::Unavailable {
+            reason: "context_hash_serialization_failed".to_string(),
+        }
+    } else {
+        PromptHashes::Partial {
+            reason: "final provider prompt capture is not exposed by intent execute".to_string(),
+            hashes,
+        }
+    };
+
+    ReplayContextHashes {
+        intent_spec_hash,
+        bdd_context_hash,
+        context_pack_hash,
+        prompt_hashes,
+        bdd_readiness: Some(bdd_report.readiness.label().to_ascii_lowercase()),
+        bdd_coverage: bdd_report
+            .coverage
+            .iter()
+            .map(|coverage| format!("{}:{}", coverage.scenario, coverage.classification.label()))
+            .collect(),
+    }
+}
+
+fn stable_yaml_hash<T: serde::Serialize>(value: &T) -> Option<String> {
+    serde_yaml::to_string(value)
+        .ok()
+        .map(|text| hash_text("duumbi-determinism-yaml-v1", &text))
+}
+
+fn stable_json_hash<T: serde::Serialize>(value: &T) -> Option<String> {
+    serde_json::to_vec(value)
+        .ok()
+        .map(|bytes| hash_bytes("duumbi-determinism-json-v1", &bytes))
+}
+
+fn hash_lines(domain: &str, lines: &[String]) -> String {
+    hash_text(domain, &lines.join("\n"))
+}
+
+fn hash_text(domain: &str, text: &str) -> String {
+    hash_bytes(domain, text.as_bytes())
+}
+
+fn hash_bytes(domain: &str, bytes: &[u8]) -> String {
+    let mut input = Vec::with_capacity(domain.len() + bytes.len() + 2);
+    input.extend_from_slice(domain.as_bytes());
+    input.push(0);
+    input.extend_from_slice(bytes.len().to_string().as_bytes());
+    input.push(0);
+    input.extend_from_slice(bytes);
+    sha256_hex_bytes(&input)
 }
 
 struct ReplayAttemptParts<'a> {
@@ -590,26 +727,71 @@ fn event_with_task(
     event
 }
 
-fn event_with_attempt(
-    run_id: &str,
+struct AttemptEvent<'a> {
+    run_id: &'a str,
     event: LedgerEventKind,
     sequence: u64,
-    timestamp: &str,
-    task_id: &str,
-    provider: &str,
+    timestamp: &'a str,
+    task_id: &'a str,
+    provider: &'a str,
     attempt: u32,
     payload: serde_json::Value,
-) -> LedgerEvent {
-    let mut event = event_with_task(run_id, event, sequence, timestamp, task_id, payload);
-    event.provider = Some(provider.to_string());
-    event.attempt = Some(attempt);
+}
+
+fn event_with_attempt(params: AttemptEvent<'_>) -> LedgerEvent {
+    let mut event = event_with_task(
+        params.run_id,
+        params.event,
+        params.sequence,
+        params.timestamp,
+        params.task_id,
+        params.payload,
+    );
+    event.provider = Some(params.provider.to_string());
+    event.attempt = Some(params.attempt);
     event
 }
 
 #[cfg(test)]
 mod tests {
+    use std::future::Future;
+    use std::pin::Pin;
+
     use super::*;
+    use crate::agents::{AgentError, LlmProvider};
     use crate::config::{ProviderKind, ProviderRole};
+    use crate::determinism::digest::exact_graph_digest;
+    use crate::intent::spec::{IntentModules, TestCase};
+    use crate::patch::PatchOp;
+
+    struct MockReplayProvider;
+
+    impl LlmProvider for MockReplayProvider {
+        fn name(&self) -> &str {
+            "mock"
+        }
+
+        fn model_name(&self) -> Option<&str> {
+            Some("determinism-fixture")
+        }
+
+        fn call_with_tools<'a>(
+            &'a self,
+            _system_prompt: &'a str,
+            _user_message: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<Vec<PatchOp>, AgentError>> + Send + 'a>> {
+            Box::pin(async { Ok(Vec::new()) })
+        }
+
+        fn call_with_tools_streaming<'a>(
+            &'a self,
+            system_prompt: &'a str,
+            user_message: &'a str,
+            _on_text: &'a (dyn Fn(&str) + Send + Sync),
+        ) -> Pin<Box<dyn Future<Output = Result<Vec<PatchOp>, AgentError>> + Send + 'a>> {
+            self.call_with_tools(system_prompt, user_message)
+        }
+    }
 
     fn provider_config(model: Option<&str>) -> ProviderConfig {
         ProviderConfig {
@@ -630,5 +812,118 @@ mod tests {
         let filtered = filter_providers(&providers, None);
 
         assert_eq!(provider_name(filtered[0]), "openai:gpt-test");
+    }
+
+    #[test]
+    fn replay_context_hashes_record_partial_prompt_evidence() {
+        let temp_dir = tempfile::TempDir::new().expect("temp dir");
+        let spec = IntentSpec {
+            intent: "Build calculator".to_string(),
+            version: 1,
+            status: IntentStatus::Pending,
+            acceptance_criteria: vec!["add(a, b) returns a + b".to_string()],
+            modules: IntentModules {
+                create: vec!["calculator/ops".to_string()],
+                modify: Vec::new(),
+            },
+            test_cases: vec![TestCase {
+                name: "addition".to_string(),
+                function: "add".to_string(),
+                args: vec![3, 5],
+                expected_return: 8,
+            }],
+            dependencies: Vec::new(),
+            bdd: Default::default(),
+            context: None,
+            created_at: None,
+            execution: None,
+        };
+        let showcase = showcases::filter_showcases_with_options(
+            Some(&["calculator".to_string()]),
+            Some(ShowcaseSuite::Core),
+            false,
+        )
+        .pop()
+        .expect("calculator showcase exists");
+
+        let hashes =
+            replay_context_hashes(showcase, "mock:determinism", &spec, temp_dir.path(), "calc");
+
+        assert!(hashes.intent_spec_hash.is_some());
+        assert!(hashes.bdd_context_hash.is_some());
+        assert!(hashes.context_pack_hash.is_some());
+        assert_eq!(hashes.bdd_readiness.as_deref(), Some("warning"));
+        assert!(hashes.bdd_coverage.is_empty());
+        assert!(matches!(
+            hashes.prompt_hashes,
+            PromptHashes::Partial { ref hashes, .. }
+                if hashes.contains_key("intent_spec")
+                    && hashes.contains_key("bdd_context")
+                    && hashes.contains_key("context_pack")
+        ));
+    }
+
+    #[tokio::test]
+    async fn replay_runner_records_attempts_without_mutating_active_graph() {
+        let active_workspace = tempfile::TempDir::new().expect("active workspace");
+        let active_graph_dir = active_workspace.path().join(".duumbi/graph");
+        std::fs::create_dir_all(&active_graph_dir).expect("active graph dir");
+        std::fs::write(
+            active_graph_dir.join("main.jsonld"),
+            r#"{"@context":{},"@graph":[]}"#,
+        )
+        .expect("active graph write");
+        let before = exact_graph_digest(&active_graph_dir).expect("active graph digest");
+
+        let artifact_dir = tempfile::TempDir::new().expect("artifact dir");
+        let config = ReplayConfig {
+            run_id: "run-fixture".to_string(),
+            attempts: 2,
+            providers: vec![provider_config(Some("determinism-fixture"))],
+            showcase_filter: Some(vec!["calculator".to_string()]),
+            provider_filter: None,
+            suite_filter: Some(ShowcaseSuite::Core),
+            smoke: false,
+            artifact_dir: artifact_dir.path().join("replays"),
+            started_at: "2026-06-19T00:00:00Z".to_string(),
+            source_commit: "test-commit".to_string(),
+            provider_source: "test".to_string(),
+            keep_workspaces: false,
+        };
+
+        let report = run_replay_with_provider_factory(
+            &config,
+            |workspace| {
+                let graph_dir = workspace.join(".duumbi/graph");
+                std::fs::create_dir_all(&graph_dir)?;
+                std::fs::write(
+                    graph_dir.join("main.jsonld"),
+                    r#"{"@context":{},"@graph":[]}"#,
+                )?;
+                Ok(())
+            },
+            |_| Ok(Box::new(MockReplayProvider)),
+        )
+        .await
+        .expect("fixture replay should produce report");
+
+        let after =
+            exact_graph_digest(&active_graph_dir).expect("active graph digest after replay");
+        assert_eq!(before, after);
+        assert_eq!(report.tasks.len(), 1);
+        assert_eq!(report.attempts.len(), 2);
+        assert!(report.attempts.iter().all(|attempt| {
+            attempt.workspace_strategy == "isolated_tempdir"
+                && attempt.initial_graph_exact_hash.is_some()
+                && attempt.final_graph_exact_hash.is_some()
+                && matches!(attempt.prompt_hashes, PromptHashes::Partial { .. })
+        }));
+
+        let ledger_path = artifact_dir.path().join("replays/run-fixture/ledger.jsonl");
+        let ledger = std::fs::read_to_string(ledger_path).expect("ledger should be written");
+        assert!(ledger.contains(r#""event":"run_started""#));
+        assert_eq!(ledger.matches(r#""event":"attempt_started""#).count(), 2);
+        assert_eq!(ledger.matches(r#""event":"attempt_failed""#).count(), 2);
+        assert!(ledger.contains(r#""event":"run_completed""#));
     }
 }

--- a/src/determinism/runner.rs
+++ b/src/determinism/runner.rs
@@ -45,12 +45,12 @@ pub struct ReplayConfig {
     pub artifact_dir: PathBuf,
     /// UTC start timestamp as RFC3339 text.
     pub started_at: String,
-    /// UTC finish timestamp as RFC3339 text supplied by the caller.
-    pub finished_at: String,
     /// Source commit used for report metadata.
     pub source_commit: String,
     /// Provider configuration source label.
     pub provider_source: String,
+    /// Retain isolated attempt workspaces under the replay bundle.
+    pub keep_workspaces: bool,
 }
 
 /// Runs determinism replay for selected benchmark showcases.
@@ -125,7 +125,7 @@ where
     let mut report = ReplayReport::new(
         &config.run_id,
         &config.started_at,
-        &config.finished_at,
+        &config.started_at,
         env!("CARGO_PKG_VERSION"),
         &config.source_commit,
         inputs,
@@ -200,6 +200,7 @@ where
                     &spec,
                     attempt,
                     &attempt_dir,
+                    config.keep_workspaces,
                     &init_workspace,
                 )
                 .await;
@@ -214,7 +215,7 @@ where
                             LedgerEventKind::AttemptFailed
                         },
                         sequence,
-                        &config.finished_at,
+                        &utc_now(),
                         showcase.name,
                         &provider_route,
                         attempt,
@@ -233,13 +234,14 @@ where
     }
 
     report.metrics = ReplayMetrics::from_attempts(&report.attempts);
+    report.finished_at = utc_now();
     append_ledger(
         &mut ledger,
         LedgerEvent::new(
             &config.run_id,
             LedgerEventKind::RunCompleted,
             sequence,
-            &config.finished_at,
+            &report.finished_at,
             serde_json::json!({
                 "attempts_total": report.metrics.attempts_total,
                 "attempts_completed": report.metrics.attempts_completed,
@@ -258,6 +260,7 @@ async fn run_single_replay<F>(
     spec: &IntentSpec,
     attempt: u32,
     attempt_dir: &Path,
+    keep_workspace: bool,
     init_workspace: &F,
 ) -> ReplayAttempt
 where
@@ -372,7 +375,10 @@ where
                 .map_or(ErrorCategory::LogicError, categorize_error),
         )
     };
-    let artifact_paths = retain_attempt_log(attempt_dir, &log);
+    let mut artifact_paths = retain_attempt_log(attempt_dir, &log);
+    if keep_workspace {
+        artifact_paths.extend(retain_workspace_snapshot(workspace, attempt_dir));
+    }
     let behavior_signature = Some(format!(
         "success={success};tests={tests_passed}/{tests_total};error={}",
         error_category
@@ -536,6 +542,35 @@ fn retain_attempt_log(attempt_dir: &Path, log: &[String]) -> Vec<String> {
     } else {
         Vec::new()
     }
+}
+
+fn retain_workspace_snapshot(workspace: &Path, attempt_dir: &Path) -> Vec<String> {
+    let source = workspace.join(".duumbi");
+    let destination = attempt_dir.join("workspace").join(".duumbi");
+    if copy_dir_recursive(&source, &destination).is_ok() {
+        vec![destination.display().to_string()]
+    } else {
+        Vec::new()
+    }
+}
+
+fn copy_dir_recursive(source: &Path, destination: &Path) -> Result<(), std::io::Error> {
+    std::fs::create_dir_all(destination)?;
+    for entry in std::fs::read_dir(source)? {
+        let entry = entry?;
+        let path = entry.path();
+        let target = destination.join(entry.file_name());
+        if path.is_dir() {
+            copy_dir_recursive(&path, &target)?;
+        } else {
+            std::fs::copy(&path, &target)?;
+        }
+    }
+    Ok(())
+}
+
+fn utc_now() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
 }
 
 fn append_ledger(writer: &mut LedgerWriter, event: LedgerEvent) -> Result<(), String> {

--- a/src/determinism/runner.rs
+++ b/src/determinism/runner.rs
@@ -164,13 +164,14 @@ where
             suite: showcase.suite.as_str().to_string(),
             tags: showcase.tags.iter().map(|tag| (*tag).to_string()).collect(),
         });
+        let task_selected_at = utc_now();
         append_ledger(
             &mut ledger,
             event_with_task(
                 &config.run_id,
                 LedgerEventKind::TaskSelected,
                 sequence,
-                &config.started_at,
+                &task_selected_at,
                 showcase.name,
                 serde_json::json!({"suite": showcase.suite.as_str(), "tags": showcase.tags}),
             ),
@@ -181,8 +182,15 @@ where
             let provider = create_provider(provider_config)?;
             let provider_route = provider_name(provider_config);
             let provider_key = safe_artifact_key(&provider_route, "provider");
-            let model_identity = ModelIdentity::Available {
-                label: provider.model_label(),
+            let model_identity = if provider
+                .model_name()
+                .is_some_and(|model| !model.trim().is_empty())
+            {
+                ModelIdentity::Available {
+                    label: provider.model_label(),
+                }
+            } else {
+                ModelIdentity::unavailable("provider did not expose resolved model")
             };
             for attempt in 1..=config.attempts {
                 let attempt_dir = run_dir
@@ -196,13 +204,14 @@ where
                         attempt_dir.display()
                     )
                 })?;
+                let attempt_started_at = utc_now();
                 append_ledger(
                     &mut ledger,
                     event_with_attempt(AttemptEvent {
                         run_id: &config.run_id,
                         event: LedgerEventKind::AttemptStarted,
                         sequence,
-                        timestamp: &config.started_at,
+                        timestamp: &attempt_started_at,
                         task_id: showcase.name,
                         provider: &provider_route,
                         attempt,
@@ -652,20 +661,11 @@ fn replay_attempt_from_error(
 ) -> ReplayAttempt {
     let category = categorize_error(&message);
     replay_attempt_from_parts(ReplayAttemptParts {
-        showcase,
-        provider_route,
-        model_identity,
-        attempt,
         tests_total,
         error_category: Some(category),
         dominant_error_code: extract_error_codes(&message).into_iter().next(),
         duration_secs,
-        ..ReplayAttemptParts::new(
-            showcase,
-            provider_route,
-            ModelIdentity::unavailable("unused"),
-            attempt,
-        )
+        ..ReplayAttemptParts::new(showcase, provider_route, model_identity, attempt)
     })
 }
 
@@ -885,7 +885,7 @@ mod tests {
             suite_filter: Some(ShowcaseSuite::Core),
             smoke: false,
             artifact_dir: artifact_dir.path().join("replays"),
-            started_at: "2026-06-19T00:00:00Z".to_string(),
+            started_at: "2000-01-01T00:00:00Z".to_string(),
             source_commit: "test-commit".to_string(),
             provider_source: "test".to_string(),
             keep_workspaces: false,
@@ -925,5 +925,41 @@ mod tests {
         assert_eq!(ledger.matches(r#""event":"attempt_started""#).count(), 2);
         assert_eq!(ledger.matches(r#""event":"attempt_failed""#).count(), 2);
         assert!(ledger.contains(r#""event":"run_completed""#));
+
+        let events = ledger
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("valid jsonl"))
+            .collect::<Vec<_>>();
+        let run_started = events
+            .iter()
+            .find(|event| {
+                event.get("event").and_then(|value| value.as_str()) == Some("run_started")
+            })
+            .expect("run_started event should exist");
+        assert_eq!(
+            run_started
+                .get("timestamp")
+                .and_then(|value| value.as_str()),
+            Some(config.started_at.as_str())
+        );
+        for event_name in ["task_selected", "attempt_started"] {
+            let matching = events
+                .iter()
+                .filter(|event| {
+                    event.get("event").and_then(|value| value.as_str()) == Some(event_name)
+                })
+                .collect::<Vec<_>>();
+            assert!(
+                !matching.is_empty(),
+                "{event_name} events should be present in ledger"
+            );
+            assert!(
+                matching.iter().all(|event| event
+                    .get("timestamp")
+                    .and_then(|value| value.as_str())
+                    != Some(config.started_at.as_str())),
+                "{event_name} events should use their emission timestamp"
+            );
+        }
     }
 }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -6,7 +6,7 @@
 //!
 //! # Algorithm
 //!
-//! 1. Read all `.jsonld` files in the graph directory (sorted by name).
+//! 1. Read all `.jsonld` files under the graph directory (sorted by path).
 //! 2. Canonicalize each JSON value:
 //!    - Remove `@id` keys from node objects (identity, not semantics).
 //!    - Remove `@context` from the top level (namespace declaration).
@@ -45,7 +45,7 @@ pub enum HashError {
     },
 }
 
-/// Computes the semantic hash of all `.jsonld` files in a graph directory.
+/// Computes the semantic hash of all `.jsonld` files under a graph directory.
 ///
 /// The hash is a hex-encoded SHA-256 string. It is deterministic across
 /// runs and machines for the same logical graph content, regardless of
@@ -101,25 +101,32 @@ pub fn semantic_hash_value(value: &serde_json::Value) -> String {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-/// Collects all `.jsonld` file paths in a directory.
+/// Collects all `.jsonld` file paths under a directory.
 fn collect_jsonld_files(dir: &Path) -> Result<Vec<PathBuf>, HashError> {
+    let mut paths = Vec::new();
+    collect_jsonld_files_into(dir, &mut paths)?;
+    Ok(paths)
+}
+
+fn collect_jsonld_files_into(dir: &Path, paths: &mut Vec<PathBuf>) -> Result<(), HashError> {
     let entries = fs::read_dir(dir).map_err(|e| HashError::Io {
         path: dir.display().to_string(),
         source: e,
     })?;
 
-    let mut paths = Vec::new();
     for entry in entries {
         let entry = entry.map_err(|e| HashError::Io {
             path: dir.display().to_string(),
             source: e,
         })?;
         let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) == Some("jsonld") {
+        if path.is_dir() {
+            collect_jsonld_files_into(&path, paths)?;
+        } else if path.extension().and_then(|e| e.to_str()) == Some("jsonld") {
             paths.push(path);
         }
     }
-    Ok(paths)
+    Ok(())
 }
 
 /// Canonicalizes a JSON-LD value for semantic hashing.
@@ -216,7 +223,11 @@ mod tests {
 
     /// Helper: write a .jsonld file with given content.
     fn write_jsonld(dir: &Path, name: &str, content: &str) {
-        fs::write(dir.join(name), content).expect("invariant: test file write must succeed");
+        let path = dir.join(name);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("invariant: test parent dirs must be created");
+        }
+        fs::write(path, content).expect("invariant: test file write must succeed");
     }
 
     #[test]
@@ -868,6 +879,68 @@ mod tests {
 
         let hash = semantic_hash(dir.path()).expect("must succeed");
         assert_eq!(hash.len(), 64, "multi-block function must hash");
+    }
+
+    #[test]
+    fn semantic_hash_includes_nested_graph_modules() {
+        let dir_a = TempDir::new().expect("invariant: temp dir creation must succeed");
+        let dir_b = TempDir::new().expect("invariant: temp dir creation must succeed");
+        let main = r#"{
+            "@type": "duumbi:Module", "@id": "duumbi:main",
+            "duumbi:name": "main",
+            "duumbi:functions": []
+        }"#;
+
+        write_jsonld(dir_a.path(), "main.jsonld", main);
+        write_jsonld(dir_b.path(), "main.jsonld", main);
+        write_jsonld(
+            dir_a.path(),
+            "calculator/ops.jsonld",
+            r#"{
+                "@type": "duumbi:Module", "@id": "duumbi:calculator/ops",
+                "duumbi:name": "calculator/ops",
+                "duumbi:functions": [{
+                    "@type": "duumbi:Function", "@id": "duumbi:calculator/ops/add",
+                    "duumbi:name": "add", "duumbi:returnType": "i64", "duumbi:params": [],
+                    "duumbi:blocks": [{
+                        "@type": "duumbi:Block", "@id": "duumbi:calculator/ops/add/entry",
+                        "duumbi:label": "entry",
+                        "duumbi:ops": [
+                            {"@type": "duumbi:Const", "@id": "duumbi:calculator/ops/add/entry/0",
+                             "duumbi:value": 1, "duumbi:resultType": "i64"}
+                        ]
+                    }]
+                }]
+            }"#,
+        );
+        write_jsonld(
+            dir_b.path(),
+            "calculator/ops.jsonld",
+            r#"{
+                "@type": "duumbi:Module", "@id": "duumbi:calculator/ops",
+                "duumbi:name": "calculator/ops",
+                "duumbi:functions": [{
+                    "@type": "duumbi:Function", "@id": "duumbi:calculator/ops/add",
+                    "duumbi:name": "add", "duumbi:returnType": "i64", "duumbi:params": [],
+                    "duumbi:blocks": [{
+                        "@type": "duumbi:Block", "@id": "duumbi:calculator/ops/add/entry",
+                        "duumbi:label": "entry",
+                        "duumbi:ops": [
+                            {"@type": "duumbi:Const", "@id": "duumbi:calculator/ops/add/entry/0",
+                             "duumbi:value": 2, "duumbi:resultType": "i64"}
+                        ]
+                    }]
+                }]
+            }"#,
+        );
+
+        let hash_a = semantic_hash(dir_a.path()).expect("hash A should succeed");
+        let hash_b = semantic_hash(dir_b.path()).expect("hash B should succeed");
+
+        assert_ne!(
+            hash_a, hash_b,
+            "nested graph modules must contribute to semantic hash evidence"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod context;
 pub mod contracts;
 pub mod credentials;
 pub mod deps;
+pub mod determinism;
 pub mod errors;
 pub mod examples;
 pub mod graph;

--- a/src/main.rs
+++ b/src/main.rs
@@ -560,7 +560,9 @@ async fn run_determinism(subcommand: cli::DeterminismSubcommand) -> Result<i32> 
             keep_workspaces,
         } => {
             let workspace = PathBuf::from(".");
-            let cfg = config::load_effective_config(&workspace)?.config;
+            let effective_config = config::load_effective_config(&workspace)?;
+            let provider_source = provider_source_label(effective_config.provider_source);
+            let cfg = effective_config.config;
             let providers = cfg.effective_providers();
             if providers.is_empty() {
                 anyhow::bail!(
@@ -585,7 +587,7 @@ async fn run_determinism(subcommand: cli::DeterminismSubcommand) -> Result<i32> 
                 artifact_dir,
                 started_at,
                 source_commit: current_git_commit().unwrap_or_else(|| "unknown".to_string()),
-                provider_source: "user".to_string(),
+                provider_source: provider_source.to_string(),
                 keep_workspaces,
             };
 
@@ -615,14 +617,12 @@ async fn run_determinism(subcommand: cli::DeterminismSubcommand) -> Result<i32> 
                 eprintln!("Replay Markdown summary written to {}", path.display());
             }
 
-            let thresholds_pass = determinism::metrics::threshold_passes(
+            let thresholds_pass = determinism::metrics::replay_ci_thresholds_pass(
                 &report.metrics.exact_graph_agreement_rate,
-                min_exact_agreement,
-            ) && determinism::metrics::threshold_passes(
                 &report.metrics.semantic_graph_agreement_rate,
-                min_semantic_agreement,
-            ) && determinism::metrics::threshold_passes(
                 &report.metrics.behavioral_agreement_rate,
+                min_exact_agreement,
+                min_semantic_agreement,
                 min_behavioral_agreement,
             );
             if ci && !thresholds_pass {
@@ -631,6 +631,18 @@ async fn run_determinism(subcommand: cli::DeterminismSubcommand) -> Result<i32> 
                 Ok(EXIT_SUCCESS)
             }
         }
+    }
+}
+
+fn provider_source_label(source: config::ProviderConfigSource) -> &'static str {
+    match source {
+        config::ProviderConfigSource::None => "none",
+        config::ProviderConfigSource::System => "system",
+        config::ProviderConfigSource::User => "user",
+        config::ProviderConfigSource::Workspace => "workspace",
+        config::ProviderConfigSource::LegacySystem => "legacy-system",
+        config::ProviderConfigSource::LegacyUser => "legacy-user",
+        config::ProviderConfigSource::LegacyWorkspace => "legacy-workspace",
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod context;
 mod contracts;
 mod credentials;
 mod deps;
+mod determinism;
 mod errors;
 mod examples;
 mod graph;
@@ -227,6 +228,7 @@ fn command_name(command: &Commands) -> &'static str {
         Commands::Telemetry { .. } => "telemetry",
         Commands::Upgrade => "upgrade",
         Commands::Benchmark { .. } => "benchmark",
+        Commands::Determinism { .. } => "determinism",
         Commands::Phase15E2e { .. } => "phase15-e2e",
         Commands::Completions { .. } => "completions",
         Commands::Studio { .. } => "studio",
@@ -514,6 +516,7 @@ async fn run(cli: Cli) -> Result<i32> {
             })
             .await
         }
+        Commands::Determinism { subcommand } => run_determinism(subcommand).await,
         Commands::Phase15E2e {
             task,
             provider,
@@ -537,6 +540,140 @@ async fn run(cli: Cli) -> Result<i32> {
         }
         Commands::Mcp { sse, port } => success_exit(run_mcp(sse, port).await),
     }
+}
+
+async fn run_determinism(subcommand: cli::DeterminismSubcommand) -> Result<i32> {
+    match subcommand {
+        cli::DeterminismSubcommand::Replay {
+            suite,
+            smoke,
+            showcase,
+            provider,
+            attempts,
+            output,
+            artifact_dir,
+            markdown_output,
+            ci,
+            min_exact_agreement,
+            min_semantic_agreement,
+            min_behavioral_agreement,
+            keep_workspaces,
+        } => {
+            let workspace = PathBuf::from(".");
+            let cfg = config::load_effective_config(&workspace)?.config;
+            let providers = cfg.effective_providers();
+            if providers.is_empty() {
+                anyhow::bail!(
+                    "No LLM providers configured. Use `duumbi provider add ...` to save a user-level provider."
+                );
+            }
+
+            let attempts = attempts.unwrap_or(2);
+            let started_at = iso8601_now();
+            let run_id = determinism_run_id(&started_at, suite, smoke);
+            let config = determinism::runner::ReplayConfig {
+                run_id,
+                attempts,
+                providers,
+                showcase_filter: showcase,
+                provider_filter: provider,
+                suite_filter: suite.map(|suite| match suite {
+                    cli::BenchmarkSuiteArg::Core => bench::showcases::ShowcaseSuite::Core,
+                    cli::BenchmarkSuiteArg::Scaled => bench::showcases::ShowcaseSuite::Scaled,
+                }),
+                smoke,
+                artifact_dir,
+                started_at,
+                source_commit: current_git_commit().unwrap_or_else(|| "unknown".to_string()),
+                provider_source: "user".to_string(),
+                keep_workspaces,
+            };
+
+            let report = determinism::runner::run_replay(&config, |path| {
+                cli::init::run_init(path).map(|_| ())
+            })
+            .await
+            .map_err(|error| anyhow::anyhow!("{error}"))?;
+            let json = serde_json::to_string_pretty(&report)
+                .context("Failed to serialize determinism replay report")?;
+            match output {
+                Some(path) => {
+                    write_text_file(&path, &json).with_context(|| {
+                        format!("Failed to write replay report to '{}'", path.display())
+                    })?;
+                    eprintln!("Replay report written to {}", path.display());
+                }
+                None => println!("{json}"),
+            }
+            if let Some(path) = markdown_output {
+                write_text_file(&path, &report.to_markdown_summary()).with_context(|| {
+                    format!(
+                        "Failed to write replay Markdown summary to '{}'",
+                        path.display()
+                    )
+                })?;
+                eprintln!("Replay Markdown summary written to {}", path.display());
+            }
+
+            let thresholds_pass = determinism::metrics::threshold_passes(
+                &report.metrics.exact_graph_agreement_rate,
+                min_exact_agreement,
+            ) && determinism::metrics::threshold_passes(
+                &report.metrics.semantic_graph_agreement_rate,
+                min_semantic_agreement,
+            ) && determinism::metrics::threshold_passes(
+                &report.metrics.behavioral_agreement_rate,
+                min_behavioral_agreement,
+            );
+            if ci && !thresholds_pass {
+                Ok(EXIT_FAILURE)
+            } else {
+                Ok(EXIT_SUCCESS)
+            }
+        }
+    }
+}
+
+fn determinism_run_id(
+    started_at: &str,
+    suite: Option<cli::BenchmarkSuiteArg>,
+    smoke: bool,
+) -> String {
+    let suite = match suite {
+        Some(cli::BenchmarkSuiteArg::Core) | None => "core",
+        Some(cli::BenchmarkSuiteArg::Scaled) => "scaled",
+    };
+    let mode = if smoke { "smoke" } else { "full" };
+    let timestamp = started_at
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '-' })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string();
+    format!("duumbi-720-{timestamp}-{suite}-{mode}")
+}
+
+fn current_git_commit() -> Option<String> {
+    let output = process::Command::new("git")
+        .args(["rev-parse", "--short=12", "HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let commit = String::from_utf8(output.stdout).ok()?;
+    let commit = commit.trim();
+    (!commit.is_empty()).then(|| commit.to_string())
+}
+
+fn write_text_file(path: &Path, contents: &str) -> Result<()> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create directory '{}'", parent.display()))?;
+    }
+    fs::write(path, contents).with_context(|| format!("Failed to write '{}'", path.display()))
 }
 
 fn success_exit(result: Result<()>) -> Result<i32> {

--- a/tests/integration_duumbi720_determinism.rs
+++ b/tests/integration_duumbi720_determinism.rs
@@ -1,0 +1,231 @@
+//! DUUMBI-720 determinism replay integration evidence.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use duumbi::bench::report::ProviderUsageSummary;
+use duumbi::determinism::digest::safe_artifact_key;
+use duumbi::determinism::evidence::{
+    LedgerEvent, LedgerEventKind, ModelIdentity, PromptHashes, REPLAY_LEDGER_SCHEMA_VERSION,
+    REPLAY_REPORT_SCHEMA_VERSION, ReplayAttempt, ReplayEnvironment, ReplayInputs, ReplayMetrics,
+    ReplayReport,
+};
+use duumbi::determinism::ledger::LedgerWriter;
+use duumbi::determinism::metrics::AgreementRate;
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn sample_attempt(attempt: u32, exact: &str, semantic: &str) -> ReplayAttempt {
+    ReplayAttempt {
+        task_id: "calculator".to_string(),
+        suite: "core".to_string(),
+        tags: vec!["smoke".to_string()],
+        provider: "mock".to_string(),
+        model_identity: ModelIdentity::Available {
+            label: "mock-model".to_string(),
+        },
+        attempt,
+        workspace_strategy: "tempdir-per-attempt".to_string(),
+        initial_graph_exact_hash: Some("initial-exact".to_string()),
+        initial_graph_semantic_hash: Some("initial-semantic".to_string()),
+        final_graph_exact_hash: Some(exact.to_string()),
+        final_graph_semantic_hash: Some(semantic.to_string()),
+        intent_spec_hash: Some("intent-spec".to_string()),
+        bdd_context_hash: Some("bdd-context".to_string()),
+        context_pack_hash: Some("context-pack".to_string()),
+        prompt_hashes: PromptHashes::Partial {
+            reason: "final provider prompt capture unavailable".to_string(),
+            hashes: [("context_pack".to_string(), "context-pack".to_string())].into(),
+        },
+        success: true,
+        tests_passed: 1,
+        tests_total: 1,
+        bdd_readiness: Some("ready".to_string()),
+        bdd_coverage: vec!["exact-graph".to_string(), "behavior".to_string()],
+        behavior_signature: Some("behavior-pass".to_string()),
+        error_category: None,
+        dominant_error_code: None,
+        provider_usage: ProviderUsageSummary::unavailable("provider usage unavailable"),
+        benchmark_evidence: None,
+        artifact_paths: vec!["attempts/calculator/mock/1".to_string()],
+        duration_secs: 0.1,
+    }
+}
+
+fn read_json(path: &Path) -> Value {
+    let text = fs::read_to_string(path).expect("json evidence should be readable");
+    assert!(!text.contains("api_key"));
+    serde_json::from_str(&text).expect("json evidence should parse")
+}
+
+#[test]
+fn determinism_replay_cli_exposes_reviewable_options_without_provider_calls() {
+    let output = Command::new(env!("CARGO_BIN_EXE_duumbi"))
+        .args(["determinism", "replay", "--help"])
+        .output()
+        .expect("duumbi determinism replay --help should run");
+
+    assert!(
+        output.status.success(),
+        "help command failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Replay selected benchmark showcases and report agreement metrics"));
+    assert!(stdout.contains("--suite"));
+    assert!(stdout.contains("--provider"));
+    assert!(stdout.contains("--attempts"));
+    assert!(stdout.contains("--markdown-output"));
+    assert!(stdout.contains("--min-exact-agreement"));
+    assert!(stdout.contains("--keep-workspaces"));
+}
+
+#[test]
+fn replay_report_json_and_markdown_keep_schema_and_agreement_evidence() {
+    let mut report = ReplayReport::new(
+        "run-720",
+        "2026-06-19T00:00:00Z",
+        "2026-06-19T00:00:01Z",
+        "0.4.0-preview",
+        "abc123",
+        ReplayInputs {
+            suite: "core".to_string(),
+            smoke: true,
+            showcases: vec!["calculator".to_string()],
+            providers: vec!["mock".to_string()],
+            attempts: 2,
+        },
+        ReplayEnvironment {
+            provider_source: "test".to_string(),
+            registry_state_hash: "registry".to_string(),
+            lockfile_hash: "absent".to_string(),
+            workspace_dependency_config_hash: "absent".to_string(),
+        },
+    );
+    report.attempts = vec![
+        sample_attempt(1, "exact-a", "semantic-a"),
+        sample_attempt(2, "exact-b", "semantic-a"),
+    ];
+    report.metrics = ReplayMetrics::from_attempts(&report.attempts);
+
+    let json = serde_json::to_value(&report).expect("report should serialize");
+    assert_eq!(json["schema_version"], REPLAY_REPORT_SCHEMA_VERSION);
+    assert_eq!(json["attempts"][0]["prompt_hashes"]["status"], "partial");
+    assert_eq!(
+        json["metrics"]["semantic_graph_agreement_rate"]["status"],
+        "available"
+    );
+    assert_eq!(
+        json["metrics"]["behavioral_agreement_rate"]["status"],
+        "available"
+    );
+    assert!(!json.to_string().contains("api_key"));
+
+    assert!(matches!(
+        report.metrics.exact_graph_agreement_rate,
+        AgreementRate::Available { rate, .. } if rate == 0.5
+    ));
+    assert!(matches!(
+        report.metrics.semantic_graph_agreement_rate,
+        AgreementRate::Available { rate, .. } if rate == 1.0
+    ));
+
+    let markdown = report.to_markdown_summary();
+    assert!(markdown.contains("# DUUMBI Determinism Replay Report"));
+    assert!(markdown.contains("| Exact graph | available |"));
+    assert!(markdown.contains("| Semantic graph | available |"));
+    assert!(markdown.contains("| calculator | mock | mock-model | 1 | true | 1/1 | none |"));
+}
+
+#[test]
+fn ledger_writer_appends_schema_versioned_events_as_jsonl() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let ledger_path = temp_dir.path().join("ledger.jsonl");
+    let mut writer = LedgerWriter::open(&ledger_path).expect("ledger should open");
+
+    writer
+        .append(&LedgerEvent::new(
+            "run-720",
+            LedgerEventKind::RunStarted,
+            1,
+            "2026-06-19T00:00:00Z",
+            serde_json::json!({"suite": "core"}),
+        ))
+        .expect("run_started should write");
+    writer
+        .append(&LedgerEvent::new(
+            "run-720",
+            LedgerEventKind::AttemptCompleted,
+            2,
+            "2026-06-19T00:00:01Z",
+            serde_json::json!({"task_id": "calculator", "success": true}),
+        ))
+        .expect("attempt_completed should write");
+
+    let contents = fs::read_to_string(&ledger_path).expect("ledger should be readable");
+    let lines: Vec<_> = contents.lines().collect();
+    assert_eq!(lines.len(), 2);
+
+    let first: Value = serde_json::from_str(lines[0]).expect("first event should parse");
+    let second: Value = serde_json::from_str(lines[1]).expect("second event should parse");
+    assert_eq!(first["schema_version"], REPLAY_LEDGER_SCHEMA_VERSION);
+    assert_eq!(first["event"], "run_started");
+    assert_eq!(second["event"], "attempt_completed");
+    assert!(!contents.contains("api_key"));
+}
+
+#[test]
+fn replay_artifact_keys_are_safe_path_components() {
+    let key = safe_artifact_key(
+        "minimax:http://localhost:8080/v1/../../secret?api_key=hidden",
+        "provider",
+    );
+    let path = PathBuf::from(&key);
+
+    assert_eq!(path.components().count(), 1);
+    assert!(!key.contains('/'));
+    assert!(!key.contains(".."));
+    assert!(!key.contains("api_key"));
+    assert!(key.starts_with("minimax-http-localhost-8080-v1-secret-"));
+}
+
+#[test]
+fn persisted_report_stays_compact_parseable_and_secret_free() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let report_path = temp_dir.path().join("report.json");
+    let report = ReplayReport::new(
+        "run-720",
+        "2026-06-19T00:00:00Z",
+        "2026-06-19T00:00:01Z",
+        "0.4.0-preview",
+        "abc123",
+        ReplayInputs {
+            suite: "core".to_string(),
+            smoke: true,
+            showcases: vec!["calculator".to_string()],
+            providers: vec!["mock".to_string()],
+            attempts: 2,
+        },
+        ReplayEnvironment {
+            provider_source: "test".to_string(),
+            registry_state_hash: "registry".to_string(),
+            lockfile_hash: "absent".to_string(),
+            workspace_dependency_config_hash: "absent".to_string(),
+        },
+    );
+
+    fs::write(
+        &report_path,
+        serde_json::to_string_pretty(&report).expect("report serializes"),
+    )
+    .expect("report writes");
+
+    let metadata = fs::metadata(&report_path).expect("report metadata");
+    assert!(metadata.len() < 64 * 1024);
+    let json = read_json(&report_path);
+    assert_eq!(json["schema_version"], REPLAY_REPORT_SCHEMA_VERSION);
+    assert_eq!(json["run_id"], "run-720");
+}


### PR DESCRIPTION
Related to #720.

## Workflow Note

Draft Stage 10 implementation PR. This PR must leave issue #720 open for Stage 11 review and Stage 12 closure.

## Specs

- Product spec: https://github.com/hgahub/duumbi/pull/735
- Technical spec: https://github.com/hgahub/duumbi/pull/736

## Implementation Summary

- Added `duumbi determinism replay` CLI with JSON report, Markdown summary, artifact bundle, CI thresholds, and workspace retention option.
- Added schema-versioned replay report and append-only ledger evidence.
- Added exact graph digests, semantic graph hashes, workspace state hashes, partial prompt/context hashes, model identity evidence, provider usage availability evidence, and conservative rewrite comparison status.
- Added largest-group agreement metrics for exact, semantic, behavioral, and failure-category equivalence.
- Added deterministic runner-level provider fixture tests for attempt isolation and active graph preservation.
- Added integration coverage for CLI/help, artifact safety, schema/report shape, JSONL ledger, Markdown, metrics, and no-secret report persistence.
- Added curated live E2E evidence at `docs/e2e/results/duumbi-720-determinism-replay-20260619.md`.

## Ralph Cycle Evidence

### Cycle 1

Goal: replay evidence foundations.

Evidence:
- Added schema-versioned evidence types.
- Added exact graph digest, workspace state hash, safe artifact key helpers.
- Added largest-group agreement metrics.

Checks:
- `cargo fmt --check`: pass
- `cargo test determinism`: pass
- `git diff --check`: pass

### Cycle 2

Goal: ledger and report summaries.

Evidence:
- Added append-only JSONL ledger writer.
- Added replay metrics derivation from attempt rows.
- Added deterministic Markdown report summary rendering.

Checks:
- `cargo fmt --check`: pass
- `cargo test determinism`: pass
- `git diff --check`: pass

### Cycle 3

Goal: provider-backed replay runner.

Evidence:
- Added replay runner using benchmark showcase/provider selection semantics.
- Added isolated attempt workspace execution and graph digest capture.
- Added run/task/attempt ledger lifecycle.
- Added resolved model label evidence.

Checks:
- `cargo fmt --check`: pass
- `cargo test determinism`: pass
- `git diff --check`: pass

### Cycle 4

Goal: public CLI surface.

Evidence:
- Added `duumbi determinism replay`.
- Added JSON and Markdown output paths.
- Added artifact directory, CI thresholds, and `--keep-workspaces`.
- Added source commit metadata and help surface.

Checks:
- `cargo fmt --check`: pass
- `cargo test determinism`: pass
- `target/debug/duumbi determinism replay --help`: pass
- `git diff --check`: pass

### Cycle 5

Goal: integration coverage and partial prompt/context hashing.

Evidence:
- Added partial prompt/context hashing for intent spec, BDD context, and context pack.
- Added BDD readiness/coverage evidence on attempts.
- Added `tests/integration_duumbi720_determinism.rs`.
- Added no-network runner fixture test for active graph preservation and isolated attempts.
- Added shared CI threshold helper used by CLI dispatch.

Checks:
- `cargo fmt --check`: pass
- `cargo test determinism`: pass
- `cargo test --test integration_duumbi720_determinism`: pass
- `cargo clippy --all-targets -- -D warnings`: pass
- `git diff --check`: pass

### Cycle 6

Goal: live E2E evidence and final readiness.

Evidence:
- Ran provider-backed replay with MiniMax from a temporary workspace config.
- Command exited 0.
- Final report schema: `duumbi.determinism.replay_report.v1`
- Final run id: `duumbi-720-2026-06-19T07-03-49Z-core-full`
- Provider source: `workspace`
- Attempts: 2
- Attempt results: 2/2 attempts succeeded, 4/4 tests passed each
- Exact agreement: 0.500
- Semantic agreement: 0.500
- Behavioral agreement: 1.000
- Provider usage: unavailable with reason `provider_response_did_not_expose_usage`
- Rewrite comparison: `not_yet_comparable`
- Ledger: 7 JSONL events
- Secret scan: no matches for raw key patterns

Checks:
- `cargo fmt --check`: pass
- `cargo test determinism`: pass
- `cargo test --test integration_duumbi720_determinism`: pass
- `cargo clippy --all-targets -- -D warnings`: pass
- `cargo test --all`: pass
- live E2E replay: pass

Resource use:
- External LLM: MiniMax live replay, 2 attempts, expected under USD 1.
- Resource gate: not triggered.
- Greptile: not invoked.

## Codex Self-Review

Findings: none blocking.

Residual risks:
- Final provider prompt hashes are partial because the existing `intent::execute` seam does not expose final prompt text. This is explicitly allowed by the technical spec and is labeled as `partial`.
- Provider usage remains unavailable because provider responses do not expose usage metadata through the current adapter path.
- Live E2E showed behavior-equivalent but graph-divergent outputs, which is expected measurement evidence rather than a failure.

## Review Plan

- Keep draft until GitHub checks finish.
- When checks pass, move PR to ready for review and request `@chatgpt-codex-connector`.
- Do not invoke Greptile here; Greptile is reserved for the final implementation PR human decision.
