### PR TITLE
Spec DUUMBI #761 authenticated repo-to-run journey

### DIFF
--- a/specs/DUUMBI-761/PRODUCT.md
+++ b/specs/DUUMBI-761/PRODUCT.md
@@ -1,0 +1,396 @@
+# DUUMBI-761: Authenticated Repo-To-Run Journey And Admin Provider Access
+
+Spec for #761.
+
+Related to #738, #750, #757, and #759.
+
+This PR is specification-only and must leave #761 open. Do not use closing
+references such as "closes", "fixes", or "resolves" for #761, #759, #757,
+#750, or #738.
+
+## Summary
+
+Define the next bounded DUUMBI Loop product slice after:
+
+- #738 delivered the provider-core/native CLI foundation in `hgahub/duumbi`.
+- #750 delivered the first local/no-cost `duumbi-loop` web/API scaffold.
+- #757 delivered the first production-integration `duumbi-loop` slice with
+  AuthAdapter, Postgres persistence, Stripe test entitlement mirror,
+  no-spend model routing, native no-provider preflight, and curated vault
+  import boundary.
+- #759 delivered the public `duumbi.dev` Loop entry route and Azure staging
+  boundary.
+
+This slice turns the staged Loop foundation into the first authenticated
+repo-to-run journey. A user can enter DUUMBI Loop from `duumbi-web`, sign in,
+register or select a GitHub repository as an optional adapter, create a
+repository-linked task by annotation or instruction, and track the workflow in
+the Loop UI. An administrator can monitor runs and configure provider access
+that customers use indirectly through DUUMBI-owned model labels.
+
+This slice does not complete the full DUUMBI Loop product.
+
+## Product Outcome
+
+An authenticated DUUMBI Loop user can start from the public `duumbi.dev` Loop
+entry, reach the Loop app, connect repository context, create a task using a
+clear annotation convention, and follow the run from intake through review
+artifacts. An organization administrator can inspect the same work across the
+organization and configure platform provider access without exposing raw
+provider/model SKUs or provider credentials to customers.
+
+## Source Context
+
+Verified during spec drafting:
+
+- #738, #750, #757, and #759 are closed as completed bounded slices.
+- #761 is open and records the requested next product goal.
+- `hgahub/duumbi-loop` currently exposes local/test login, organization
+  dashboard, runs, providers, billing, native no-provider run creation,
+  Postgres persistence, Stripe test entitlement mirror, no-spend model route
+  decisions, curated vault import, `/health`, `/ready`, and
+  `/ops/e2e-evidence`.
+- `hgahub/duumbi-loop` does not yet expose the complete product journey for
+  GitHub repository registration, annotation-based task intake, visible step
+  tracking, or admin provider-access configuration.
+- `hgahub/duumbi-web` already has the public Loop route from #759. This slice
+  should add or adjust the navigational Loop menu/link and CTA behavior only as
+  needed for the authenticated journey.
+- `hgahub/duumbi-infra` already hosts the staging boundary from #759. This
+  slice may need secret/config additions for provider-access placeholders, but
+  it must not enable live provider/model spend by default.
+- GitHub and GitLab remain optional adapters. The native `provider-duumbi` path
+  remains primary.
+
+## Scope
+
+This product slice covers:
+
+- `duumbi-web` Loop navigation into the authenticated Loop app,
+- authenticated Loop app entry using the existing AuthAdapter boundary,
+- organization-scoped GitHub repository registration as an optional adapter,
+- repository selection for task creation,
+- annotation or instruction based task intake for a selected repository,
+- run tracking UI with step state, events, artifacts, and review results,
+- admin run monitoring across the organization,
+- admin provider-access configuration status and controls,
+- provider route decision visibility for administrators,
+- provider/model SKU hiding from customer-facing surfaces,
+- audit evidence for repository, run, provider-access, and routing changes,
+- test/staging-only E2E without live provider/model spend.
+
+## Non-Goals
+
+- No implementation code in this spec PR.
+- No Ralph cycles in this spec PR.
+- No Greptile review for this spec PR.
+- No full DUUMBI Loop product launch.
+- No production `auth.duumbi.dev` service implementation.
+- No live Stripe products or live payment changes.
+- No live provider/model spend by default.
+- No requirement that GitHub or GitLab become prerequisites for DUUMBI Loop.
+- No exposure of raw provider/model SKUs to customer-facing users.
+- No storage of provider secrets in source control, PR bodies, issue comments,
+  logs, evidence files, or browser-rendered customer pages.
+- No broad worker queue execution beyond explicit, bounded E2E.
+- No arbitrary vault import expansion.
+- No production-grade GitHub App marketplace listing requirement in this slice.
+
+## Users And Roles
+
+- Visitor: reaches DUUMBI Loop from `duumbi-web`.
+- Authenticated user: signs in and views the organization dashboard.
+- Developer: registers or selects repositories and creates repository-linked
+  tasks when permitted.
+- Reviewer: views run state, artifacts, and review results.
+- Organization admin: monitors organization runs, provider status, route
+  decisions, and audit events.
+- Platform admin: configures provider access and routing policy that customers
+  consume through DUUMBI-owned model labels.
+
+## Product Surfaces
+
+### Public Loop Navigation
+
+Owner: `hgahub/duumbi-web`.
+
+The public DUUMBI site must expose a Loop menu item or equivalent top-level
+navigation path. The path must make it clear that DUUMBI Loop is the app entry,
+not only a marketing page. In staging, the CTA may target
+`https://staging.loop.duumbi.dev` or a configured request-access path.
+
+The page and navigation must not claim that the full DUUMBI Loop product is
+complete. GitHub/GitLab must be presented as optional adapters, not as the only
+way to use Loop.
+
+### Authenticated Loop Entry
+
+Owner: `hgahub/duumbi-loop`.
+
+The Loop app must require authentication for organization dashboard, repository
+registration, task creation, run tracking, and admin provider settings.
+Staging may continue to use the local/test AuthAdapter while preserving the
+future `auth.duumbi.dev` compatibility boundary.
+
+### Repository Registration
+
+Owner: `hgahub/duumbi-loop`.
+
+A user with the right role can register a GitHub repository as an optional
+adapter. The product must support:
+
+- organization-scoped repository rows,
+- provider connection status,
+- repository URL or owner/name metadata,
+- default branch or selected ref metadata,
+- repository limit preflight from entitlement,
+- disabled states for provider revoked, plan limit, or admin disabled,
+- native workspace registration without Git provider credentials.
+
+For this slice, a real GitHub credential may be simulated or test-scoped unless
+the technical gates explicitly approve a GitHub App/OAuth path. The UI must not
+require GitHub credentials to prove the native path still works.
+
+### Annotation-Based Task Intake
+
+Owner: `hgahub/duumbi-loop`.
+
+The task creation surface must let a user create a run from a selected
+repository using an annotation or repository-linked instruction. The accepted
+annotation format is implementation-owned, but it must be explicit and
+testable. Examples:
+
+- `@duumbi-loop draft a spec for the selected issue`
+- `@duumbi-loop review this change with Strict Review`
+- a form field containing an annotation and selected repository/ref metadata
+
+The annotation must resolve into a DUUMBI Loop run with:
+
+- organization ID,
+- actor user ID,
+- repository registration ID,
+- optional provider connection ID,
+- annotation text,
+- selected ref or workspace ref,
+- workflow kind,
+- DUUMBI-owned model label,
+- estimated credits,
+- initial step state,
+- audit event.
+
+### Run Tracking And Review
+
+Owner: `hgahub/duumbi-loop`.
+
+The user-facing UI must show:
+
+- run state,
+- current workflow step,
+- queued/running/completed/blocked/failure states,
+- credit estimate and final credit usage,
+- model label,
+- source/repository summary,
+- artifacts,
+- review target or review result when present,
+- no-spend and no-live-provider evidence in staging.
+
+The UI must be useful for repeated monitoring. Avoid a decorative-only view.
+
+### Admin Monitoring
+
+Owner: `hgahub/duumbi-loop`.
+
+An organization admin can view:
+
+- active and recent runs across the organization,
+- run events and state transitions,
+- repository registration status,
+- provider connection status,
+- model route decisions,
+- credit debits and entitlement state,
+- audit events for repository, task, provider-access, and routing changes.
+
+### Admin Provider Access Configuration
+
+Owner: `hgahub/duumbi-loop`, with secret/runtime support from
+`hgahub/duumbi-infra` when hosted.
+
+An admin surface must show provider access in a customer-safe way:
+
+- DUUMBI-owned labels: Fast, Balanced, Deep Research, Strict Review,
+  Private/BYOK,
+- provider access status: not configured, test configured, enabled, disabled,
+  or blocked,
+- route mode: no-spend/mock, platform key, BYOK, or disabled,
+- last validation timestamp,
+- audit trail.
+
+Customer-facing users must not see raw provider/model SKUs. Admin/audit
+surfaces may store or show raw provider/model SKU metadata only when the user is
+authorized and the value is needed for operations. Provider secrets must never
+be displayed after entry.
+
+## BDD Scenarios
+
+### Scenario: Public navigation reaches Loop
+
+Given a visitor opens `duumbi.dev`
+When they use the Loop menu or Loop CTA
+Then they can reach the configured DUUMBI Loop app entry
+And the public copy does not claim that the full DUUMBI Loop product is
+complete.
+
+### Scenario: Authenticated app entry protects organization data
+
+Given a visitor is not authenticated
+When they open an organization dashboard, repository page, run page, or admin
+provider settings page
+Then the app requires authentication
+And no organization data, repository metadata, provider status, route decision,
+or artifact content is exposed.
+
+### Scenario: User signs in and sees organization dashboard
+
+Given a user completes the staging auth flow
+When they open the Loop dashboard
+Then they see their organization, current runs, repository status, credit
+summary, and available DUUMBI-owned model labels.
+
+### Scenario: GitHub repository registration is optional
+
+Given a signed-in user has permission to manage repositories
+When they open repository registration
+Then GitHub is available as an optional adapter
+And native workspace registration remains available without GitHub credentials.
+
+### Scenario: Repository limit blocks registration before write
+
+Given an organization has reached its repository entitlement limit
+When a user submits another repository registration
+Then the request fails closed before creating the repository row
+And an audit event records the denied preflight without storing secrets.
+
+### Scenario: Provider revoked repository is not selectable
+
+Given a repository depends on a revoked provider connection
+When a user opens the task creation form
+Then the repository appears disabled or unavailable
+And the UI explains that provider access must be repaired or native context
+must be used.
+
+### Scenario: User creates annotation task for registered repository
+
+Given a signed-in developer selects a registered repository
+And enters a valid `@duumbi-loop` annotation or repository-linked instruction
+When they submit the task
+Then the app creates a Loop run tied to that repository
+And records the annotation, workflow kind, actor, selected ref, model label,
+credit estimate, and audit event.
+
+### Scenario: Invalid annotation is rejected
+
+Given a signed-in developer enters an empty, malformed, or unsupported
+annotation
+When they submit the task
+Then no run is created
+And the UI shows a validation error without consuming credits.
+
+### Scenario: Credit preflight blocks over-cap run
+
+Given a task estimate exceeds the organization's max credits per run or
+available credits
+When a user submits the task
+Then the request fails closed before queueing or writing a run
+And the denial is visible in admin audit evidence.
+
+### Scenario: User tracks workflow progress
+
+Given a run exists for a repository-linked annotation
+When the user opens the run detail page
+Then they can see the run state, current step, run events, selected repository,
+model label, estimated credits, artifacts, and review status.
+
+### Scenario: Review artifact is visible when complete
+
+Given a run produces a review result or GraphPatch review target
+When the user opens the run detail page
+Then the review summary and artifact references are visible
+And the UI does not expose raw source dumps or secrets.
+
+### Scenario: Admin sees organization run monitor
+
+Given an organization admin opens the admin monitor
+When runs are active or completed
+Then the admin can see organization-wide run state, actor, repository, workflow
+step, model label, route mode, credit usage, and failure/blocker summary.
+
+### Scenario: Admin configures provider access status
+
+Given a platform admin opens provider access settings
+When they configure a provider in test or no-spend mode
+Then the provider access status updates
+And the secret material is write-only
+And an audit event records who changed the configuration.
+
+### Scenario: Customer cannot see raw provider SKUs
+
+Given a customer-facing user opens dashboard, task creation, or run detail
+When model choices or route decisions are shown
+Then they see only DUUMBI-owned model labels
+And raw provider/model SKUs are not visible.
+
+### Scenario: Admin audit can inspect route decision metadata
+
+Given an authorized admin opens route decision audit
+When a run has a model route decision
+Then the admin can see the DUUMBI-owned label, route mode, spend flag, and
+audit metadata
+And any raw provider/model SKU is redacted unless explicitly authorized.
+
+### Scenario: Staging E2E uses no-spend routing
+
+Given the staging environment is used for E2E
+When a repository-linked annotation task is created and tracked
+Then external LLM calls are 0
+And live provider/model spend is 0
+And live Stripe calls are 0
+And Git provider credentials are either 0 or explicitly test-scoped.
+
+### Scenario: GitHub adapter failure does not break native path
+
+Given GitHub adapter credentials are missing, revoked, or disabled
+When a user creates a native workspace task
+Then the native `provider-duumbi` path still works
+And the UI clearly separates native context from GitHub repository context.
+
+### Scenario: Admin provider access does not start spend by default
+
+Given an admin saves provider access configuration
+When the environment is staging or no-spend mode
+Then no live provider/model call is made
+And spend remains blocked until explicit production approval.
+
+### Scenario: Audit trail covers sensitive actions
+
+Given repository registration, task creation, provider access changes, or route
+policy changes occur
+When an admin opens audit evidence
+Then each action includes actor, organization, target, action, timestamp, and
+correlation ID
+And secrets are not included in audit payloads.
+
+## Acceptance Gates
+
+Stage 10 implementation must not start until:
+
+- product and technical specs are approved,
+- auth ownership remains within the `duumbi-loop` AuthAdapter boundary for this
+  slice,
+- GitHub credential ownership is decided as test-scoped/stubbed or explicitly
+  approved for a real GitHub App/OAuth flow,
+- provider secret storage is secret-backed and admin-only,
+- billing/credit preflight semantics are mapped to tests,
+- cross-repo write order is explicit,
+- no-spend staging policy is testable,
+- the implementation plan preserves non-closing references until final
+  workflow closure.

