### PR TITLE
[codex] Draft DUUMBI-765 hosted GitHub App staging E2E specs

### DIFF
--- a/specs/DUUMBI-765/PRODUCT.md
+++ b/specs/DUUMBI-765/PRODUCT.md
@@ -1,0 +1,305 @@
+# DUUMBI-765 Product Spec: Hosted GitHub App Staging E2E And Controlled Worker Enablement
+
+Related to #765
+
+Workflow note: this is a spec-only artifact. Any PR containing this document must
+use non-closing issue references and must leave #765 open for Stage 10
+implementation.
+
+## Summary
+
+DUUMBI Loop now has the provider-core native foundation, local web and infra
+scaffold, production-integration persistence, public duumbi.dev Loop entry,
+authenticated repository and task surfaces, and the real optional GitHub App
+adapter plus Postgres-backed async worker queue.
+
+This slice proves that the GitHub App adapter and async worker path can operate
+in hosted Azure staging under explicit operator control. It connects a
+non-production GitHub App installation on `hgahub/duumbi-github-test` to
+`staging.loop.duumbi.dev`, verifies signed webhook intake, writes durable
+queue/run/event/artifact evidence to staging Postgres, enables the worker only
+for an approved no-spend E2E window, and disables or scales it back to zero
+after evidence is captured.
+
+This is not full DUUMBI Loop completion. The slice is a bounded hosted staging
+proof for GitHub App intake and controlled worker execution only.
+
+## Product Outcome
+
+DUUMBI operators can run one controlled hosted staging E2E that proves:
+
+- the staging GitHub App can be installed on the approved test repository,
+- `@duumbi-loop` annotations from GitHub reach DUUMBI Loop through a signed
+  webhook,
+- duplicate or invalid webhook deliveries do not create duplicate work,
+- a queued task can move through worker-controlled states,
+- no-spend model routing is enforced,
+- the admin monitor exposes queue, worker, provider, audit, and failure
+  evidence,
+- the worker is disabled or scaled down after the E2E window.
+
+Organization users still see GitHub as optional. Native provider-duumbi
+workflows remain available without GitHub, and customer-facing model labels
+remain DUUMBI-owned.
+
+## Current Context
+
+- #738 delivered the provider-core/native CLI foundation.
+- #750 delivered the first local/no-cost `duumbi-loop` web+infra slice.
+- #757 delivered the first production-integration `duumbi-loop` slice.
+- #759 delivered the public duumbi.dev Loop entry route and Azure staging
+  boundary.
+- #761 delivered authenticated repository/task/admin surfaces and Postgres
+  persistence.
+- #763 delivered the real optional GitHub App adapter boundary and
+  Postgres-backed async worker queue.
+
+## Stage 5 Acceptance Check
+
+The slice may proceed to Stage 7 and Stage 9 drafting because the core product
+and architecture decisions are bounded:
+
+- GitHub remains optional and is proven through a non-production GitHub App.
+- The staging test repository is `hgahub/duumbi-github-test`.
+- `duumbi-loop` owns app/API behavior, webhook handling, queue state, worker
+  behavior, admin monitor evidence, and no-spend model routing.
+- `duumbi-infra` owns Azure staging secret references, Container App
+  environment variables, worker enablement controls, budget controls, and
+  preview/apply evidence.
+- `duumbi-web` changes are out of scope unless the public entry copy or CTA
+  needs a small correction.
+- Hosted worker execution is disabled by default and may run only during an
+  explicitly approved E2E window.
+- No production auth, live Stripe, live provider/model spend, GitLab adapter,
+  or Ralph cycles are allowed.
+
+## Users
+
+- DUUMBI operator: configures the non-production GitHub App, staging secrets,
+  worker E2E window, and teardown/disable procedure.
+- Organization admin: verifies provider connection, repository registration,
+  worker health, queue state, audit, and blocked/failed run evidence.
+- Organization member: triggers a staged annotation task and reviews run state
+  and artifacts.
+- Reviewer/implementation agent: verifies the slice without treating hosted
+  staging as production readiness.
+
+## In Scope
+
+- Non-production GitHub App staging configuration boundary.
+- GitHub App installation for `hgahub/duumbi-github-test`.
+- Staging webhook URL and HMAC signature verification.
+- Key Vault and Container App secret-reference model for GitHub App settings.
+- Allowlisted staging/test repository registration.
+- Hosted `@duumbi-loop` annotation intake from GitHub webhook events.
+- Staging Postgres persistence for queue, runs, events, artifacts, webhook
+  deliveries, and provider state.
+- Controlled worker enablement with max replicas 1, scale-to-zero where
+  possible, and explicit E2E approval.
+- No-spend DUUMBI model routing for the full hosted smoke.
+- Admin monitor evidence for worker health, queue backlog, blocked/failed runs,
+  provider access, audit, and webhook delivery state.
+- Disable, scale-to-zero, or teardown evidence after E2E.
+
+## Out Of Scope
+
+- Full DUUMBI Loop product completion.
+- Production auth or central `auth.duumbi.dev`.
+- Live Stripe products, live Stripe webhooks, checkout, billing portal, or
+  invoices.
+- Live provider/model spend or external LLM calls.
+- Customer exposure of raw provider/model SKUs.
+- GitLab adapter implementation.
+- GitHub Marketplace publication.
+- Broad repository write-back, PR authoring, merge automation, or production
+  repository automation.
+- Production GitHub App credentials.
+- Persistent hosted worker execution outside an approved E2E window.
+- Creating a new production database service.
+- Ralph cycles.
+
+## Product Requirements
+
+### Staging GitHub App Setup
+
+Operators can configure a non-production GitHub App for staging. The app must be
+owned by the DUUMBI/hgahub operator boundary, not by an individual developer's
+personal workflow. The app must be installed only on approved test repositories
+for this slice, starting with `hgahub/duumbi-github-test`.
+
+The product must communicate that GitHub is optional. Native DUUMBI workflows
+must not require a GitHub provider connection.
+
+### Secret Boundary
+
+GitHub App credentials and webhook secrets must be stored through Key Vault and
+Container App secret references. Normal issue comments, PR bodies, Pulumi
+outputs, logs, screenshots, and evidence files must not contain raw secrets,
+private keys, installation tokens, database URLs, or webhook payload bodies.
+
+### Hosted Webhook Intake
+
+Staging accepts GitHub webhook deliveries only when the webhook secret is
+configured and the request signature is valid. Unsupported events, unknown
+installations, disabled providers, empty annotations, malformed annotations, and
+duplicate deliveries must be recorded in safe evidence without retry storms or
+duplicate queue writes.
+
+### Allowlisted Test Repository
+
+Only the approved staging repository may be used for the live hosted E2E:
+
+```text
+hgahub/duumbi-github-test
+```
+
+If any other repository is included in the GitHub App installation or webhook
+path, the E2E must stop with findings unless the operator explicitly extends the
+allowlist in a later issue.
+
+### Controlled Worker Enablement
+
+The hosted worker is disabled by default. To run the E2E, an operator must
+explicitly enable the worker through the approved staging configuration and
+record the E2E window. The worker must run with max replicas 1 and deterministic
+no-spend routing. After E2E, the worker must be disabled, scaled to zero, or the
+staging resources must be torn down according to the approved runbook.
+
+### No-Spend Routing
+
+All hosted smoke execution must use the no-spend DUUMBI model router. The UI and
+run records may show DUUMBI-owned labels such as Fast, Balanced, Deep Research,
+Strict Review, and Private/BYOK, but no customer surface may expose raw provider
+or model SKUs.
+
+### Staging Evidence
+
+The E2E evidence must show:
+
+- health/readiness status,
+- configured environment mode,
+- persistence backend,
+- worker enabled/approved state before, during, and after the E2E window,
+- webhook delivery status and idempotency behavior,
+- queued/running/review/completed/failed or blocked state transitions,
+- admin monitor queue and worker status,
+- no-spend and no-live-service guardrails,
+- teardown/disable state.
+
+## BDD Scenarios
+
+### Scenario: Native DUUMBI remains available without GitHub
+
+Given a staging organization has no GitHub provider connection
+When a user opens the Loop app
+Then native provider-duumbi task creation remains available
+And GitHub is presented as an optional adapter.
+
+### Scenario: Operator configures a non-production GitHub App
+
+Given the operator has created a non-production GitHub App for staging
+When the app credentials are configured
+Then the raw private key, client secret, webhook secret, and installation token
+are stored only through approved secret references
+And no raw secret appears in source control, logs, PR text, issue comments, or
+evidence artifacts.
+
+### Scenario: Test repository is allowlisted
+
+Given the GitHub App is installed for staging
+When the operator registers repositories for the E2E
+Then `hgahub/duumbi-github-test` is accepted
+And any unapproved repository is rejected or blocked before queueing.
+
+### Scenario: Staging webhook requires a valid signature
+
+Given GitHub sends a webhook to staging
+When the signature is missing or invalid
+Then DUUMBI Loop rejects the request
+And no task request, run, artifact, or worker job is created.
+
+### Scenario: Duplicate webhook delivery is idempotent in staging
+
+Given GitHub sends the same delivery id twice
+When staging receives both requests
+Then only one accepted queue item is created
+And the duplicate delivery is recorded as ignored.
+
+### Scenario: Empty annotation does not retry forever
+
+Given a signed GitHub comment contains only `@duumbi-loop`
+When staging receives the webhook
+Then DUUMBI Loop records an ignored delivery with empty-annotation evidence
+And returns a successful non-queued response to prevent retry storms.
+
+### Scenario: Annotation queues hosted staging work
+
+Given the GitHub App is installed on `hgahub/duumbi-github-test`
+And the repository is registered and enabled
+And the organization has available test credits
+When a signed GitHub comment contains `@duumbi-loop review this change`
+Then DUUMBI Loop creates a task request, run, and queued worker job
+And the run references the repository, annotation, model label, and webhook
+delivery id.
+
+### Scenario: Worker remains disabled by default
+
+Given staging is deployed outside an E2E window
+When the operator checks readiness and evidence
+Then the worker reports disabled or scaled to zero
+And worker execution outside explicit E2E is zero.
+
+### Scenario: Worker runs only during an approved E2E window
+
+Given a queued staging worker job exists
+And the operator explicitly enables the worker for E2E
+When the worker claims the job
+Then the run moves from queued to running
+And the worker uses the no-spend DUUMBI model router
+And admin monitor shows the active or recently completed worker state.
+
+### Scenario: Worker disable is verified after E2E
+
+Given the hosted E2E has completed or failed with evidence
+When the operator ends the E2E window
+Then the worker is disabled, scaled to zero, or destroyed
+And evidence records the final disabled/teardown state.
+
+### Scenario: Billing and cloud cost gates fail closed
+
+Given test billing or cloud budget guardrails are missing
+When a hosted E2E run is requested
+Then the system stops before worker execution
+And records findings without live Stripe calls, live model spend, or uncontrolled
+cloud cost.
+
+### Scenario: Admin can inspect queue and provider evidence
+
+Given a hosted GitHub annotation was processed
+When an admin opens the worker/provider monitor
+Then they can see webhook delivery status, provider access status, queue state,
+attempt counts, blocked/failed reasons, and audit events.
+
+## Acceptance Criteria
+
+- The product and technical specs are merged in `hgahub/duumbi` as spec-only
+  artifacts for #765.
+- The spec PR uses only non-closing references such as `Related to #765`.
+- The execution issue remains open after the spec PR.
+- The Stage 10 prompt is included in the technical spec.
+- The implementation path is bounded to staged GitHub App E2E and controlled
+  worker enablement.
+- The test repository is explicitly `hgahub/duumbi-github-test`.
+- The full DUUMBI Loop product is explicitly not complete.
+
+## Codex Self-Review
+
+- Product scope is bounded to hosted staging E2E and controlled worker
+  enablement.
+- GitHub remains optional and GitLab remains out of scope.
+- The spec does not require production auth, live Stripe, live model/provider
+  spend, raw provider/model SKU exposure, or Ralph cycles.
+- The spec records clear operator gates for secrets, worker enablement,
+  cloud budget, and teardown.
+- No unresolved product blocker remains for drafting. Missing live secrets are
+  implementation prerequisites, not product-scope blockers.

