### PR TITLE
[codex] Fix quinn-proto cargo audit advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3243,9 +3243,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## Summary

Fixes the post-merge `main` CI `cargo audit` failure by updating the vulnerable transitive dependency:

- `quinn-proto` `0.11.14` -> `0.11.15`

This addresses `RUSTSEC-2026-0185`, which was reported through:

```text
reqwest 0.13.4 -> quinn 0.11.9 -> quinn-proto 0.11.14
```

## Scope

- Dependency-only fix.
- `Cargo.lock` only.
- No DUUMBI Loop #765 implementation changes.
- No spec changes.
- No Pulumi, no Ralph cycles, no Greptile.

## Verification

- `cargo audit`: passed; `RUSTSEC-2026-0185` no longer reproduces. Existing allowed warnings for `paste` and `proc-macro-error2` remain warnings only.
- `cargo fmt --check`: passed.
- `git diff --check`: passed.
- `cargo clippy --all-targets -- -D warnings`: passed.
- `cargo test`: passed.

Related to #765.