--- a/specs/DUUMBI-761/TECHNICAL.md
+++ b/specs/DUUMBI-761/TECHNICAL.md
@@ -1,0 +1,674 @@
+# DUUMBI-761: Authenticated Repo-To-Run Journey And Admin Provider Access - Technical Specification
+
+Spec for #761.
+
+Related to #738, #750, #757, and #759.
+
+This PR is specification-only and must leave #761 open. Do not use closing
+references such as "closes", "fixes", or "resolves" for #761, #759, #757,
+#750, or #738.
+
+## Implementation Objective
+
+Prepare a Stage 10 implementation agent to build the next bounded DUUMBI Loop
+slice:
+
+```text
+duumbi-web Loop navigation -> authenticated duumbi-loop app ->
+repository registration -> annotation task intake -> run tracking ->
+admin provider-access controls
+```
+
+The implementation must let an authenticated user create and track a
+repository-linked DUUMBI Loop task while letting administrators configure and
+audit provider access that customers use indirectly through DUUMBI-owned model
+labels.
+
+Invariants:
+
+- `provider-duumbi` remains the primary native path.
+- GitHub/GitLab remain optional adapters, not prerequisites.
+- DUUMBI-owned model labels are the customer-facing contract.
+- Raw provider/model SKUs are admin/audit metadata only.
+- Provider credentials are admin-only, secret-backed, write-only after entry,
+  and audited.
+- Staging must use deterministic no-spend/mock routing unless explicit
+  production-spend approval is recorded in a later slice.
+- This slice does not complete the full DUUMBI Loop product.
+
+## Agent Audience
+
+- Stage 10 implementation coordinator.
+- `duumbi-web` navigation implementer.
+- `duumbi-loop` app/API/domain implementer.
+- GitHub adapter boundary implementer.
+- `duumbi-infra` secret/config implementer if hosted staging needs new
+  configuration.
+- Security, privacy, billing, and audit reviewers.
+- Future agents implementing production auth, live billing, real provider spend,
+  or full GitHub/GitLab app integrations.
+
+## Verified Current State
+
+### `hgahub/duumbi`
+
+#738, #750, #757, and #759 are closed as completed bounded slices. This spec PR
+should add only:
+
+- `specs/DUUMBI-761/PRODUCT.md`
+- `specs/DUUMBI-761/TECHNICAL.md`
+
+unless a documentation-only cross-reference is required.
+
+### `hgahub/duumbi-loop`
+
+Current relevant surfaces from the #750, #757, and #759 implementation line:
+
+- local/test AuthAdapter and secure session cookie,
+- organization dashboard,
+- run list and run detail pages,
+- providers page,
+- billing page,
+- account lifecycle API shell,
+- Postgres startup via `DUUMBI_LOOP_DATABASE_URL`,
+- Stripe test entitlement mirror and credit ledger,
+- deterministic no-spend model router,
+- native no-provider run creation,
+- curated vault import boundary,
+- staging `/health`, `/ready`, and `/ops/e2e-evidence`.
+
+Current gaps for #761:
+
+- no complete repository registration UI/API for real or stubbed GitHub
+  repository metadata,
+- no repository-linked annotation task intake,
+- no run events/step timeline UI suitable for process tracking,
+- no admin organization run monitor,
+- no admin provider-access configuration surface,
+- no provider secret write-only/audit model,
+- no customer/admin separation for route decision detail.
+
+### `hgahub/duumbi-web`
+
+#759 added the public Loop route. This slice should add or adjust navigation so
+the Loop menu/link points to the authenticated Loop entry. The public site must
+not own authenticated domain logic or secrets.
+
+### `hgahub/duumbi-infra`
+
+#759 delivered the staging boundary, custom domain, Key Vault secret boundary,
+GHCR guard, and hosted smoke evidence. This slice may need new secret names or
+configuration placeholders for provider access. It must not enable live
+provider/model spend by default.
+
+### `hgahub/duumbi-registry`
+
+Read-only unless implementation discovers that repository or model-label
+metadata needs a formal registry boundary. Do not make registry the Loop tenant,
+billing, or provider-secret source of truth.
+
+### `hgahub/duumbi-vault`
+
+Reference material only. No arbitrary vault import expansion in this slice.
+
+## Cross-Repo Ownership And PR Order
+
+| Order | Repo | Owns In This Slice | Must Not Own |
+| ---: | --- | --- | --- |
+| 1 | `hgahub/duumbi` | Spec artifacts for #761. | Runtime app, secrets, Azure resources. |
+| 2 | `hgahub/duumbi-web` | Loop navigation/menu entry and configured app handoff. | Authenticated app logic, repository data, provider settings. |
+| 3 | `hgahub/duumbi-loop` | Authenticated repository registration, annotation task intake, run tracking UI/API, admin monitor, provider-access model, audit, tests. | Public marketing visual system, Azure resource definitions, raw provider execution. |
+| 4 | `hgahub/duumbi-infra` | Secret/config names and staging app settings only if needed after app contract stabilizes. | Product logic, provider routing policy, customer UI. |
+| 5 | `hgahub/duumbi` | Core contract updates only if `provider-duumbi` cannot represent repository-linked run context. | Loop tenant/app ownership. |
+| 6 | `hgahub/duumbi-registry` | Read-only unless explicit metadata API boundary is required. | Tenant state, provider secrets. |
+| 7 | `hgahub/duumbi-vault` | Curated docs only if needed. | Runtime source of truth or secrets. |
+
+Recommended implementation order:
+
+1. `duumbi-web`: add or adjust Loop menu/link and route verification.
+2. `duumbi-loop`: implement repository registration, annotation intake, run
+   tracking, admin provider-access controls, and tests.
+3. `duumbi-infra`: add provider-secret config placeholders only after
+   `duumbi-loop` contract names are final.
+4. `duumbi` core only if a hard provider-duumbi contract gap is found.
+
+Do not start live provider/model spend or production auth work in this slice.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    Web["duumbi-web Loop menu"]
+    App["duumbi-loop authenticated app"]
+    Auth["AuthAdapter"]
+    Org["Organization and membership"]
+    Repo["Repository registrations"]
+    GitHub["GitHub optional adapter"]
+    Native["provider-duumbi native context"]
+    Intake["Annotation task intake"]
+    Runs["Loop runs and events"]
+    Review["Review artifacts"]
+    Admin["Admin monitor"]
+    ProviderAccess["Admin provider access"]
+    Secrets["Secret-backed provider config"]
+    Router["DUUMBI model label router"]
+    Audit["Audit events"]
+
+    Web --> App
+    App --> Auth
+    App --> Org
+    App --> Repo
+    Repo -. optional .-> GitHub
+    Repo --> Native
+    Repo --> Intake
+    Intake --> Runs
+    Runs --> Review
+    Runs --> Router
+    Admin --> Runs
+    Admin --> ProviderAccess
+    ProviderAccess --> Secrets
+    ProviderAccess --> Router
+    App --> Audit
+    ProviderAccess --> Audit
+```
+
+## Auth And Authorization
+
+`duumbi-loop` keeps ownership of the AuthAdapter boundary for this slice.
+Production `auth.duumbi.dev` remains future-compatible but not required.
+
+Required checks:
+
+- unauthenticated users cannot access organization data,
+- membership is checked on every org-scoped API and page,
+- repository registration requires Owner/Admin/Developer or a narrower
+  capability,
+- task creation requires `can_start_run`,
+- admin monitor requires Owner/Admin,
+- provider-access configuration requires Owner or platform admin role,
+- billing/credit details remain scoped to the organization,
+- session and account lifecycle behavior from #750/#757 must keep passing.
+
+Recommended capability names:
+
+- `repo:read`
+- `repo:write`
+- `run:create`
+- `run:read`
+- `admin:runs`
+- `admin:provider_access`
+- `audit:read`
+
+## Data Model Boundaries
+
+`duumbi-loop` owns Postgres-compatible migrations. Prefer additive migrations
+after the #757 schema.
+
+### Repository Registration
+
+Extend or formalize `repository_registrations`:
+
+- `id`
+- `organization_id`
+- `provider_connection_id` nullable
+- `adapter_kind`: `native`, `github`, `gitlab`
+- `display_name`
+- `repository_url` nullable
+- `provider_owner` nullable
+- `provider_repo` nullable
+- `default_branch` nullable
+- `selected_ref` nullable
+- `native_workspace_ref` nullable
+- `status`: `enabled_indexed`, `disabled`, `disabled_by_plan_limit`,
+  `disabled_by_provider_revoked`, `pending_validation`
+- `created_by_user_id`
+- `created_at`
+- `updated_at`
+
+Repository rows must not store access tokens.
+
+### Provider Connections
+
+Extend or formalize `provider_connections`:
+
+- `id`
+- `organization_id`
+- `adapter_kind`: `github`, `gitlab`, `native`
+- `status`: `not_configured`, `test_configured`, `enabled`, `disabled`,
+  `revoked`, `blocked`
+- `credential_ref` nullable secret reference
+- `external_installation_id` nullable
+- `scopes_summary` nullable
+- `last_validated_at` nullable
+- `created_by_user_id`
+- `updated_by_user_id`
+- `created_at`
+- `updated_at`
+
+The `credential_ref` points to a secret-backed reference. It is never displayed
+after entry and never returned to customer-facing APIs.
+
+### Annotation Tasks
+
+Add `loop_task_requests` or equivalent:
+
+- `id`
+- `organization_id`
+- `actor_user_id`
+- `repository_registration_id`
+- `provider_connection_id` nullable
+- `annotation_text`
+- `normalized_instruction`
+- `selected_ref` nullable
+- `workflow_kind`
+- `model_label`
+- `estimated_credits`
+- `preflight_status`
+- `created_run_id` nullable
+- `created_at`
+
+Annotation parsing must be deterministic for tests. It must reject empty,
+malformed, or unsupported annotations before run creation.
+
+### Run Events
+
+Ensure `loop_run_events` or equivalent supports:
+
+- `id`
+- `organization_id`
+- `run_id`
+- `event_kind`
+- `state_before` nullable
+- `state_after` nullable
+- `message`
+- `actor_user_id` nullable
+- `created_at`
+
+Run tracking UI should consume event rows rather than inferring all process
+state from a single run row.
+
+### Provider Access And Routing
+
+Add `provider_access_configs` or equivalent:
+
+- `id`
+- `organization_id` nullable for platform default
+- `label`
+- `route_mode`: `no_spend`, `platform_key`, `byok`, `disabled`
+- `provider_kind` nullable
+- `raw_provider_sku` nullable, admin/audit only
+- `credential_ref` nullable
+- `status`
+- `live_spend_allowed`
+- `last_validated_at` nullable
+- `created_by_user_id`
+- `updated_by_user_id`
+- `created_at`
+- `updated_at`
+
+Existing `model_route_decisions` should reference the selected label and route
+mode. Customer-facing APIs return label and route mode only. Admin APIs may
+return raw provider/model SKU metadata only for authorized admin/audit users and
+must redact credential references.
+
+### Audit Events
+
+Audit events must cover:
+
+- login/session lifecycle where already supported,
+- repository registration created/disabled/validated,
+- provider connection created/disabled/revoked,
+- annotation task accepted/rejected,
+- run created/state changed,
+- provider access created/updated/disabled,
+- route policy changed,
+- credit preflight denied.
+
+Minimum fields:
+
+- actor user ID,
+- organization ID,
+- action,
+- target type,
+- target ID,
+- correlation ID,
+- timestamp,
+- redacted metadata.
+
+## API Boundaries
+
+Recommended `duumbi-loop` APIs:
+
+```text
+GET  /api/orgs/{org_id}/repositories
+POST /api/orgs/{org_id}/repositories
+GET  /api/orgs/{org_id}/repositories/{repository_id}
+PATCH /api/orgs/{org_id}/repositories/{repository_id}
+
+GET  /api/orgs/{org_id}/provider-connections
+POST /api/orgs/{org_id}/provider-connections/github/test
+PATCH /api/orgs/{org_id}/provider-connections/{connection_id}
+
+POST /api/orgs/{org_id}/task-requests
+GET  /api/orgs/{org_id}/task-requests/{task_request_id}
+
+GET  /api/orgs/{org_id}/runs
+GET  /api/orgs/{org_id}/runs/{run_id}
+GET  /api/orgs/{org_id}/runs/{run_id}/events
+GET  /api/orgs/{org_id}/runs/{run_id}/artifacts
+
+GET  /api/admin/orgs/{org_id}/runs
+GET  /api/admin/orgs/{org_id}/provider-access
+POST /api/admin/orgs/{org_id}/provider-access
+PATCH /api/admin/orgs/{org_id}/provider-access/{config_id}
+GET  /api/admin/orgs/{org_id}/audit-events
+```
+
+Server-rendered pages may be added or updated:
+
+```text
+GET /o/{org}/repositories
+GET /o/{org}/repositories/new
+GET /o/{org}/tasks/new
+GET /o/{org}/runs
+GET /o/{org}/runs/{run_id}
+GET /o/{org}/admin/runs
+GET /o/{org}/admin/provider-access
+GET /o/{org}/admin/audit
+```
+
+API responses must not expose secrets. Customer-facing responses must not expose
+raw provider/model SKUs.
+
+## GitHub Adapter Boundary
+
+This slice may implement GitHub as a test/stub adapter first, unless
+maintainers explicitly approve a real GitHub App or OAuth flow before Stage 10.
+
+Required either way:
+
+- GitHub is optional.
+- Native workspace registration remains available.
+- Missing/revoked GitHub credentials do not break native runs.
+- Repository URL/owner/name parsing is validated.
+- Credentials are not stored in repository rows.
+- Provider connection state is explicit and auditable.
+
+If a real GitHub integration is approved:
+
+- prefer GitHub App installation tokens over user PATs,
+- store only secret references and external installation metadata,
+- request minimum read scopes required for repository metadata and annotation
+  context,
+- avoid persisting raw source content unless explicitly accepted by the user and
+  bounded by retention policy,
+- record permission and installation changes in audit events.
+
+## Annotation Intake
+
+The accepted annotation grammar must be simple and deterministic.
+
+Recommended minimum grammar:
+
+```text
+@duumbi-loop <instruction>
+```
+
+Optional fields can be represented through form controls rather than embedded
+syntax:
+
+- repository ID,
+- selected ref,
+- workflow kind,
+- model label,
+- knowledge/context toggles.
+
+Preflight order:
+
+1. authenticate user,
+2. authorize organization membership and run capability,
+3. validate repository registration and provider status,
+4. parse annotation,
+5. validate model label availability,
+6. estimate credits,
+7. verify billing/entitlement and parallel run limits,
+8. create task request and run in one durable transaction,
+9. write audit event and run event.
+
+If any preflight fails, do not create a run and do not debit credits.
+
+## Billing And Entitlement Constraints
+
+Use the existing Stripe test entitlement mirror and credit ledger.
+
+Required checks before run creation:
+
+- billing status is active or otherwise allowed for test/staging,
+- repository limit has not been exceeded,
+- parallel run limit has not been exceeded,
+- selected model label is allowed,
+- estimate does not exceed `max_credits_per_run`,
+- available credit balance can cover the estimate,
+- over-cap requests fail before task/run write.
+
+No live Stripe calls are allowed in this slice. Stripe test webhook behavior
+from #750/#757 must continue to pass.
+
+## Security And Privacy Requirements
+
+- Provider credentials are write-only after entry.
+- Secret material is stored only through approved secret-backed references.
+- Do not log provider tokens, database URLs, annotation bodies that may contain
+  secrets, raw source dumps, or personal data.
+- Customer-facing APIs and pages expose DUUMBI-owned model labels only.
+- Admin APIs require stronger authorization and redact secret references.
+- Audit events must use redacted metadata.
+- Repository context stored in DB must be bounded metadata, not unbounded source
+  content.
+- Artifact references must validate path traversal and ownership.
+- CSRF protection or same-site form protections must exist for mutating
+  server-rendered routes.
+- Session cookies remain HttpOnly, Secure, SameSite, and scoped appropriately.
+- Hosted staging keeps no-spend model routing unless explicitly approved
+  otherwise in a later issue.
+
+## BDD-To-Test Mapping
+
+| Product Scenario | Required Tests |
+| --- | --- |
+| Public navigation reaches Loop | `duumbi-web` route/nav build test; CTA target verifier. |
+| Authenticated app entry protects organization data | `duumbi-loop` integration tests for unauthenticated dashboard/repo/run/admin routes. |
+| User signs in and sees organization dashboard | login to dashboard integration test with repo/model/credit summary assertions. |
+| GitHub repository registration is optional | repository page/API test showing GitHub option and native option. |
+| Repository limit blocks registration before write | unit/integration test asserting no repository row after limit failure. |
+| Provider revoked repository is not selectable | repository/task form test and API validation test. |
+| User creates annotation task for registered repository | integration test creating repo, posting annotation, asserting task/run/audit rows. |
+| Invalid annotation is rejected | parser unit test and API test with no run/credit write. |
+| Credit preflight blocks over-cap run | billing preflight test asserting fail-before-write. |
+| User tracks workflow progress | run detail page/API test showing state, events, artifacts, repo, model label. |
+| Review artifact is visible when complete | review artifact rendering test with path/ownership validation. |
+| Admin sees organization run monitor | admin page/API authorization and content tests. |
+| Admin configures provider access status | provider access create/update tests with write-only secret behavior. |
+| Customer cannot see raw provider SKUs | customer API/page snapshot or assertion tests. |
+| Admin audit can inspect route decision metadata | admin route-decision/audit tests with role checks and redaction. |
+| Staging E2E uses no-spend routing | local/staging E2E evidence with external calls/spend/live Stripe = 0. |
+| GitHub adapter failure does not break native path | integration test with revoked GitHub connection and successful native run. |
+| Admin provider access does not start spend by default | provider config test asserting no live call and `live_spend_allowed=false`. |
+| Audit trail covers sensitive actions | audit tests for repo, task, provider-access, route-policy changes. |
+
+## Local Verification Requirements
+
+`duumbi-web` PR:
+
+- install/build command used by existing repo,
+- route/nav verifier,
+- no secret/env requirement for static build.
+
+`duumbi-loop` PR:
+
+- `cargo fmt --check`,
+- `cargo clippy --all-targets -- -D warnings`,
+- `cargo test`,
+- Postgres migration/integration tests with `DUUMBI_LOOP_DATABASE_URL`,
+- auth/session regression tests,
+- repository registration tests,
+- annotation parser tests,
+- run tracking tests,
+- admin provider-access tests,
+- audit redaction tests,
+- no-spend route tests.
+
+`duumbi-infra` PR, only if needed:
+
+- TypeScript check,
+- Pulumi preview,
+- no secret values in outputs,
+- no provider/model spend enabled.
+
+## Live E2E Plan
+
+Default E2E is local or staging no-spend:
+
+1. Open `duumbi-web` Loop menu/link.
+2. Reach `duumbi-loop` staging app.
+3. Sign in through local/test AuthAdapter.
+4. Create a native workspace repository and a test/stub GitHub repository.
+5. Submit `@duumbi-loop draft a spec for this repo change`.
+6. Verify task request and run creation.
+7. Verify run state, events, artifacts, review summary, model label, and credit
+   estimate in the UI.
+8. Open admin monitor and verify the run, route decision, provider status, and
+   audit events.
+9. Configure provider access in no-spend/test mode.
+10. Verify no customer-facing surface exposes raw provider/model SKUs.
+11. Record evidence:
+    - external LLM calls = 0,
+    - live provider/model spend = 0,
+    - live Stripe calls = 0,
+    - Git provider credentials = 0 or explicitly test-scoped,
+    - worker execution outside explicit E2E = 0,
+    - Ralph cycles = 0.
+
+Hosted E2E must stop with findings unless:
+
+- staging app is healthy and ready,
+- Postgres-compatible persistence is configured,
+- provider credentials are test-scoped or explicitly disabled,
+- no-spend router is active,
+- budget and worker guardrails from #759 remain in effect.
+
+## Ralph Cycle Resource Policy
+
+Ralph cycles are not allowed by default for this slice.
+
+Stage 10 may request a Ralph cycle only if all are true:
+
+- the blocker cannot be resolved from repo context, specs, or deterministic
+  local tests,
+- the request is scoped to a single question,
+- estimated external cost is below USD 2,
+- live provider/model spend is not triggered,
+- no production secrets are exposed,
+- the issue comment records purpose, expected cost, inputs, and result.
+
+If these conditions are not met, stop with findings instead of starting a Ralph
+cycle.
+
+## Stage 10 Implementation Prompt
+
+```text
+Run DUUMBI Stage 10 implementation for #761 using
+specs/DUUMBI-761/PRODUCT.md and specs/DUUMBI-761/TECHNICAL.md.
+
+Target issue: https://github.com/hgahub/duumbi/issues/761
+
+Parent context:
+- #738 delivered the provider-core/native CLI foundation.
+- #750 delivered the first local/no-cost duumbi-loop web+infra slice.
+- #757 delivered the first production-integration duumbi-loop slice.
+- #759 delivered the public duumbi.dev Loop entry route and Azure staging
+  boundary.
+- #738, #750, #757, and #759 are closed as completed bounded slices.
+- The full DUUMBI Loop product is not complete.
+
+Goal:
+Implement the next bounded authenticated DUUMBI Loop repo-to-run journey:
+- duumbi-web Loop menu/link to the DUUMBI Loop app,
+- authenticated duumbi-loop app entry,
+- organization-scoped repository registration with GitHub as an optional
+  adapter and native workspace registration still available,
+- annotation-based task intake for a selected repository,
+- user-facing run tracking with state, step events, artifacts, and review
+  result,
+- admin run monitor,
+- admin provider-access configuration used indirectly by customers through
+  DUUMBI-owned model labels,
+- audit evidence for repository, task, route, and provider-access changes.
+
+Recommended PR order:
+1. hgahub/duumbi-web: Loop menu/link and configured app handoff.
+2. hgahub/duumbi-loop: repository registration, annotation intake, run
+   tracking, admin monitor, provider-access model, audit, tests, and local
+   Postgres evidence.
+3. hgahub/duumbi-infra: provider-secret config placeholders only if required
+   by the duumbi-loop contract; no live spend enablement.
+4. hgahub/duumbi only if provider-duumbi cannot represent repository-linked
+   run context.
+
+Constraints:
+- GitHub/GitLab remain optional adapters, not prerequisites.
+- provider-duumbi remains the primary path.
+- DUUMBI-owned model labels remain the user-facing contract.
+- Customers must not see raw provider/model SKUs.
+- Provider credentials must be admin-only, secret-backed, write-only after
+  entry, and audited.
+- No production auth.
+- No live Stripe products or live Stripe calls.
+- No live provider/model spend or external LLM calls.
+- No GitHub/GitLab production credentials unless explicitly approved; test/stub
+  adapter is acceptable for the first implementation PR.
+- No Ralph cycles unless explicitly authorized under the resource policy.
+- Use non-closing references such as "Related to #761".
+- Greptile is reserved for the final implementation PR review.
+
+Required verification:
+- duumbi-web build and Loop navigation/link verifier,
+- duumbi-loop cargo fmt, clippy, and tests,
+- Postgres migration/integration tests,
+- auth/session authorization tests,
+- repository registration and entitlement limit tests,
+- annotation parser and task creation tests,
+- over-cap blocked-before-write tests,
+- run tracking and review artifact tests,
+- admin provider-access and audit redaction tests,
+- no-spend model-router tests,
+- local or staging E2E evidence recording external LLM calls = 0, live
+  provider/model spend = 0, live Stripe calls = 0, Git provider credentials = 0
+  or explicitly test-scoped, worker execution outside explicit E2E = 0, and
+  Ralph cycles = 0.
+
+Stop with findings if auth ownership, GitHub credential ownership, provider
+secret handling, billing, auditability, security/privacy, model routing, cloud
+budget, or cross-repo write access creates a blocker.
+```
+
+## Stage 7 And Stage 9 Self-Review Checklist
+
+Stage 7 product gate passes only if:
+
+- product spec is in English,
+- BDD scenarios cover navigation, auth, repository registration, annotation
+  intake, run tracking, admin monitor, provider access, model-label hiding, and
+  no-spend staging,
+- non-goals are explicit,
+- the full DUUMBI Loop product is not claimed complete.
+
+Stage 9 technical gate passes only if:
+
+- every BDD scenario maps to tests,
+- cross-repo ownership and PR order are explicit,
+- API/data model boundaries are explicit,
+- auth/session, GitHub adapter, provider-secret, billing, audit, and security
+  boundaries are explicit,
+- live E2E and Ralph Cycle policies are explicit,
+- Stage 10 prompt is present.


### PR DESCRIPTION
## Summary

Spec for #761.

Adds the next bounded DUUMBI Loop specs for the authenticated repo-to-run journey and admin provider-access configuration:

- `specs/DUUMBI-761/PRODUCT.md`
- `specs/DUUMBI-761/TECHNICAL.md`

Related to #761, #759, #757, #750, and #738.

## Scope

This is a spec-only PR. It does not create implementation code, hosted resources, provider credentials, live provider/model spend, live Stripe products, or Ralph cycles.

The specs define:

- duumbi-web Loop navigation into the Loop app,
- authenticated Loop app entry,
- GitHub repository registration as an optional adapter,
- native workspace path remaining available,
- annotation-based task intake,
- user-facing run tracking and review artifacts,
- admin run monitor,
- admin provider-access configuration,
- customer-safe DUUMBI-owned model labels,
- secret-backed provider credential policy,
- BDD-to-test mapping,
- live no-spend E2E plan,
- Ralph Cycle resource policy,
- Stage 10 implementation prompt.

## Workflow Note

This PR must leave #761 open for implementation and final workflow closure. Do not use closing issue references for #761.

The full DUUMBI Loop product is not complete.

## Verification

- `git diff --check`
- non-ASCII scan: 0 findings
- BDD scenario to technical mapping scan: 19 scenarios, 0 missing mappings
- `pre-commit run --files specs/DUUMBI-761/PRODUCT.md specs/DUUMBI-761/TECHNICAL.md`