--- a/specs/DUUMBI-765/TECHNICAL.md
+++ b/specs/DUUMBI-765/TECHNICAL.md
@@ -1,0 +1,633 @@
+# DUUMBI-765 Technical Spec: Hosted GitHub App Staging E2E And Controlled Worker Enablement
+
+Related to #765
+
+Workflow note: this is a spec-only artifact. Any PR containing this document must
+use non-closing issue references and must leave #765 open for Stage 10
+implementation.
+
+## Purpose
+
+Prepare Stage 10 implementation for a bounded hosted staging proof of the real
+optional GitHub App adapter and Postgres-backed async worker path.
+
+The implementation must prove a signed GitHub webhook from the approved test
+repository can enter `duumbi-loop` in Azure staging, create durable queue/run
+evidence, run through an explicitly enabled no-spend worker E2E window, expose
+admin monitor evidence, and return the worker to disabled or scale-to-zero
+state.
+
+This is not full DUUMBI Loop completion.
+
+## Implementation Principles
+
+- `provider-duumbi` remains the primary native path.
+- GitHub remains optional, not a prerequisite.
+- GitLab remains out of scope.
+- DUUMBI-owned model labels remain the customer-facing contract.
+- Raw provider/model SKUs must not appear in customer surfaces.
+- Production auth is not introduced in this slice.
+- Live Stripe products and live Stripe calls are not allowed.
+- Live provider/model spend and external LLM calls are not allowed.
+- Hosted worker execution requires explicit E2E approval and must be disabled
+  afterward.
+- No `pulumi up` may run until local/app gates pass and the user explicitly
+  approves the hosted apply.
+- No Ralph cycles are allowed.
+- Greptile must not be invoked for spec PRs. For later implementation PRs,
+  request at most one Greptile review per PR.
+
+## Cross-Repo Ownership And PR Order
+
+1. `hgahub/duumbi`: spec artifacts only for #765.
+2. `hgahub/duumbi-loop`: staging deploy-contract gaps, smoke/evidence endpoint
+   additions, GitHub App staging config validation, worker toggle behavior,
+   admin monitor evidence, tests, and evidence docs only if the current #763
+   implementation is insufficient.
+3. `hgahub/duumbi-infra`: Key Vault secret refs, Container App environment
+   wiring, worker enablement controls, staging app settings, preview evidence,
+   and optional apply only after explicit approval.
+4. `hgahub/duumbi-web`: only if the public `/loop` route, navigation, or CTA
+   copy needs a small staging handoff adjustment.
+5. `hgahub/duumbi-registry`: read-only unless a blocking metadata boundary is
+   discovered.
+6. `hgahub/duumbi-vault`: curated references only; not runtime source of truth.
+
+Recommended implementation PR order:
+
+1. `duumbi-loop`: verify/add deploy-contract and evidence behavior required for
+   hosted GitHub App smoke.
+2. `duumbi-infra`: wire secrets, environment variables, worker controls, and
+   preview evidence.
+3. `duumbi-web`: only if copy or CTA changes are required after app/infra
+   contract review.
+
+## Verified Current Boundaries
+
+### `hgahub/duumbi-loop`
+
+The merged #763 implementation already provides:
+
+- `GET /health`
+- `GET /ready`
+- `GET /ops/e2e-evidence`
+- `POST /api/webhooks/github`
+- GitHub App callback and provider connection surfaces
+- repository registration/sync surfaces
+- webhook signature verification and idempotency behavior
+- ignored-delivery paths for unsupported, unregistered, disabled, no-annotation,
+  empty-annotation, and credit-or-limit-blocked cases
+- Postgres persistence for GitHub installation state, webhook deliveries, and
+  loop worker jobs
+- admin worker monitor route
+- worker disabled unless `DUUMBI_LOOP_ENABLE_WORKER=true` and
+  `DUUMBI_LOOP_WORKER_E2E_APPROVED=true`
+- local no-spend worker execution helpers and tests
+
+Stage 10 must avoid reimplementing those surfaces unless a hosted deploy
+contract gap is found.
+
+### `hgahub/duumbi-infra`
+
+The #759 Azure staging boundary already defines:
+
+- `rg-duumbi-loop-staging`
+- `cae-duumbi-loop-staging`
+- `ca-duumbi-loop-web-staging`
+- `ca-duumbi-loop-worker-staging`
+- `stduumbiloopstaging`
+- `kv-duumbi-loop-staging`
+- `log-duumbi-loop-staging`
+- `staging.loop.duumbi.dev`
+- USD 20/month non-prod Loop budget with 50/80/100 alerts
+- web and worker max replicas 1
+- worker disabled by default
+- `DUUMBI_LOOP_DATABASE_URL` supplied through Key Vault secret reference
+
+The local `duumbi-infra` checkout may contain unpushed operator config or
+Pulumi stack changes. Implementation agents must inspect status and avoid
+overwriting unrelated local changes.
+
+### `hgahub/duumbi-web`
+
+The public `/loop` route already exists and states that DUUMBI Loop is staged,
+GitHub/GitLab are optional adapters, and full product completion is not
+claimed. No public web change is required by default.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    GitHub["GitHub App on hgahub/duumbi-github-test"]
+    Webhook["Signed webhook to staging.loop.duumbi.dev"]
+    App["duumbi-loop web/API Container App"]
+    KV["kv-duumbi-loop-staging"]
+    PG["Staging Postgres"]
+    Queue["Postgres worker queue"]
+    Worker["duumbi-loop worker Container App"]
+    Router["No-spend DUUMBI model router"]
+    Admin["Admin monitor"]
+    Evidence["E2E evidence artifact"]
+    Budget["USD 20 budget and alerts"]
+
+    KV --> App
+    KV --> Worker
+    GitHub --> Webhook
+    Webhook --> App
+    App --> PG
+    PG --> Queue
+    Worker --> Queue
+    Worker --> Router
+    Worker --> PG
+    Admin --> PG
+    App --> Evidence
+    Worker --> Evidence
+    Budget -. guardrail .-> App
+    Budget -. guardrail .-> Worker
+```
+
+## API, Deploy, And Secret Boundaries
+
+### Hosted App Contract
+
+Required public/staging endpoints:
+
+```text
+GET /health
+GET /ready
+GET /ops/e2e-evidence
+POST /api/webhooks/github
+GET /api/admin/orgs/{org_id}/worker-jobs
+```
+
+Required staging behavior:
+
+- `/ready` reports environment, persistence backend, model router mode, worker
+  enabled state, worker E2E approval state, Stripe mode, and safe warnings.
+- `/ops/e2e-evidence` reports no-spend guardrails and must not expose secrets
+  or raw webhook payloads.
+- `POST /api/webhooks/github` requires a configured webhook secret and valid
+  HMAC signature for live staging intake.
+- Admin monitor requires authenticated/admin access; if staging still uses a
+  local auth adapter, evidence must state that production auth is not enabled.
+
+### Required Staging Environment Variables
+
+Non-secret values:
+
+```text
+DUUMBI_LOOP_ADDR=0.0.0.0:8080
+DUUMBI_LOOP_ENV=staging
+DUUMBI_LOOP_MODEL_ROUTER=no_spend
+DUUMBI_LOOP_STRIPE_MODE=test
+DUUMBI_LOOP_ENABLE_WORKER=false
+DUUMBI_LOOP_WORKER_E2E_APPROVED=false
+DUUMBI_LOOP_GITHUB_LIVE_ADAPTER_ENABLED=true
+DUUMBI_LOOP_GITHUB_ALLOWED_REPOSITORIES=hgahub/duumbi-github-test
+```
+
+Worker E2E window values, only during explicit E2E:
+
+```text
+DUUMBI_LOOP_ENABLE_WORKER=true
+DUUMBI_LOOP_WORKER_E2E_APPROVED=true
+DUUMBI_LOOP_WORKER_ID=worker_staging_e2e
+DUUMBI_LOOP_WORKER_MAX_ATTEMPTS=2
+DUUMBI_LOOP_WORKER_TASK_TIMEOUT_SECONDS=<bounded value>
+DUUMBI_LOOP_WORKER_POLL_INTERVAL_MS=<bounded value>
+DUUMBI_LOOP_WORKER_LEASE_SECONDS=<bounded value>
+```
+
+Secret values must use Key Vault / Container App secret refs:
+
+```text
+DUUMBI_LOOP_DATABASE_URL
+DUUMBI_LOOP_GITHUB_APP_ID
+DUUMBI_LOOP_GITHUB_CLIENT_ID
+DUUMBI_LOOP_GITHUB_CLIENT_SECRET
+DUUMBI_LOOP_GITHUB_APP_PRIVATE_KEY
+DUUMBI_LOOP_GITHUB_WEBHOOK_SECRET
+```
+
+If the current app expects `_REF` variables for some secrets, Stage 10 may
+either preserve that contract or add a backward-compatible secret resolution
+layer. It must not commit raw secrets.
+
+### Key Vault Secret Names
+
+Recommended Key Vault secret names:
+
+```text
+duumbi-loop-database-url
+duumbi-loop-github-app-id
+duumbi-loop-github-client-id
+duumbi-loop-github-client-secret
+duumbi-loop-github-app-private-key
+duumbi-loop-github-webhook-secret
+```
+
+Pulumi outputs may expose only secret names or configured/missing status, never
+secret values.
+
+### GitHub App Staging Credential Policy
+
+- Use a non-production GitHub App.
+- Install only on `hgahub/duumbi-github-test` for this slice.
+- Use repository-scoped permissions only.
+- Do not use production GitHub App credentials.
+- Do not use personal access tokens for runtime adapter behavior.
+- Installation tokens must be short-lived and never stored in normal database
+  fields, logs, PRs, issues, or evidence artifacts.
+- Private key material must remain in Key Vault or approved secret storage.
+- Rotation must be possible by updating Key Vault/Pulumi secret config without
+  source changes.
+
+Minimum permissions for this slice:
+
+- metadata read,
+- contents read only if needed for source context,
+- issues read where issue comments are used,
+- pull requests read where PR comments are used,
+- webhook event delivery for issue comments, pull request comments, pull
+  request review comments, installation, repository, and push events as
+  required by the existing #763 adapter.
+
+No repository write permission is required.
+
+## Data Model Boundaries
+
+This slice must use the existing #763 Postgres model where possible:
+
+- provider connections,
+- repository registrations,
+- GitHub App installation state,
+- GitHub webhook deliveries,
+- task requests,
+- runs,
+- run events,
+- artifacts,
+- loop worker jobs,
+- credit ledger,
+- audit events.
+
+Additive migrations are allowed only when hosted staging exposes a concrete
+missing field, such as:
+
+- staging repository allowlist evidence,
+- E2E worker window timestamps,
+- secret configuration status,
+- worker disable/teardown evidence.
+
+Do not replace the Postgres-backed queue with an external queue service in this
+slice.
+
+## Webhook Security, Replay, And Idempotency
+
+Implementation must verify:
+
+- `X-Hub-Signature-256` is present and valid,
+- webhook secret is configured in live staging,
+- delivery id is present,
+- event/action is allowlisted,
+- installation id maps to an enabled provider connection,
+- repository maps to an enabled registered repository,
+- repository full name is allowlisted for this slice,
+- duplicate delivery ids are idempotently ignored,
+- malformed or empty annotations return safe non-queued responses,
+- invalid signatures do not write task requests, runs, artifacts, or worker
+  jobs.
+
+Evidence must include delivery statuses without raw payload bodies.
+
+## Worker Enablement And State Requirements
+
+Default hosted state:
+
+- worker Container App deployed only if required by the existing infra contract,
+- min replicas 0 where compatible,
+- max replicas 1,
+- `DUUMBI_LOOP_ENABLE_WORKER=false`,
+- `DUUMBI_LOOP_WORKER_E2E_APPROVED=false`,
+- no worker execution outside explicit E2E.
+
+E2E enabled state:
+
+- operator explicitly approves apply/config update,
+- worker enabled and E2E approved,
+- max replicas remains 1,
+- no-spend router remains active,
+- one staged queue item is processed,
+- worker is disabled or scaled to zero after evidence.
+
+Required state behavior:
+
+- queued jobs can be claimed once,
+- running jobs record lease owner and timeout,
+- retry attempts are bounded,
+- cancellations release reserved credits when no billable work occurred,
+- stale leases are recovered or failed according to policy,
+- terminal failures release reservations when appropriate,
+- admin monitor shows queue depth, active leases, blocked jobs, failed jobs, and
+  recent attempts.
+
+## Security And Privacy Requirements
+
+- Do not expose raw secrets in source, logs, Pulumi output, issue comments, PR
+  bodies, screenshots, or evidence docs.
+- Do not store raw GitHub private keys or installation tokens in regular DB
+  columns.
+- Do not log raw webhook payloads or source content.
+- Store only bounded, sanitized hashes or summaries for webhook evidence.
+- Reject unallowlisted repositories.
+- Do not use production auth, production GitHub App credentials, live Stripe,
+  or live provider/model keys.
+- Evidence must distinguish GitHub runtime credentials from GitHub CLI/API use
+  for PR/issue coordination.
+- Admin monitor must remain admin-only.
+
+## Billing And Cloud-Cost Constraints
+
+- Stripe test mode only.
+- Live Stripe calls: 0.
+- Live provider/model spend: 0.
+- External LLM calls: 0.
+- Azure non-prod Loop budget remains USD 20/month with 50/80/100 alerts.
+- Worker max replicas 1.
+- Worker min replicas 0 or disabled outside E2E.
+- Hosted E2E must stop if budget, alert, DB, secret, DNS, or worker controls
+  are missing.
+- Teardown/disable evidence is required after hosted E2E.
+
+## BDD-To-Test Mapping
+
+| BDD Scenario | Test Or Evidence | Repo |
+| --- | --- | --- |
+| Native DUUMBI remains available without GitHub | Existing or added route/API test showing provider-duumbi remains available when GitHub live adapter is disabled. | `duumbi-loop` |
+| Operator configures a non-production GitHub App | Infra preview/evidence showing secret refs and configured/missing status without raw values. | `duumbi-infra` |
+| Test repository is allowlisted | Unit/integration test or config test rejects non-`hgahub/duumbi-github-test` repository in staging mode. | `duumbi-loop` |
+| Staging webhook requires a valid signature | Existing #763 webhook tests plus hosted smoke invalid-signature check if safe. | `duumbi-loop` |
+| Duplicate webhook delivery is idempotent in staging | Existing #763 integration test plus hosted evidence for one accepted and one duplicate delivery. | `duumbi-loop` |
+| Empty annotation does not retry forever | Existing regression test for `ignored_empty_annotation`; hosted evidence optional. | `duumbi-loop` |
+| Annotation queues hosted staging work | Hosted E2E evidence from `hgahub/duumbi-github-test` showing task, run, delivery, and queued job. | `duumbi-loop` |
+| Worker remains disabled by default | `/ready`, `/ops/e2e-evidence`, and Pulumi preview evidence assert disabled or scaled-to-zero worker. | `duumbi-loop`, `duumbi-infra` |
+| Worker runs only during approved E2E | Hosted E2E evidence showing approval window, worker enabled, one job processed, no-spend router active. | `duumbi-loop`, `duumbi-infra` |
+| Worker disable is verified after E2E | Post-E2E `/ready`, `/ops/e2e-evidence`, or Pulumi output shows disabled/scaled-to-zero state. | `duumbi-loop`, `duumbi-infra` |
+| Billing and cloud cost gates fail closed | Tests/evidence show missing budget/secret/DB gates block hosted smoke before spend or worker execution. | `duumbi-infra`, `duumbi-loop` |
+| Admin can inspect queue and provider evidence | Admin monitor test and hosted screenshot/API evidence with sanitized payload summaries. | `duumbi-loop` |
+
+## Verification Plan
+
+### `duumbi-loop`
+
+Run when any app/API/deploy-contract code changes are made:
+
+```text
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+If Postgres-specific hosted-staging behavior changes:
+
+```text
+DUUMBI_LOOP_RUN_POSTGRES_TESTS=1 \
+DUUMBI_LOOP_DATABASE_URL='<redacted local or staging-safe Postgres URL>' \
+cargo test
+```
+
+Expected focused coverage:
+
+- GitHub allowed repository config parsing,
+- non-allowlisted repository blocked before queueing,
+- secret status/evidence endpoint redaction,
+- worker E2E approval guard,
+- no-spend router remains active during worker enablement,
+- admin monitor remains available and sanitized.
+
+### `duumbi-infra`
+
+Run for infra changes:
+
+```text
+npm install
+npx tsc --noEmit
+pulumi preview --stack loop-staging --non-interactive
+```
+
+Do not run `pulumi up` unless the user explicitly approves it after preview.
+
+Expected preview evidence:
+
+- Key Vault secret names present,
+- Container App secret refs present,
+- no raw secret values in outputs,
+- worker disabled by default,
+- worker max replicas 1,
+- budget and 50/80/100 alerts present,
+- database secret configured as real Pulumi secret before hosted smoke,
+- staging custom domain remains `staging.loop.duumbi.dev`.
+
+### `duumbi-web`
+
+Only if public route/CTA changes are made:
+
+```text
+npm run build
+npm run verify:loop-route
+```
+
+## Live Hosted E2E Plan
+
+### Phase 0: Stop Gate Review
+
+Before any hosted apply or worker enablement, verify:
+
+- user explicitly approves Azure apply,
+- `duumbi-infra:loopDatabaseUrl` is configured as a real Pulumi secret,
+- GitHub App staging secrets are configured as secret refs,
+- budget alerts are configured,
+- DNS/custom domain is healthy,
+- worker remains disabled by default,
+- no-spend model router is configured,
+- test repository is `hgahub/duumbi-github-test`.
+
+If any item is missing, stop with findings.
+
+### Phase 1: Local/Staging Contract Verification
+
+1. Verify `duumbi-loop` local checks.
+2. Verify `/ready` and `/ops/e2e-evidence` in local or existing staging mode.
+3. Verify worker disabled evidence.
+4. Verify fake GitHub webhook and worker tests still pass.
+
+### Phase 2: Infra Preview
+
+1. Run TypeScript check.
+2. Run Pulumi preview for `loop-staging`.
+3. Confirm approved resources only.
+4. Confirm secret refs, budget, worker controls, custom domain, and no raw
+   secret outputs.
+
+### Phase 3: Explicit Hosted Apply Gate
+
+Stop and ask for explicit approval before `pulumi up`.
+
+If approval is not granted, record preview-only findings and do not continue to
+hosted smoke.
+
+### Phase 4: Hosted Webhook Intake Smoke
+
+After approved apply:
+
+1. Confirm `https://staging.loop.duumbi.dev/health`.
+2. Confirm `https://staging.loop.duumbi.dev/ready`.
+3. Confirm `https://staging.loop.duumbi.dev/ops/e2e-evidence`.
+4. Install/configure the non-production GitHub App only on
+   `hgahub/duumbi-github-test`.
+5. Register the repository in staging.
+6. Send or trigger a signed `@duumbi-loop` annotation.
+7. Verify one webhook delivery, one task request, one run, and one queued job.
+8. Verify duplicate delivery is ignored if safe to replay.
+
+### Phase 5: Controlled Worker E2E Window
+
+1. Ask for explicit approval to enable worker E2E.
+2. Enable worker with `DUUMBI_LOOP_ENABLE_WORKER=true` and
+   `DUUMBI_LOOP_WORKER_E2E_APPROVED=true`.
+3. Confirm max replicas 1 and no-spend model router.
+4. Let one queued job run to review/completed/failed/blocked.
+5. Capture run events, artifacts, admin monitor, and no-spend evidence.
+6. Disable or scale worker to zero immediately after evidence.
+
+### Phase 6: Post-E2E Disable Evidence
+
+Verify:
+
+- worker disabled or scaled to zero,
+- no worker execution outside explicit E2E,
+- live Stripe calls = 0,
+- live provider/model spend = 0,
+- external LLM calls = 0,
+- production auth = 0,
+- GitHub production credentials = 0,
+- Ralph cycles = 0.
+
+## Ralph Cycle Resource Policy
+
+- Spec PRs: Ralph cycles = 0.
+- Implementation PRs: Ralph cycles = 0 unless a later issue explicitly changes
+  policy.
+- External LLM call cap: 0.
+- Live provider/model spend cap: 0.
+- Live Stripe call cap: 0.
+- GitLab credential use cap: 0.
+- GitHub runtime credential use is limited to the non-production GitHub App
+  installed on `hgahub/duumbi-github-test` for the approved hosted E2E window.
+- Worker execution is allowed only during an explicit E2E window and must return
+  to disabled or scale-to-zero state afterward.
+- Azure work requires explicit apply approval, budget evidence, and teardown or
+  disable evidence.
+
+## Stage 10 Implementation Prompt
+
+```text
+Run DUUMBI Stage 10 implementation for #765 using
+specs/DUUMBI-765/PRODUCT.md and specs/DUUMBI-765/TECHNICAL.md.
+
+Target issue: https://github.com/hgahub/duumbi/issues/765
+
+Parent context:
+- #738 delivered the provider-core/native CLI foundation.
+- #750 delivered the first local/no-cost duumbi-loop web+infra slice.
+- #757 delivered the first production-integration duumbi-loop slice.
+- #759 delivered the public duumbi.dev Loop entry route and Azure staging boundary.
+- #761 delivered authenticated repository/task/admin surfaces and Postgres persistence.
+- #763 delivered the real optional GitHub App adapter boundary and Postgres-backed async worker queue.
+- The full DUUMBI Loop product is not complete.
+
+Goal:
+Implement the next bounded DUUMBI Loop hosted GitHub App staging E2E and
+controlled worker enablement slice:
+- non-production GitHub App staging secret/config boundary,
+- Key Vault and Container App secret refs for GitHub App and webhook settings,
+- allowlisted repository `hgahub/duumbi-github-test`,
+- hosted signed webhook intake at `staging.loop.duumbi.dev`,
+- Postgres-backed task/run/event/artifact/worker evidence in staging,
+- controlled worker enablement only during an explicit E2E window,
+- admin monitor evidence for provider access, webhook deliveries, queue backlog,
+  worker health, blocked/failed runs, and audit events,
+- no-spend DUUMBI model routing for all hosted smoke,
+- post-E2E worker disable, scale-to-zero, or teardown evidence.
+
+Recommended PR order:
+1. hgahub/duumbi-loop: only staging deploy-contract gaps, smoke/evidence endpoint
+   additions, GitHub App staging config validation, worker toggle behavior, tests,
+   and evidence docs if the current #763 implementation is insufficient.
+2. hgahub/duumbi-infra: Key Vault secret refs, Container App env wiring, worker
+   enablement controls, staging app settings, and Pulumi preview evidence.
+3. hgahub/duumbi-web: only if public Loop copy/navigation/CTA needs adjustment.
+4. Other repos only if a blocking contract gap is discovered and recorded.
+
+Constraints:
+- Do not claim the full DUUMBI Loop product is complete.
+- GitHub remains optional, not a prerequisite.
+- GitLab remains out of scope.
+- provider-duumbi remains primary.
+- DUUMBI-owned model labels remain the user-facing contract.
+- No production auth.
+- No live Stripe products or live Stripe calls.
+- No live provider/model spend or external LLM calls.
+- Do not expose raw provider/model SKUs to customers.
+- Use only the non-production GitHub App and the allowlisted test repo
+  `hgahub/duumbi-github-test` for hosted GitHub E2E.
+- Do not use GitHub/GitLab production provider credentials.
+- Do not run pulumi up until local/app gates are green, Pulumi preview is clean,
+  and the user explicitly approves apply.
+- Do not enable the hosted worker until the user explicitly approves the E2E
+  window.
+- Worker must be disabled or scaled to zero after E2E evidence.
+- No Ralph cycles.
+- Use non-closing references such as "Related to #765".
+- Greptile is reserved for the final implementation PR review; request at most
+  one Greptile review per PR.
+
+Required verification:
+- duumbi-loop cargo fmt --check, clippy, and tests if duumbi-loop changes.
+- duumbi-loop focused tests for repository allowlist, webhook security,
+  idempotency, worker approval guard, no-spend router, and sanitized evidence if
+  those gaps are touched.
+- duumbi-infra npx tsc --noEmit and pulumi preview for loop-staging if infra
+  changes.
+- duumbi-web build/route verification only if web changes.
+- Hosted smoke only after explicit apply approval and real staging secrets are
+  configured.
+- Evidence file/comment recording external LLM calls = 0, live provider/model
+  spend = 0, live Stripe calls = 0, production auth = 0, GitLab credentials = 0,
+  GitHub runtime credentials limited to non-production GitHub App on
+  hgahub/duumbi-github-test, worker execution outside explicit E2E = 0, and Ralph
+  cycles = 0.
+
+Stop with findings if GitHub App ownership, staging secrets, webhook security,
+database access, cloud budget, worker cost, Azure ownership, domain/DNS,
+provider routing, or cross-repo ownership creates a blocker.
+```
+
+## Codex Self-Review
+
+### Product Gate
+
+- The slice is bounded to hosted staging proof, not full product completion.
+- The test repository is explicit: `hgahub/duumbi-github-test`.
+- GitHub remains optional and GitLab remains out of scope.
+- No production auth, live Stripe, live provider/model spend, raw SKU exposure,
+  or Ralph cycles are required.
+
+### Technical Gate
+
+- Cross-repo ownership and PR order are explicit.
+- Existing #763 `duumbi-loop` surfaces are reused instead of reimplemented.
+- Secret refs, webhook security, replay/idempotency, worker approval, budget,
+  and teardown gates are explicit.
+- Pulumi apply and worker enablement both remain explicit approval gates.
+- No unresolved architecture blocker remains for spec drafting. Missing live
+  staging secrets are Stage 10 prerequisites and stop gates, not spec blockers.


