### PR TITLE
Release v0.4.1-preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1202,7 +1202,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "duumbi"
-version = "0.4.0-preview"
+version = "0.4.1-preview"
 dependencies = [
  "anyhow",
  "axum",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "duumbi-studio"
-version = "0.4.0-preview"
+version = "0.4.1-preview"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/duumbi-studio"]
 
 [package]
 name = "duumbi"
-version = "0.4.0-preview"
+version = "0.4.1-preview"
 edition = "2024"
 license = "MPL-2.0"
 default-run = "duumbi"

--- a/README.md
+++ b/README.md
@@ -22,23 +22,21 @@ Traditional compilers transform text → AST → machine code. DUUMBI skips the 
 
 ### Developer preview release
 
-DUUMBI `v0.4.0-preview` is distributed as prebuilt GitHub Release archives for:
+DUUMBI `v0.4.1-preview` is distributed as prebuilt GitHub Release archives for:
 
 | Platform | Target | Status |
 |----------|--------|--------|
 | macOS Apple Silicon | `aarch64-apple-darwin` | Required preview target |
+| macOS Intel | `x86_64-apple-darwin` | Required preview target |
 | Linux x86_64 | `x86_64-unknown-linux-gnu` | Required preview target |
 | Linux ARM64 | `aarch64-unknown-linux-gnu` | Extra preview target |
-
-macOS Intel (`x86_64-apple-darwin`) is not included in this developer preview.
-Build from source on Intel Macs if needed.
 
 Preview write-path evidence is intentionally limited. The current scaled
 intent-execute smoke notes are tracked in
 [`docs/e2e/duumbi-689-known-limitations.md`](docs/e2e/duumbi-689-known-limitations.md).
 
 Download the archive for your platform from the
-[`v0.4.0-preview` release](https://github.com/hgahub/duumbi/releases/tag/v0.4.0-preview)
+[`v0.4.1-preview` release](https://github.com/hgahub/duumbi/releases/tag/v0.4.1-preview)
 and verify it with the published checksum file:
 
 For the archive install, Rust is not required to install DUUMBI itself. The
@@ -49,7 +47,7 @@ equivalent C compiler/linker on Linux. Linux systems also need the runtime
 linker dependencies used by the DUUMBI C runtime, including libcurl.
 
 ```bash
-DUUMBI_VERSION=v0.4.0-preview
+DUUMBI_VERSION=v0.4.1-preview
 DUUMBI_TARGET=<target>
 
 curl -LO "https://github.com/hgahub/duumbi/releases/download/${DUUMBI_VERSION}/duumbi-${DUUMBI_VERSION}-${DUUMBI_TARGET}.tar.gz"

--- a/crates/duumbi-studio/Cargo.toml
+++ b/crates/duumbi-studio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "duumbi-studio"
-version = "0.4.0-preview"
+version = "0.4.1-preview"
 edition = "2024"
 license = "MPL-2.0"
 


### PR DESCRIPTION
Bumps version 0.4.0-preview → 0.4.1-preview across the workspace (Cargo.toml, duumbi-studio/Cargo.toml, Cargo.lock) and updates README to add macOS Intel as a required preview target.