### PR DESCRIPTION
## Summary

Spec for #765.

This PR adds the combined DUUMBI product and technical specs for the next bounded DUUMBI Loop hosted GitHub App staging E2E and controlled worker enablement slice.

Artifacts:
- `specs/DUUMBI-765/PRODUCT.md`
- `specs/DUUMBI-765/TECHNICAL.md`

## Workflow note

This is a spec-only PR. It must leave the execution issue open. Use non-closing references only.

Related to #765.

## Scope

- Non-production GitHub App staging configuration boundary.
- GitHub webhook URL and signature verification in Azure staging.
- Key Vault / Container App secret-reference model for GitHub App and webhook settings.
- Allowlisted staging/test repository: `hgahub/duumbi-github-test`.
- Hosted `@duumbi-loop` annotation intake from GitHub webhook.
- Postgres-backed queue/run/event/artifact persistence in staging.
- Controlled worker enablement: disabled by default, enabled only for explicit E2E windows, max replicas 1, scale-to-zero where possible.
- Admin monitor evidence for worker health, queue backlog, blocked/failed runs, provider access, and audit events.
- No-spend DUUMBI model router for all hosted smoke execution.
- Teardown/disable procedure after E2E.

## Gate decisions

- Stage 5 acceptance: pass for bounded spec drafting.
- Stage 7 product gate: pass.
- Stage 9 technical gate: pass.
- Blocking questions found: none for spec drafting. Missing live staging secrets remain Stage 10 stop gates and implementation prerequisites, not spec blockers.

## Constraints preserved

- No implementation code.
- No Ralph cycles.
- No Greptile for this spec PR.
- GitHub remains optional.
- GitLab remains out of scope.
- provider-duumbi remains primary.
- No production auth.
- No live Stripe products or live Stripe calls.
- No live provider/model spend.
- No raw provider/model SKU exposure.
- No Pulumi up during spec drafting.

## Verification

- `git diff --check`
- `pre-commit run --files specs/DUUMBI-765/PRODUCT.md specs/DUUMBI-765/TECHNICAL.md`
- Confirmed no closing issue references.
- Codex self-review on both specs.
